### PR TITLE
Support heterogeneous C++26 overloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project("unordered_dense"
-    VERSION 1.3.3
+    VERSION 1.4.0
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense")
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 1.3.3
+// Version 1.4.0
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
@@ -31,8 +31,8 @@
 
 // see https://semver.org/spec/v2.0.0.html
 #define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 1 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
-#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 3 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
-#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 3 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
+#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 4 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
+#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 0 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
 
 // API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/
 #define ANKERL_UNORDERED_DENSE_VERSION_CONCAT1(major, minor, patch) v##major##_##minor##_##patch

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -363,9 +363,16 @@ using detect_is_transparent = typename T::is_transparent;
 template <typename T>
 using detect_iterator = typename T::iterator;
 
-template <typename H, typename KE>
-using is_transparent =
-    std::enable_if_t<is_detected_v<detect_is_transparent, H> && is_detected_v<detect_is_transparent, KE>, bool>;
+// enable_if helpers
+
+template <typename Mapped>
+constexpr bool is_map_v = !std::is_void_v<Mapped>;
+
+template <typename Hash, typename KeyEqual>
+constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& is_detected_v<detect_is_transparent, KeyEqual>;
+
+template <typename From, typename To1, typename To2>
+constexpr bool is_neither_convertible_v = !std::is_convertible_v<From, To1> && !std::is_convertible_v<From, To2>;
 
 // This is it, the table. Doubles as map and set, and uses `void` for T when its used as a set.
 template <class Key,
@@ -722,6 +729,19 @@ private:
         return const_cast<table*>(this)->do_find(key); // NOLINT(cppcoreguidelines-pro-type-const-cast)
     }
 
+    template <typename K, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto do_at(K const& key) -> Q& {
+        if (auto it = find(key); end() != it) {
+            return it->second;
+        }
+        throw std::out_of_range("ankerl::unordered_dense::map::at(): key not found");
+    }
+
+    template <typename K, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto do_at(K const& key) const -> Q const& {
+        return const_cast<table*>(this)->at(key); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    }
+
 public:
     table()
         : table(0) {}
@@ -1006,24 +1026,77 @@ public:
         }
     }
 
-    template <class M, typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto insert_or_assign(Key const& key, M&& mapped) -> std::pair<iterator, bool> {
         return do_insert_or_assign(key, std::forward<M>(mapped));
     }
 
-    template <class M, typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto insert_or_assign(Key&& key, M&& mapped) -> std::pair<iterator, bool> {
         return do_insert_or_assign(std::move(key), std::forward<M>(mapped));
     }
 
-    template <class M, typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <typename K,
+              typename M,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto insert_or_assign(K&& key, M&& mapped) -> std::pair<iterator, bool> {
+        return do_insert_or_assign(std::forward<K>(key), std::forward<M>(mapped));
+    }
+
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto insert_or_assign(const_iterator /*hint*/, Key const& key, M&& mapped) -> iterator {
         return do_insert_or_assign(key, std::forward<M>(mapped)).first;
     }
 
-    template <class M, typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <class M, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto insert_or_assign(const_iterator /*hint*/, Key&& key, M&& mapped) -> iterator {
         return do_insert_or_assign(std::move(key), std::forward<M>(mapped)).first;
+    }
+
+    template <typename K,
+              typename M,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto insert_or_assign(const_iterator /*hint*/, K&& key, M&& mapped) -> iterator {
+        return do_insert_or_assign(std::forward<K>(key), std::forward<M>(mapped)).first;
+    }
+
+    // Single arguments for unordered_set can be used without having to construct the value_type
+    template <class K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<!is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto emplace(K&& key) -> std::pair<iterator, bool> {
+        if (is_full()) {
+            increase_size();
+        }
+
+        auto hash = mixed_hash(key);
+        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
+        auto bucket_idx = bucket_idx_from_hash(hash);
+
+        while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+            if (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
+                m_equal(key, m_values[at(m_buckets, bucket_idx).m_value_idx])) {
+                // found it, return without ever actually creating anything
+                return {begin() + static_cast<difference_type>(at(m_buckets, bucket_idx).m_value_idx), false};
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+
+        // value is new, insert element first, so when exception happens we are in a valid state
+        m_values.emplace_back(std::forward<K>(key));
+        // now place the bucket and shift up until we find an empty spot
+        auto value_idx = static_cast<value_idx_type>(m_values.size() - 1);
+        place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+        return {begin() + static_cast<difference_type>(value_idx), true};
     }
 
     template <class... Args>
@@ -1032,15 +1105,16 @@ public:
             increase_size();
         }
 
-        // first emplace_back the object so it is constructed. If the key is already there, pop it.
-        auto& val = m_values.emplace_back(std::forward<Args>(args)...);
-        auto hash = mixed_hash(get_key(val));
+        // we have to instantiate the value_type to be able to access the key.
+        // 1. emplace_back the object so it is constructed. 2. If the key is already there, pop it later in the loop.
+        auto& key = get_key(m_values.emplace_back(std::forward<Args>(args)...));
+        auto hash = mixed_hash(key);
         auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
         auto bucket_idx = bucket_idx_from_hash(hash);
 
         while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
             if (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
-                m_equal(get_key(val), get_key(m_values[at(m_buckets, bucket_idx).m_value_idx]))) {
+                m_equal(key, get_key(m_values[at(m_buckets, bucket_idx).m_value_idx]))) {
                 m_values.pop_back(); // value was already there, so get rid of it
                 return {begin() + static_cast<difference_type>(at(m_buckets, bucket_idx).m_value_idx), false};
             }
@@ -1060,24 +1134,48 @@ public:
         return emplace(std::forward<Args>(args)...).first;
     }
 
-    template <class... Args, typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto try_emplace(Key const& key, Args&&... args) -> std::pair<iterator, bool> {
         return do_try_emplace(key, std::forward<Args>(args)...);
     }
 
-    template <class... Args, typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto try_emplace(Key&& key, Args&&... args) -> std::pair<iterator, bool> {
         return do_try_emplace(std::move(key), std::forward<Args>(args)...);
     }
 
-    template <class... Args, typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto try_emplace(const_iterator /*hint*/, Key const& key, Args&&... args) -> iterator {
         return do_try_emplace(key, std::forward<Args>(args)...).first;
     }
 
-    template <class... Args, typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <class... Args, typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto try_emplace(const_iterator /*hint*/, Key&& key, Args&&... args) -> iterator {
         return do_try_emplace(std::move(key), std::forward<Args>(args)...).first;
+    }
+
+    template <
+        typename K,
+        typename... Args,
+        typename Q = T,
+        typename H = Hash,
+        typename KE = KeyEqual,
+        std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE> && is_neither_convertible_v<K&&, iterator, const_iterator>,
+                         bool> = true>
+    auto try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
+        return do_try_emplace(std::forward<K>(key), std::forward<Args>(args)...);
+    }
+
+    template <
+        typename K,
+        typename... Args,
+        typename Q = T,
+        typename H = Hash,
+        typename KE = KeyEqual,
+        std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE> && is_neither_convertible_v<K&&, iterator, const_iterator>,
+                         bool> = true>
+    auto try_emplace(const_iterator /*hint*/, K&& key, Args&&... args) -> iterator {
+        return do_try_emplace(std::forward<K>(key), std::forward<Args>(args)...).first;
     }
 
     auto erase(iterator it) -> iterator {
@@ -1125,7 +1223,7 @@ public:
         return do_erase_key(key);
     }
 
-    template <class K, class H = Hash, class KE = KeyEqual, is_transparent<H, KE> = true>
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
     auto erase(K&& key) -> size_t {
         return do_erase_key(std::forward<K>(key));
     }
@@ -1138,34 +1236,58 @@ public:
 
     // lookup /////////////////////////////////////////////////////////////////
 
-    template <typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto at(key_type const& key) -> Q& {
-        if (auto it = find(key); end() != it) {
-            return it->second;
-        }
-        throw std::out_of_range("ankerl::unordered_dense::map::at(): key not found");
-    } // LCOV_EXCL_LINE is this a gcov/lcov bug? this method is fully tested.
-
-    template <typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
-    auto at(key_type const& key) const -> Q const& {
-        return const_cast<table*>(this)->at(key); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+        return do_at(key);
     }
 
-    template <typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto at(K const& key) -> Q& {
+        return do_at(key);
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
+    auto at(key_type const& key) const -> Q const& {
+        return do_at(key);
+    }
+
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto at(K const& key) const -> Q const& {
+        return do_at(key);
+    }
+
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto operator[](Key const& key) -> Q& {
         return try_emplace(key).first->second;
     }
 
-    template <typename Q = T, std::enable_if_t<!std::is_void_v<Q>, bool> = true>
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto operator[](Key&& key) -> Q& {
         return try_emplace(std::move(key)).first->second;
+    }
+
+    template <typename K,
+              typename Q = T,
+              typename H = Hash,
+              typename KE = KeyEqual,
+              std::enable_if_t<is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
+    auto operator[](K&& key) -> Q& {
+        return try_emplace(std::forward<K>(key)).first->second;
     }
 
     auto count(Key const& key) const -> size_t {
         return find(key) == end() ? 0 : 1;
     }
 
-    template <class K, class H = Hash, class KE = KeyEqual, is_transparent<H, KE> = true>
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
     auto count(K const& key) const -> size_t {
         return find(key) == end() ? 0 : 1;
     }
@@ -1178,12 +1300,12 @@ public:
         return do_find(key);
     }
 
-    template <class K, class H = Hash, class KE = KeyEqual, is_transparent<H, KE> = true>
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
     auto find(K const& key) -> iterator {
         return do_find(key);
     }
 
-    template <class K, class H = Hash, class KE = KeyEqual, is_transparent<H, KE> = true>
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
     auto find(K const& key) const -> const_iterator {
         return do_find(key);
     }
@@ -1192,7 +1314,7 @@ public:
         return find(key) != end();
     }
 
-    template <class K, class H = Hash, class KE = KeyEqual, is_transparent<H, KE> = true>
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
     auto contains(K const& key) const -> bool {
         return find(key) != end();
     }
@@ -1207,13 +1329,13 @@ public:
         return {it, it == end() ? end() : it + 1};
     }
 
-    template <class K, class H = Hash, class KE = KeyEqual, is_transparent<H, KE> = true>
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
     auto equal_range(K const& key) -> std::pair<iterator, iterator> {
         auto it = do_find(key);
         return {it, it == end() ? end() : it + 1};
     }
 
-    template <class K, class H = Hash, class KE = KeyEqual, is_transparent<H, KE> = true>
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
     auto equal_range(K const& key) const -> std::pair<const_iterator, const_iterator> {
         auto it = do_find(key);
         return {it, it == end() ? end() : it + 1};

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '1.3.3',
+    version: '1.4.0',
     license: 'MIT',
     default_options : ['cpp_std=c++17', 'warning_level=3', 'werror=true'])
 

--- a/scripts/lint/lint-version.py
+++ b/scripts/lint/lint-version.py
@@ -21,6 +21,11 @@ file_pattern_count = [
         f"{root}/CMakeLists.txt",
         r"^\s+VERSION (\d+)\.(\d+)\.(\d+)\n",
         1),
+    (
+        f"{root}/test/unit/namespace.cpp",
+        r"unordered_dense::v(\d+)_(\d+)_(\d+)",
+        3
+    )
 ]
 
 # let's parse the reference from svector.h

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -2,10 +2,10 @@
 
 #include <doctest.h>
 
-static_assert(std::is_same_v<ankerl::unordered_dense::v1_3_3::map<int, int>, ankerl::unordered_dense::map<int, int>>);
-static_assert(std::is_same_v<ankerl::unordered_dense::v1_3_3::hash<int>, ankerl::unordered_dense::hash<int>>);
+static_assert(std::is_same_v<ankerl::unordered_dense::v1_4_0::map<int, int>, ankerl::unordered_dense::map<int, int>>);
+static_assert(std::is_same_v<ankerl::unordered_dense::v1_4_0::hash<int>, ankerl::unordered_dense::hash<int>>);
 
 TEST_CASE("version_namespace") {
-    auto map = ankerl::unordered_dense::v1_3_3::map<int, int>{};
+    auto map = ankerl::unordered_dense::v1_4_0::map<int, int>{};
     REQUIRE(map.empty());
 }

--- a/test/unit/transparent.cpp
+++ b/test/unit/transparent.cpp
@@ -96,9 +96,13 @@ struct string_hash {
 
 } // namespace docs
 
-void check(string_hash const& sh, size_t num_charstar, size_t num_stringview, size_t num_string) {
+template <typename C>
+void check(int line, C const& container, size_t num_charstar, size_t num_stringview, size_t num_string) {
+    auto sh = container.hash_function();
     auto counts = sh.counts();
-    INFO(counts[0] << " charstar, " << counts[1] << " string_view, " << counts[2] << " string");
+    INFO("check line " << line << ": expect (" << num_charstar << ", " << num_stringview << ", " << num_string << ") got ("
+                       << counts[0] << ", " << counts[1] << ", " << counts[2]
+                       << ") for (num_charstar, num_stringview, num_string)");
     REQUIRE(counts[0] == num_charstar);
     REQUIRE(counts[1] == num_stringview);
     REQUIRE(counts[2] == num_string);
@@ -107,119 +111,119 @@ void check(string_hash const& sh, size_t num_charstar, size_t num_stringview, si
 TEST_CASE("transparent_find") {
     auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash, std::equal_to<>>();
     map.try_emplace("hello", 1);
-    check(map.hash_function(), 0, 0, 1);
+    check(__LINE__, map, 1, 0, 0);
 
     auto it = map.find("huh");
-    check(map.hash_function(), 1, 0, 1);
+    check(__LINE__, map, 2, 0, 0);
     REQUIRE(it == map.end());
     it = map.find("hello");
-    check(map.hash_function(), 2, 0, 1);
+    check(__LINE__, map, 3, 0, 0);
     REQUIRE(it != map.end());
 
     auto cit = std::as_const(map).find("huh");
-    check(map.hash_function(), 3, 0, 1);
+    check(__LINE__, map, 4, 0, 0);
     REQUIRE(cit == map.end());
     REQUIRE(cit == map.cend());
     cit = std::as_const(map).find("hello");
-    check(map.hash_function(), 4, 0, 1);
+    check(__LINE__, map, 5, 0, 0);
     REQUIRE(cit != map.end());
 
     // string_view
     it = map.find("huh"sv);
     REQUIRE(it == map.end());
-    check(map.hash_function(), 4, 1, 1);
+    check(__LINE__, map, 5, 1, 0);
     it = map.find("hello"sv);
     REQUIRE(it != map.end());
-    check(map.hash_function(), 4, 2, 1);
+    check(__LINE__, map, 5, 2, 0);
 
     // string
     it = map.find("huh"s);
     REQUIRE(it == map.end());
-    check(map.hash_function(), 4, 2, 2);
+    check(__LINE__, map, 5, 2, 1);
     it = map.find("hello"s);
     REQUIRE(it != map.end());
-    check(map.hash_function(), 4, 2, 3);
+    check(__LINE__, map, 5, 2, 2);
 }
 
 TEST_CASE("transparent_count") {
     auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash, std::equal_to<>>();
     map.try_emplace("hello", 1);
-    check(map.hash_function(), 0, 0, 1);
+    check(__LINE__, map, 1, 0, 0);
 
     REQUIRE(0 == map.count("huh"));
-    check(map.hash_function(), 1, 0, 1);
+    check(__LINE__, map, 2, 0, 0);
     REQUIRE(1 == map.count("hello"));
-    check(map.hash_function(), 2, 0, 1);
+    check(__LINE__, map, 3, 0, 0);
 
     REQUIRE(0 == map.count("huh"sv));
-    check(map.hash_function(), 2, 1, 1);
+    check(__LINE__, map, 3, 1, 0);
     REQUIRE(1 == map.count("hello"sv));
-    check(map.hash_function(), 2, 2, 1);
+    check(__LINE__, map, 3, 2, 0);
 
     REQUIRE(0 == map.count("huh"s));
-    check(map.hash_function(), 2, 2, 2);
+    check(__LINE__, map, 3, 2, 1);
     REQUIRE(1 == map.count("hello"s));
-    check(map.hash_function(), 2, 2, 3);
+    check(__LINE__, map, 3, 2, 2);
 }
 
 TEST_CASE("transparent_contains") {
     auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash, std::equal_to<>>();
     map.try_emplace("hello", 1);
-    check(map.hash_function(), 0, 0, 1);
+    check(__LINE__, map, 1, 0, 0);
 
     REQUIRE(!map.contains("huh"));
-    check(map.hash_function(), 1, 0, 1);
+    check(__LINE__, map, 2, 0, 0);
     REQUIRE(map.contains("hello"));
-    check(map.hash_function(), 2, 0, 1);
+    check(__LINE__, map, 3, 0, 0);
 
     REQUIRE(!map.contains("huh"sv));
-    check(map.hash_function(), 2, 1, 1);
+    check(__LINE__, map, 3, 1, 0);
     REQUIRE(map.contains("hello"sv));
-    check(map.hash_function(), 2, 2, 1);
+    check(__LINE__, map, 3, 2, 0);
 
     REQUIRE(!map.contains("huh"s));
-    check(map.hash_function(), 2, 2, 2);
+    check(__LINE__, map, 3, 2, 1);
     REQUIRE(map.contains("hello"s));
-    check(map.hash_function(), 2, 2, 3);
+    check(__LINE__, map, 3, 2, 2);
 }
 
 TEST_CASE("transparent_erase") {
     auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash, std::equal_to<>>();
     map.try_emplace("hello", 1);
-    check(map.hash_function(), 0, 0, 1);
+    check(__LINE__, map, 1, 0, 0);
     REQUIRE(0 == map.erase("huh"));
-    check(map.hash_function(), 1, 0, 1);
+    check(__LINE__, map, 2, 0, 0);
     REQUIRE(1 == map.erase("hello"));
-    check(map.hash_function(), 2, 0, 1);
+    check(__LINE__, map, 3, 0, 0);
 
     map.try_emplace("hello", 1);
-    check(map.hash_function(), 2, 0, 2);
+    check(__LINE__, map, 4, 0, 0);
     REQUIRE(0 == map.erase("huh"sv));
-    check(map.hash_function(), 2, 1, 2);
+    check(__LINE__, map, 4, 1, 0);
     REQUIRE(1 == map.erase("hello"sv));
-    check(map.hash_function(), 2, 2, 2);
+    check(__LINE__, map, 4, 2, 0);
 
     map.try_emplace("hello", 1);
-    check(map.hash_function(), 2, 2, 3);
+    check(__LINE__, map, 5, 2, 0);
     REQUIRE(0 == map.erase("huh"s));
-    check(map.hash_function(), 2, 2, 4);
+    check(__LINE__, map, 5, 2, 1);
     REQUIRE(1 == map.erase("hello"s));
-    check(map.hash_function(), 2, 2, 5);
+    check(__LINE__, map, 5, 2, 2);
 }
 
 TEST_CASE("transparent_equal_range") {
     auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash, std::equal_to<>>();
     map.try_emplace("hello", 1);
-    check(map.hash_function(), 0, 0, 1);
+    check(__LINE__, map, 1, 0, 0);
 
     auto range = map.equal_range("hello");
-    check(map.hash_function(), 1, 0, 1);
+    check(__LINE__, map, 2, 0, 0);
     REQUIRE(range.first != range.second);
     REQUIRE(range.first->first == "hello");
     REQUIRE(range.second == map.end());
 
     auto crange = std::as_const(map).equal_range("hello"sv);
-    check(map.hash_function(), 1, 1, 1);
+    check(__LINE__, map, 2, 1, 0);
     REQUIRE(crange.first != range.second);
     REQUIRE(crange.first->first == "hello");
     REQUIRE(crange.second == map.end());
@@ -238,4 +242,131 @@ TEST_CASE("transparent_string_eq") {
     for (auto const& kv : ke.counts()) {
         REQUIRE(kv.second == 1U);
     }
+}
+
+TEST_CASE("transparent_at") {
+    auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash, string_eq>();
+    map.try_emplace("asdf", 123);
+    check(__LINE__, map, 1, 0, 0);
+
+    auto& vt = map.at("asdf");
+    check(__LINE__, map, 2, 0, 0);
+    REQUIRE(vt == 123);
+
+    // NOLINTNEXTLINE(llvm-else-after-return,readability-else-after-return)
+    REQUIRE_THROWS_AS(map.at("nope"sv), std::out_of_range);
+    check(__LINE__, map, 2, 1, 0);
+}
+
+TEST_CASE("transparent_at_not") {
+    // no string_eq, so not is_transparent
+    auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash>();
+    map.try_emplace("asdf", 123);
+    check(__LINE__, map, 0, 0, 1);
+
+    auto& vt = map.at("asdf");
+    check(__LINE__, map, 0, 0, 2);
+    REQUIRE(vt == 123);
+
+    // NOLINTNEXTLINE(llvm-else-after-return,readability-else-after-return)
+    REQUIRE_THROWS_AS(map.at("nope"), std::out_of_range);
+    check(__LINE__, map, 0, 0, 3);
+}
+
+TEST_CASE("transparent_insert_or_assign") {
+    auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash, string_eq>();
+    auto r = map.insert_or_assign("asdf", 123U);
+    check(__LINE__, map, 1, 0, 0);
+    REQUIRE(r.first->first == "asdf");
+    REQUIRE(r.first->second == 123U);
+    REQUIRE(r.second);
+
+    r = map.insert_or_assign("asdf", 42U);
+    check(__LINE__, map, 2, 0, 0);
+    REQUIRE(r.first->first == "asdf");
+    REQUIRE(r.first->second == 42U);
+    REQUIRE(!r.second);
+    REQUIRE(map.size() == 1U);
+}
+
+TEST_CASE("transparent_insert_or_assign_not") {
+    auto map = ankerl::unordered_dense::map<std::string, size_t, string_hash>();
+    auto r = map.insert_or_assign("asdf", 123U);
+    check(__LINE__, map, 0, 0, 1);
+    REQUIRE(r.first->first == "asdf");
+    REQUIRE(r.first->second == 123U);
+    REQUIRE(r.second);
+
+    r = map.insert_or_assign("asdf", 42U);
+    check(__LINE__, map, 0, 0, 2);
+    REQUIRE(r.first->first == "asdf");
+    REQUIRE(r.first->second == 42U);
+    REQUIRE(!r.second);
+    REQUIRE(map.size() == 1U);
+}
+
+TEST_CASE("transparent_insert_or_assign_iterator") {
+    using map_t = ankerl::unordered_dense::map<std::string, size_t, string_hash, string_eq>;
+    auto map = map_t();
+    auto r = map.insert_or_assign(map_t::const_iterator{}, "asdf", 123U);
+    check(__LINE__, map, 1, 0, 0);
+    REQUIRE(r->first == "asdf");
+    REQUIRE(r->second == 123U);
+
+    r = map.insert_or_assign(map_t::const_iterator{}, "asdf", 42U);
+    check(__LINE__, map, 2, 0, 0);
+    REQUIRE(r->first == "asdf");
+    REQUIRE(r->second == 42U);
+    REQUIRE(map.size() == 1U);
+}
+
+TEST_CASE("transparent_insert_or_assign_iterator_not") {
+    using map_t = ankerl::unordered_dense::map<std::string, size_t, string_hash>;
+    auto map = map_t();
+    auto r = map.insert_or_assign(map_t::const_iterator{}, "asdf", 123U);
+    check(__LINE__, map, 0, 0, 1);
+    REQUIRE(r->first == "asdf");
+    REQUIRE(r->second == 123U);
+
+    r = map.insert_or_assign(map_t::const_iterator{}, "asdf", 42U);
+    check(__LINE__, map, 0, 0, 2);
+    REQUIRE(r->first == "asdf");
+    REQUIRE(r->second == 42U);
+    REQUIRE(map.size() == 1U);
+}
+
+// insert() transparent is only possible with unordered_set, not with unordered_map
+TEST_CASE("transparent_set_insert") {
+    auto set = ankerl::unordered_dense::set<std::string, string_hash, string_eq>();
+    set.insert("abcdefg");
+    check(__LINE__, set, 1, 0, 0);
+    set.insert("abcdefg");
+    check(__LINE__, set, 2, 0, 0);
+}
+
+// insert() transparent is only possible with unordered_set, not with unordered_map
+TEST_CASE("transparent_set_insert_not") {
+    auto set = ankerl::unordered_dense::set<std::string, string_hash>();
+    set.insert("abcdefg");
+    check(__LINE__, set, 0, 0, 1);
+    set.insert("abcdefg");
+    check(__LINE__, set, 0, 0, 2);
+}
+
+// emplace() transparent is only possible with unordered_set, not with unordered_map
+TEST_CASE("transparent_set_emplace") {
+    auto set = ankerl::unordered_dense::set<std::string, string_hash, string_eq>();
+    set.emplace("abcdefg");
+    check(__LINE__, set, 1, 0, 0);
+    set.emplace("abcdefg");
+    check(__LINE__, set, 2, 0, 0);
+}
+
+// emplace() transparent is only possible with unordered_set, not with unordered_map
+TEST_CASE("transparent_set_emplace_not") {
+    auto set = ankerl::unordered_dense::set<std::string, string_hash>();
+    set.emplace("abcdefg");
+    check(__LINE__, set, 0, 0, 1);
+    set.emplace("abcdefg");
+    check(__LINE__, set, 0, 0, 2);
 }


### PR DESCRIPTION
Implements heterogeneous overloads for various additional methods. Previously, only "P1690R1 Refinement Proposal for P0919 Heterogeneous lookup for unordered containers" was implemented.

This adds overloads for map:

* try_emplace
* insert_or_assign
* operator[]
* at

and for set:

* insert
* Additionally, emplace() was updated too to work too.