### PR TITLE
add values() API for xvalues

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1883,8 +1883,16 @@ public:
     }
 
     // nonstandard API: expose the underlying values container
-    [[nodiscard]] auto values() const noexcept -> value_container_type const& {
+    [[nodiscard]] auto values() const& noexcept -> value_container_type const& {
         return m_values;
+    }
+
+    [[nodiscard]] auto values() const&& noexcept -> value_container_type&& {
+        return std::move(const_cast<table*>(this)->m_values);
+    }
+
+    [[nodiscard]] auto values() && noexcept -> value_container_type&& {
+        return std::move(m_values);
     }
 
     // non-member functions ///////////////////////////////////////////////////

--- a/test/meson.build
+++ b/test/meson.build
@@ -76,6 +76,7 @@ test_sources = [
     'unit/tuple_hash.cpp',
     'unit/unique_ptr.cpp',
     'unit/unordered_set.cpp',
+    'unit/values.cpp',
     'unit/vectorofmaps.cpp',
     'unit/windows_include.cpp',
 ]

--- a/test/unit/values.cpp
+++ b/test/unit/values.cpp
@@ -1,0 +1,39 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/counter.h>
+#include <app/doctest.h>
+
+#include <fmt/format.h>
+
+TEST_CASE_MAP("values", counter::obj, counter::obj) {
+    counter counts;
+    INFO(counts);
+
+    counts("start");
+    size_t const n = 100;
+    auto map = map_t();
+    for (size_t i = 0; i < n; ++i) {
+        map.emplace(counter::obj(i, counts), counter::obj(i, counts));
+    }
+    counts("filled");
+    const auto cmap = map;
+    counts("copyed");
+
+    auto d1 = counts.data();
+    auto values = std::move(map).values();
+    counts("values() &&");
+    auto cvalues = std::move(cmap).values();
+    counts("values() const&&");
+    auto d2 = counts.data();
+    REQUIRE(d1 == d2);
+    REQUIRE(values.size() == n);
+    REQUIRE(cvalues.size() == n);
+
+    map.clear();
+    for (size_t i = 0; i < n; ++i) {
+        map.emplace(counter::obj(i, counts), counter::obj(i, counts));
+    }
+    for (size_t i = 0; i < n; ++i) {
+        REQUIRE(map.contains(counter::obj(i, counts)));
+    }
+}


### PR DESCRIPTION
We can use values() API to get the finally underlying vector in some efficient scenes:
```
auto map = map_t();
for (...) map.emplace(...);
auto vec = std::move(map).values();
std::sort(vec.begin(), vec.end(), [](...) { ... });
if (vec.size() > topn) vec.resize(topn);
for (auto &v : vec) ...;
```