### PR TITLE
fix #79: don't reuse m_buckets when allocator does not compare equal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,4 +71,4 @@ jobs:
         name: Windows_Meson_Testlog
         path: |
           builddir/meson-logs/testlog.txt
-          builddir/test/udm.exe
+          builddir/test/udm-test.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project("unordered_dense"
-    VERSION 4.0.1
+    VERSION 4.0.2
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense")
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '4.0.1',
+    version: '4.0.2',
     license: 'MIT',
     default_options : [
         'cpp_std=c++17', 

--- a/test/app/stacktrace.cpp
+++ b/test/app/stacktrace.cpp
@@ -20,7 +20,7 @@ void handle(int sig) {
 
     // print out all the frames to stderr
     fmt::print(stderr, "Error: signal {}. See stacktrace with\n", sig);
-    fmt::print(stderr, "addr2line -Cafpie ./test/udm");
+    fmt::print(stderr, "addr2line -Cafpie ./test/udm-test");
     for (size_t i = 0; i < static_cast<size_t>(size); ++i) {
         fmt::print(stderr, " {}", ary[i]);
     }

--- a/test/meson.build
+++ b/test/meson.build
@@ -60,6 +60,7 @@ test_sources = [
     'unit/namespace.cpp',
     'unit/not_copyable.cpp',
     'unit/not_moveable.cpp',
+    'unit/pmr_move_with_allocators.cpp',
     'unit/pmr.cpp',
     'unit/rehash.cpp',
     'unit/replace.cpp',
@@ -141,7 +142,7 @@ endif
 #endif
 
 test_exe = executable(
-    'udm',
+    'udm-test',
     test_sources,
     include_directories: incdir,
     cpp_args: cpp_args,

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -2,7 +2,7 @@
 
 #include <doctest.h>
 
-namespace versioned_namespace = ankerl::unordered_dense::v4_0_1;
+namespace versioned_namespace = ankerl::unordered_dense::v4_0_2;
 
 static_assert(std::is_same_v<versioned_namespace::map<int, int>, ankerl::unordered_dense::map<int, int>>);
 static_assert(std::is_same_v<versioned_namespace::hash<int>, ankerl::unordered_dense::hash<int>>);

--- a/test/unit/pmr.cpp
+++ b/test/unit/pmr.cpp
@@ -195,9 +195,9 @@ TEST_CASE("pmr_move_different_mr") {
     show(mr1, "mr1");
     show(mr2, "mr2");
 
-    REQUIRE(mr1.num_allocs() == 2);
+    REQUIRE(mr1.num_allocs() == 3);
     REQUIRE(mr1.num_deallocs() == 1);
-    REQUIRE(mr1.num_is_equals() == 0);
+    REQUIRE(mr1.num_is_equals() == 1);
 
     REQUIRE(mr2.num_allocs() == 2);
     REQUIRE(mr2.num_deallocs() == 0);

--- a/test/unit/pmr_move_with_allocators.cpp
+++ b/test/unit/pmr_move_with_allocators.cpp
@@ -1,0 +1,34 @@
+#include <ankerl/unordered_dense.h>
+
+#define ENABLE_LOG_LINE
+#include <app/doctest.h>
+#include <app/print.h>
+
+#if defined(ANKERL_UNORDERED_DENSE_PMR)
+// windows' vector has different allocation behavior, macos has linker errors
+#    if __linux__
+
+using int_str_map = ankerl::unordered_dense::pmr::map<int, std::string>;
+
+// creates a map and moves it out
+auto return_hello_world(ANKERL_UNORDERED_DENSE_PMR::memory_resource* resource) {
+    int_str_map map_default_resource(resource);
+    map_default_resource[0] = "Hello";
+    map_default_resource[1] = "World";
+    return map_default_resource;
+}
+
+TEST_CASE("move_with_allocators") {
+    int_str_map map_default_resource(ANKERL_UNORDERED_DENSE_PMR::new_delete_resource());
+
+    ANKERL_UNORDERED_DENSE_PMR::synchronized_pool_resource pool;
+
+    // segfaults if m_buckets is reused
+    {
+        map_default_resource = return_hello_world(&pool);
+        REQUIRE(map_default_resource.contains(0));
+    }
+}
+
+#    endif
+#endif


### PR DESCRIPTION
m_buckets can only be reused when the allocators are equal. Otherwise we would deallocate with m_buckets with the incorrect allocator.

Also bumped the version for the fix.