### PR TITLE
Fix potential quadratic complexity caused by `reserve(size + 1)`

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -849,8 +849,8 @@ private:
         // reallocates -- and it used to do so with the block already allocated and owned by
         // nobody, which leaked it. Reserving first means the only allocation still outstanding
         // when something fails is one that has not happened yet, and the push_back below cannot
-        // fail because the capacity is already there. Grow geometrically: reserve(size() + 1)
-        // forces a reallocation on every new segment with libstdc++.
+        // fail because the capacity is already there. Grow geometrically to avoid reallocation
+        // on every new segment.
         if (m_blocks.size() == m_blocks.capacity()) {
             m_blocks.reserve((std::max)(std::size_t{1}, m_blocks.capacity() * 2));
         }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -849,8 +849,11 @@ private:
         // reallocates -- and it used to do so with the block already allocated and owned by
         // nobody, which leaked it. Reserving first means the only allocation still outstanding
         // when something fails is one that has not happened yet, and the push_back below cannot
-        // fail because the capacity is already there.
-        m_blocks.reserve(m_blocks.size() + 1);
+        // fail because the capacity is already there. Grow geometrically: reserve(size() + 1)
+        // forces a reallocation on every new segment with libstdc++.
+        if (m_blocks.size() == m_blocks.capacity()) {
+            m_blocks.reserve((std::max)(std::size_t{1}, m_blocks.capacity() * 2));
+        }
         pointer block = std::allocator_traits<Allocator>::allocate(ba, num_elements_in_block);
         m_blocks.push_back(block);
     }


### PR DESCRIPTION
# Bug
I believe `v4.9.0` introduced a performance regression while aiming for exception safety. The code introduced: 
```
m_blocks.reserve(m_blocks.size() + 1);
```
which leads to m_blocks reallocation on every insert in a chain of inserts with libstdc++ and others, which is quadratic.

# Sample program
The following program demonstrates this:
```
//   clang++ -O3 -DNDEBUG -std=c++17 -I include bench_segmented_growth.cpp -o bench_segmented_growth
//   ./bench_segmented_growth

#include <ankerl/unordered_dense.h>

#include <chrono>
#include <cstdio>
#include <string>

int main() {
    static constexpr std::size_t targets[] = {250'000, 500'000, 1'000'000, 2'000'000, 4'000'000, 8'000'000};

    for (auto target : targets) {
        ankerl::unordered_dense::segmented_map<std::string, int> map;

        auto const t0 = std::chrono::steady_clock::now();
        for (std::size_t i = 0; i < target; ++i) {
            map.try_emplace(std::to_string(i), 0);
        }
        auto const t1 = std::chrono::steady_clock::now();

        std::printf("%.4f s  (%zu entries)\n", std::chrono::duration<double>(t1 - t0).count(), target);
    }
}
```

when running on `main` I get the following output on machine:
```
0.0498 s  (250000 entries)
0.1105 s  (500000 entries)
0.3333 s  (1000000 entries)
1.3306 s  (2000000 entries)
5.3910 s  (4000000 entries)
21.8044 s  (8000000 entries)
```

when running with the fix:
```
0.0468 s  (250000 entries)
0.0929 s  (500000 entries)
0.2095 s  (1000000 entries)
0.4428 s  (2000000 entries)
1.0223 s  (4000000 entries)
2.3013 s  (8000000 entries)
```

# Alternative fixes

Another option could be to remove the `reserve` all-together and wrap the `push_back` in a try-catch block, like:
```
pointer block = std::allocator_traits<Allocator>::allocate(ba, num_elements_in_block);

if constexpr (ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()) {
    try {
        m_blocks.push_back(block);
    } catch (...) {
        std::allocator_traits<Allocator>::deallocate(ba, block, num_elements_in_block);
        throw;
    }
} else {
    m_blocks.push_back(block);
}
```
pros: 
- let's the specific `std::vector` implementation handle the scaling factor (in the PR diff, we hardcode 2x)

cons: 
- more complex code