### PR TITLE
Remove duplicate clang-tidy line

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,6 @@ CheckOptions:
   readability-identifier-naming.GlobalVariablePrefix: 'global_'
   readability-identifier-naming.MemberPrefix: 'm_'
   readability-identifier-naming.PrivateMemberPrefix: 'm_'
-  readability-identifier-naming.PrivateMemberPrefix: 'm_'
   readability-identifier-naming.ProtectedMemberPrefix: 'm_'
   readability-identifier-naming.PublicMemberPrefix: ''
   readability-identifier-naming.StaticConstantPrefix: 'static_'


### PR DESCRIPTION
When running clang-tidy (17.0.6-5; alma linux 9.4) the current configuration emits an error about a duplicate entry.  Personally I think clang should handle that nicer but this removes the duplicate entry.

```
_deps/unordered_dense-src/.clang-tidy:49:3: error: duplicated mapping key 'readability-identifier-naming.PrivateMemberPrefix'
  readability-identifier-naming.PrivateMemberPrefix: 'm_'
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```