### PR TITLE
Make mapped_type only available for map, not for set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project("unordered_dense"
-    VERSION 2.0.1
+    VERSION 2.0.2
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense")
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '2.0.1',
+    version: '2.0.2',
     license: 'MIT',
     default_options : ['cpp_std=c++17', 'warning_level=3', 'werror=true'])
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -63,6 +63,7 @@ test_sources = [
     'unit/replace.cpp',
     'unit/reserve_and_assign.cpp',
     'unit/reserve.cpp',
+    'unit/set_or_map_types.cpp',
     'unit/set.cpp',
     'unit/std_hash.cpp',
     'unit/swap.cpp',

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -2,10 +2,10 @@
 
 #include <doctest.h>
 
-static_assert(std::is_same_v<ankerl::unordered_dense::v2_0_1::map<int, int>, ankerl::unordered_dense::map<int, int>>);
-static_assert(std::is_same_v<ankerl::unordered_dense::v2_0_1::hash<int>, ankerl::unordered_dense::hash<int>>);
+static_assert(std::is_same_v<ankerl::unordered_dense::v2_0_2::map<int, int>, ankerl::unordered_dense::map<int, int>>);
+static_assert(std::is_same_v<ankerl::unordered_dense::v2_0_2::hash<int>, ankerl::unordered_dense::hash<int>>);
 
 TEST_CASE("version_namespace") {
-    auto map = ankerl::unordered_dense::v2_0_1::map<int, int>{};
+    auto map = ankerl::unordered_dense::v2_0_2::map<int, int>{};
     REQUIRE(map.empty());
 }

--- a/test/unit/set_or_map_types.cpp
+++ b/test/unit/set_or_map_types.cpp
@@ -1,0 +1,11 @@
+#include <ankerl/unordered_dense.h>
+
+template <typename T>
+using detect_has_mapped_type = typename T::mapped_type;
+
+using map_t = ankerl::unordered_dense::map<int, double>;
+static_assert(std::is_same_v<double, map_t::mapped_type>);
+static_assert(ankerl::unordered_dense::detail::is_detected_v<detect_has_mapped_type, map_t>);
+
+using set_t = ankerl::unordered_dense::set<int>;
+static_assert(!ankerl::unordered_dense::detail::is_detected_v<detect_has_mapped_type, set_t>);


### PR DESCRIPTION
This should help e.g. serializers who want to distinguish between map and set by checking for mapped_type. Also, it's more correct.