### PR TITLE
Passthrough is_avalanching from std::hash

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -277,6 +277,15 @@ struct hash {
     }
 };
 
+template <typename T>
+struct hash<T, typename std::hash<T>::is_avalanching> {
+    using is_avalanching = void;
+    auto operator()(T const& obj) const noexcept(noexcept(std::declval<std::hash<T>>().operator()(std::declval<T const&>())))
+        -> uint64_t {
+        return std::hash<T>{}(obj);
+    }
+};
+
 template <typename CharT>
 struct hash<std::basic_string<CharT>> {
     using is_avalanching = void;


### PR DESCRIPTION
If a `std::hash` specialisation has `using is_avalanching = void;` pass this through to `unordered_dense::hash` this avoids duplicating a hash function for a custom type if you want it to work for generic stl containers and unordered_dense with a correct avalanche tag.