### PR TITLE
Document heterogenous lookup using `is_transparent`

### DIFF
--- a/test/unit/transparent.cpp
+++ b/test/unit/transparent.cpp
@@ -1,17 +1,48 @@
 #include <ankerl/unordered_dense.h>
 
-#include <doctest.h>
+#include <app/name_of_type.h>
 
-#include <array>       // for array
-#include <cstddef>     // for size_t
-#include <functional>  // for equal_to
-#include <string>      // for basic_string, string, operator""s
-#include <string_view> // for basic_string_view, operator""sv
-#include <type_traits> // for add_const_t
-#include <utility>     // for pair, as_const
-#include <vector>      // for vector
+#include <doctest.h>
+#include <fmt/format.h>
+
+#include <array>         // for array
+#include <cstddef>       // for size_t
+#include <functional>    // for equal_to
+#include <string>        // for basic_string, string, operator""s
+#include <string_view>   // for basic_string_view, operator""sv
+#include <type_traits>   // for add_const_t
+#include <unordered_map> // for unordered_map
+#include <utility>       // for pair, as_const
+#include <vector>        // for vector
 
 using namespace std::literals;
+
+class string_eq {
+    mutable std::unordered_map<std::string, size_t> m_names_to_counts{};
+
+public:
+    using is_transparent = void;
+
+    template <class T, class U>
+    auto operator()(T&& lhs, U&& rhs) const -> decltype(std::forward<T>(lhs) == std::forward<U>(rhs)) {
+        auto names = fmt::format("{} -> {}", name_of_type<T>(), name_of_type<U>());
+        ++m_names_to_counts[names];
+        return std::forward<T>(lhs) == std::forward<U>(rhs);
+    }
+
+    auto counts() const -> std::unordered_map<std::string, size_t> const& {
+        return m_names_to_counts;
+    }
+
+    string_eq() = default;
+    ~string_eq() = default;
+
+    string_eq(string_eq const&) = default;
+    auto operator=(string_eq const&) -> string_eq& = default;
+
+    string_eq(string_eq&&) = delete;
+    auto operator=(string_eq&&) -> string_eq& = delete;
+};
 
 // transparent hash, counts number of calls per operator
 class string_hash {
@@ -22,18 +53,19 @@ class string_hash {
 public:
     using hash_type = ankerl::unordered_dense::hash<std::string_view>;
     using is_transparent = void;
+    using is_avalanching = void;
 
-    [[nodiscard]] auto operator()(const char* str) const -> uint64_t {
+    [[nodiscard]] auto operator()(const char* str) const noexcept -> uint64_t {
         ++m_num_charstar;
         return hash_type{}(str);
     }
 
-    [[nodiscard]] auto operator()(std::string_view str) const -> uint64_t {
+    [[nodiscard]] auto operator()(std::string_view str) const noexcept -> uint64_t {
         ++m_num_stringview;
         return hash_type{}(str);
     }
 
-    [[nodiscard]] auto operator()(std::string const& str) const -> uint64_t {
+    [[nodiscard]] auto operator()(std::string const& str) const noexcept -> uint64_t {
         ++m_num_string;
         return hash_type{}(str);
     }
@@ -42,6 +74,27 @@ public:
         return {m_num_charstar, m_num_stringview, m_num_string};
     }
 };
+
+namespace docs {
+
+struct string_hash {
+    using is_transparent = void; // enable heterogenous lookup
+    using is_avalanching = void; // mark class as high quality avalanching hash
+
+    [[nodiscard]] auto operator()(const char* str) const noexcept -> uint64_t {
+        return ankerl::unordered_dense::hash<std::string_view>{}(str);
+    }
+
+    [[nodiscard]] auto operator()(std::string_view str) const noexcept -> uint64_t {
+        return ankerl::unordered_dense::hash<std::string_view>{}(str);
+    }
+
+    [[nodiscard]] auto operator()(std::string const& str) const noexcept -> uint64_t {
+        return ankerl::unordered_dense::hash<std::string_view>{}(str);
+    }
+};
+
+} // namespace docs
 
 void check(string_hash const& sh, size_t num_charstar, size_t num_stringview, size_t num_string) {
     auto counts = sh.counts();
@@ -170,4 +223,19 @@ TEST_CASE("transparent_equal_range") {
     REQUIRE(crange.first != range.second);
     REQUIRE(crange.first->first == "hello");
     REQUIRE(crange.second == map.end());
+}
+
+TEST_CASE("transparent_string_eq") {
+    auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash, string_eq>();
+    map.try_emplace("hello", 1);
+
+    REQUIRE(map.count("hello"));
+    REQUIRE(map.count("hello"sv));
+    REQUIRE(map.count("hello"s));
+
+    auto ke = map.key_eq();
+    REQUIRE(ke.counts().size() == 3);
+    for (auto const& kv : ke.counts()) {
+        REQUIRE(kv.second == 1U);
+    }
 }


### PR DESCRIPTION
Now with documentation in README.md. Also updated transparent.cpp example and improved tests