### PR TITLE
Fix deallocation with nullptr in some cases 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project("unordered_dense"
-    VERSION 3.0.0
+    VERSION 3.0.1
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense")
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -372,7 +372,7 @@ template <typename Mapped>
 constexpr bool is_map_v = !std::is_void_v<Mapped>;
 
 template <typename Hash, typename KeyEqual>
-constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& is_detected_v<detect_is_transparent, KeyEqual>;
+constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash> && is_detected_v<detect_is_transparent, KeyEqual>;
 
 template <typename From, typename To1, typename To2>
 constexpr bool is_neither_convertible_v = !std::is_convertible_v<From, To1> && !std::is_convertible_v<From, To2>;
@@ -842,8 +842,10 @@ public:
         : table(init, bucket_count, hash, KeyEqual(), alloc) {}
 
     ~table() {
-        auto ba = bucket_alloc(m_values.get_allocator());
-        bucket_alloc_traits::deallocate(ba, m_buckets, bucket_count());
+        if (nullptr != m_buckets) {
+            auto ba = bucket_alloc(m_values.get_allocator());
+            bucket_alloc_traits::deallocate(ba, m_buckets, bucket_count());
+        }
     }
 
     auto operator=(table const& other) -> table& {

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -371,8 +371,10 @@ using detect_reserve = decltype(std::declval<T&>().reserve(size_t{}));
 template <typename Mapped>
 constexpr bool is_map_v = !std::is_void_v<Mapped>;
 
+// clang-format off
 template <typename Hash, typename KeyEqual>
-constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash> && is_detected_v<detect_is_transparent, KeyEqual>;
+constexpr bool is_transparent_v = is_detected_v<detect_is_transparent, Hash>&& is_detected_v<detect_is_transparent, KeyEqual>;
+// clang-format on
 
 template <typename From, typename To1, typename To2>
 constexpr bool is_neither_convertible_v = !std::is_convertible_v<From, To1> && !std::is_convertible_v<From, To2>;

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 3.0.0
+// Version 3.0.1
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
@@ -32,7 +32,7 @@
 // see https://semver.org/spec/v2.0.0.html
 #define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 3 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
 #define ANKERL_UNORDERED_DENSE_VERSION_MINOR 0 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
-#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 0 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
+#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 1 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
 
 // API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/
 #define ANKERL_UNORDERED_DENSE_VERSION_CONCAT1(major, minor, patch) v##major##_##minor##_##patch

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '3.0.0',
+    version: '3.0.1',
     license: 'MIT',
     default_options : ['cpp_std=c++17', 'warning_level=3', 'werror=true'])
 

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -2,10 +2,10 @@
 
 #include <doctest.h>
 
-static_assert(std::is_same_v<ankerl::unordered_dense::v3_0_0::map<int, int>, ankerl::unordered_dense::map<int, int>>);
-static_assert(std::is_same_v<ankerl::unordered_dense::v3_0_0::hash<int>, ankerl::unordered_dense::hash<int>>);
+static_assert(std::is_same_v<ankerl::unordered_dense::v3_0_1::map<int, int>, ankerl::unordered_dense::map<int, int>>);
+static_assert(std::is_same_v<ankerl::unordered_dense::v3_0_1::hash<int>, ankerl::unordered_dense::hash<int>>);
 
 TEST_CASE("version_namespace") {
-    auto map = ankerl::unordered_dense::v3_0_0::map<int, int>{};
+    auto map = ankerl::unordered_dense::v3_0_1::map<int, int>{};
     REQUIRE(map.empty());
 }

--- a/test/unit/pmr.cpp
+++ b/test/unit/pmr.cpp
@@ -122,11 +122,20 @@ TEST_CASE("pmr") {
 
 TEST_CASE("pmr_no_null") {
     auto mr = no_null_memory_resource();
+    { auto map = ankerl::unordered_dense::pmr::map<uint64_t, uint64_t>(&mr); }
     {
         auto map = ankerl::unordered_dense::pmr::map<uint64_t, uint64_t>(&mr);
         for (size_t i = 0; i < 1; ++i) {
             map[i] = i;
         }
+    }
+
+    {
+        auto map = ankerl::unordered_dense::pmr::map<uint64_t, uint64_t>(&mr);
+        for (size_t i = 0; i < 1; ++i) {
+            map[i] = i;
+        }
+        auto map2 = std::move(map);
     }
 }
 


### PR DESCRIPTION
When map is moved or never initialized, destructor called deallocate with nullptr.