### PR TITLE
unordered_dense::set iterator is now const_iterator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project("unordered_dense"
-    VERSION 2.0.2
+    VERSION 3.0.0
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense")
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 2.0.2
+// Version 3.0.0
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
@@ -30,9 +30,9 @@
 #define ANKERL_UNORDERED_DENSE_H
 
 // see https://semver.org/spec/v2.0.0.html
-#define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 2 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
+#define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 3 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
 #define ANKERL_UNORDERED_DENSE_VERSION_MINOR 0 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
-#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 2 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
+#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 0 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
 
 // API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/
 #define ANKERL_UNORDERED_DENSE_VERSION_CONCAT1(major, minor, patch) v##major##_##minor##_##patch

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -396,12 +396,12 @@ template <class Key,
           class KeyEqual,
           class AllocatorOrContainer,
           class Bucket>
-class table : public std::conditional_t<std::is_void_v<T>, base_table_type_set, base_table_type_map<T>> {
+class table : public std::conditional_t<is_map_v<T>, base_table_type_map<T>, base_table_type_set> {
 public:
     using value_container_type = std::conditional_t<
         is_detected_v<detect_iterator, AllocatorOrContainer>,
         AllocatorOrContainer,
-        typename std::vector<typename std::conditional_t<std::is_void_v<T>, Key, std::pair<Key, T>>, AllocatorOrContainer>>;
+        typename std::vector<typename std::conditional_t<is_map_v<T>, std::pair<Key, T>, Key>, AllocatorOrContainer>>;
 
 private:
     using bucket_alloc =
@@ -423,8 +423,8 @@ public:
     using const_reference = typename value_container_type::const_reference;
     using pointer = typename value_container_type::pointer;
     using const_pointer = typename value_container_type::const_pointer;
-    using iterator = typename value_container_type::iterator;
     using const_iterator = typename value_container_type::const_iterator;
+    using iterator = std::conditional_t<is_map_v<T>, typename value_container_type::iterator, const_iterator>;
     using bucket_type = Bucket;
 
 private:
@@ -491,10 +491,10 @@ private:
     }
 
     [[nodiscard]] static constexpr auto get_key(value_type const& vt) -> key_type const& {
-        if constexpr (std::is_void_v<T>) {
-            return vt;
-        } else {
+        if constexpr (is_map_v<T>) {
             return vt.first;
+        } else {
+            return vt;
         }
     }
 
@@ -1202,6 +1202,7 @@ public:
         return begin() + static_cast<difference_type>(value_idx_to_remove);
     }
 
+    template <typename Q = T, std::enable_if_t<is_map_v<Q>, bool> = true>
     auto erase(const_iterator it) -> iterator {
         return erase(begin() + (it - cbegin()));
     }
@@ -1432,14 +1433,14 @@ public:
         }
         for (auto const& b_entry : b) {
             auto it = a.find(get_key(b_entry));
-            if constexpr (std::is_void_v<T>) {
-                // set: only check that the key is here
-                if (a.end() == it) {
+            if constexpr (is_map_v<T>) {
+                // map: check that key is here, then also check that value is the same
+                if (a.end() == it || !(b_entry.second == it->second)) {
                     return false;
                 }
             } else {
-                // map: check that key is here, then also check that value is the same
-                if (a.end() == it || !(b_entry.second == it->second)) {
+                // set: only check that the key is here
+                if (a.end() == it) {
                     return false;
                 }
             }

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '2.0.2',
+    version: '3.0.0',
     license: 'MIT',
     default_options : ['cpp_std=c++17', 'warning_level=3', 'werror=true'])
 

--- a/scripts/lint/lint-clang-format.py
+++ b/scripts/lint/lint-clang-format.py
@@ -16,7 +16,10 @@ globs = [
     f"{root_path}/test/**/*.h",
     f"{root_path}/test/**/*.cpp",
 ]
-exclusions = ["nanobench\.h", "FuzzedDataProvider\.h"]
+exclusions = [
+    "nanobench\.h",
+    "FuzzedDataProvider\.h",
+    '/third-party/']
 
 files = []
 for g in globs:

--- a/test/bench/copy.cpp
+++ b/test/bench/copy.cpp
@@ -1,7 +1,6 @@
 #include <ankerl/unordered_dense.h> // for map, operator==
 
-#include <third-party/nanobench.h>  // for Rng, Bench
-#include <third-party/robin_hood.h> // for unordered_node_map, unordered_fl...
+#include <third-party/nanobench.h> // for Rng, Bench
 
 #include <doctest.h>  // for TestCase, skip, TEST_CASE, test_...
 #include <fmt/core.h> // for format
@@ -27,6 +26,8 @@ void bench(std::string_view name) {
     REQUIRE(a == b);
 }
 
+#if 0
+
 TEST_CASE("bench_copy_rhn" * doctest::test_suite("bench") * doctest::skip()) {
     bench<robin_hood::unordered_node_map<uint64_t, uint64_t>>("robin_hood::unordered_node_map");
 }
@@ -34,6 +35,8 @@ TEST_CASE("bench_copy_rhn" * doctest::test_suite("bench") * doctest::skip()) {
 TEST_CASE("bench_copy_rhf" * doctest::test_suite("bench") * doctest::skip()) {
     bench<robin_hood::unordered_flat_map<uint64_t, uint64_t>>("robin_hood::unordered_flat_map");
 }
+
+#endif
 
 TEST_CASE("bench_copy_udm" * doctest::test_suite("bench") * doctest::skip()) {
     bench<ankerl::unordered_dense::map<uint64_t, uint64_t>>("ankerl::unordered_dense::map");

--- a/test/bench/find_random.cpp
+++ b/test/bench/find_random.cpp
@@ -1,8 +1,7 @@
 #include <ankerl/unordered_dense.h> // for map
 
-#include <app/name_of_type.h>       // for name_of_type
-#include <third-party/nanobench.h>  // for Rng
-#include <third-party/robin_hood.h> // for unordered_flat_map
+#include <app/name_of_type.h>      // for name_of_type
+#include <third-party/nanobench.h> // for Rng
 
 #include <doctest.h>  // for TestCase, skip, ResultBuilder
 #include <fmt/core.h> // for format, print
@@ -87,10 +86,14 @@ TEST_CASE("bench_find_random_uo" * doctest::test_suite("bench") * doctest::skip(
     bench<std::unordered_map<size_t, size_t>>();
 }
 
+#if 0
+
 // 10.55
 TEST_CASE("bench_find_random_rh" * doctest::test_suite("bench") * doctest::skip()) {
     bench<robin_hood::unordered_flat_map<size_t, size_t>>();
 }
+
+#endif
 
 // 8.87
 TEST_CASE("bench_find_random_udm" * doctest::test_suite("bench") * doctest::skip()) {

--- a/test/bench/quick_overall_map.cpp
+++ b/test/bench/quick_overall_map.cpp
@@ -1,8 +1,7 @@
 #include <ankerl/unordered_dense.h> // for map, hash
 
-#include <app/geomean.h>            // for geomean
-#include <third-party/nanobench.h>  // for Rng, doNotOptimizeAway, Bench
-#include <third-party/robin_hood.h> // for unordered_node_map, unordered_fl...
+#include <app/geomean.h>           // for geomean
+#include <third-party/nanobench.h> // for Rng, doNotOptimizeAway, Bench
 
 #include <doctest.h>  // for TestCase, skip, ResultBuilder
 #include <fmt/core.h> // for print, format
@@ -168,6 +167,8 @@ void bench_all(ankerl::nanobench::Bench* bench, std::string_view name) {
 
 } // namespace
 
+#if 0
+
 // A relatively quick benchmark that should get a relatively good single number of how good the map
 // is. It calculates geometric mean of several benchmarks.
 TEST_CASE("bench_quick_overall_rhf" * doctest::test_suite("bench") * doctest::skip()) {
@@ -177,9 +178,9 @@ TEST_CASE("bench_quick_overall_rhf" * doctest::test_suite("bench") * doctest::sk
                                                                    "robin_hood::unordered_flat_map<std::string, size_t>");
     fmt::print("{} bench_quick_overall_rhf\n", geomean1(bench));
 
-#ifdef ROBIN_HOOD_COUNT_ENABLED
+#    ifdef ROBIN_HOOD_COUNT_ENABLED
     std::cout << robin_hood::counts() << std::endl;
-#endif
+#    endif
 }
 
 TEST_CASE("bench_quick_overall_rhn" * doctest::test_suite("bench") * doctest::skip()) {
@@ -189,10 +190,12 @@ TEST_CASE("bench_quick_overall_rhn" * doctest::test_suite("bench") * doctest::sk
                                                                    "robin_hood::unordered_node_map<std::string, size_t>");
     fmt::print("{} bench_quick_overall_rhn\n", geomean1(bench));
 
-#ifdef ROBIN_HOOD_COUNT_ENABLED
+#    ifdef ROBIN_HOOD_COUNT_ENABLED
     std::cout << robin_hood::counts() << std::endl;
-#endif
+#    endif
 }
+
+#endif
 
 TEST_CASE("bench_quick_overall_std" * doctest::test_suite("bench") * doctest::skip()) {
     ankerl::nanobench::Bench bench;
@@ -244,6 +247,8 @@ void test_big() {
     fmt::print("{} map.size()\n", map.size());
 }
 
+#if 0
+
 // 3346376 max RSS, 0:12.40
 TEST_CASE("memory_map_huge_rhf" * doctest::test_suite("bench") * doctest::skip()) {
     test_big<robin_hood::unordered_flat_map<uint64_t, size_t>>();
@@ -253,6 +258,8 @@ TEST_CASE("memory_map_huge_rhf" * doctest::test_suite("bench") * doctest::skip()
 TEST_CASE("memory_map_huge_rhn" * doctest::test_suite("bench") * doctest::skip()) {
     test_big<robin_hood::unordered_node_map<uint64_t, size_t>>();
 }
+
+#endif
 
 // 3296524 max RSS, 0:50.76
 TEST_CASE("memory_map_huge_uo" * doctest::test_suite("bench") * doctest::skip()) {

--- a/test/bench/swap.cpp
+++ b/test/bench/swap.cpp
@@ -1,6 +1,5 @@
 #include <ankerl/unordered_dense.h> // for map
 #include <third-party/nanobench.h>  // for Rng, doNotOptimizeAway, Bench
-#include <third-party/robin_hood.h> // for unordered_node_map, unordered_fl...
 
 #include <doctest.h>  // for TestCase, skip, TEST_CASE, test_...
 #include <fmt/core.h> // for format
@@ -33,6 +32,8 @@ void bench(std::string_view name) {
 
 } // namespace
 
+#if 0
+
 TEST_CASE("bench_swap_rhn" * doctest::test_suite("bench") * doctest::skip()) {
     bench<robin_hood::unordered_node_map<uint64_t, uint64_t>>("robin_hood::unordered_node_map");
 }
@@ -40,6 +41,8 @@ TEST_CASE("bench_swap_rhn" * doctest::test_suite("bench") * doctest::skip()) {
 TEST_CASE("bench_swap_rhf" * doctest::test_suite("bench") * doctest::skip()) {
     bench<robin_hood::unordered_flat_map<uint64_t, uint64_t>>("robin_hood::unordered_flat_map");
 }
+
+#endif
 
 TEST_CASE("bench_swap_std" * doctest::test_suite("bench") * doctest::skip()) {
     bench<std::unordered_map<uint64_t, uint64_t>>("std::unordered_map");

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -2,10 +2,10 @@
 
 #include <doctest.h>
 
-static_assert(std::is_same_v<ankerl::unordered_dense::v2_0_2::map<int, int>, ankerl::unordered_dense::map<int, int>>);
-static_assert(std::is_same_v<ankerl::unordered_dense::v2_0_2::hash<int>, ankerl::unordered_dense::hash<int>>);
+static_assert(std::is_same_v<ankerl::unordered_dense::v3_0_0::map<int, int>, ankerl::unordered_dense::map<int, int>>);
+static_assert(std::is_same_v<ankerl::unordered_dense::v3_0_0::hash<int>, ankerl::unordered_dense::hash<int>>);
 
 TEST_CASE("version_namespace") {
-    auto map = ankerl::unordered_dense::v2_0_2::map<int, int>{};
+    auto map = ankerl::unordered_dense::v3_0_0::map<int, int>{};
     REQUIRE(map.empty());
 }

--- a/test/unit/unordered_set.cpp
+++ b/test/unit/unordered_set.cpp
@@ -41,7 +41,7 @@ TEST_CASE("unordered_set_string") {
     REQUIRE(set.size() == 1);
 
     REQUIRE(set.begin() != set.end());
-    std::string& str = *set.begin();
+    std::string const& str = *set.begin();
     REQUIRE(str == std::string(static_cast<size_t>(2000), 'a'));
 
     auto it = set.begin();


### PR DESCRIPTION
This is the same as for std::unordered_set. Bump version to 3.0.0 due to incompatible API change.

Also, some minor cleanup.