### PR TITLE
Ask whether a test would notice the bug, not whether it ran the line

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,13 @@ jobs:
       # network), so they belong here rather than in the nightly fuzz workflow.
       - run: ./scripts/test_fuzz_afl.py
 
+      # Same reasoning for scripts/mutate/mutate.py, and one more: what that tool decides is
+      # whether a test noticed a bug, so every way it can be wrong is silent -- a bug block that
+      # substitutes nothing, a filter that matches no case, a lane still holding yesterday's
+      # binary all come back "survived" and read as a hole in the suite. Hermetic too: no
+      # compiler, no meson, no lanes, no cgroups.
+      - run: ./scripts/test_mutate.py
+
   # Linux, macOS, Windows, the sanitizers and the hardened build used to be four jobs repeating
   # the same ten lines of checkout, python, cache and artifact setup. They differ only in the
   # runner, the compiler and the meson arguments, which is what the matrix carries. The displayed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,59 @@ meson test -C builddir/clang_release unit --verbose
 ./builddir/clang_release/test/udm-test
 ```
 
+## Mutation testing
+
+Coverage says a line ran. `scripts/mutate/mutate.py` says something would have noticed it
+misbehaving: it breaks the header, rebuilds, runs the suite and asks whether anything went red.
+What nothing notices is a hole in the tests. It never touches the working tree — every build
+happens in a throwaway copy of the repo.
+
+The everyday use is putting a *specific* bug back, which is the check that decides whether a new
+test earns its place. Bugs worth keeping live in `scripts/mutate/bugs/`:
+
+```sh
+scripts/mutate/mutate.py --replace OLD NEW               # one, must match exactly once
+scripts/mutate/mutate.py --bugs scripts/mutate/bugs/erase-path.txt
+scripts/mutate/mutate.py --reverse HEAD                  # undo a fix, keep today's tests
+```
+
+The other mode sweeps for holes nobody thought of, mutating one token at a time. Both compose, and
+a change is best asked both questions at once:
+
+```sh
+scripts/mutate/mutate.py --diff HEAD~1                   # only what this change touched
+scripts/mutate/mutate.py --lines 1278-1290 --dry-run     # how many, and how long
+scripts/mutate/mutate.py --bugs bugs.txt --lines 1278-1290 --reuse
+```
+
+A mutant costs one full rebuild of the test binary — all ~90 translation units include the header,
+so there is no incremental mutant build and ccache cannot help either. That is ~100 CPU-seconds of
+compiling against 3 of running the suite, which is why the lanes default to one ninja job each and
+a single named bug instead gets the whole machine. Budget roughly a minute for a handful of
+mutants and an hour for a sweep of a whole function.
+
+Verdicts are `caught` (a test failed — the number worth moving), `compiler` (the build refused it),
+`hang`, `oom` and `survived`. Without a sanitizer, a mutant that reads one slot past a bucket comes
+back `survived` however good the tests are, so re-run anything surprising with
+`--meson-arg=-Db_sanitize=address,undefined` before believing it.
+
+Each lane runs inside a cgroup with a memory cap (`systemd-run --user --scope`), because a mutated
+growth policy turns an insert into a request for more memory than the machine has. Capped, that is
+one `oom` verdict; uncapped, the kernel picks the victim and it is as likely to be another lane as
+the mutant that caused it. `--memory-limit` overrides the default, which is the smaller of a lane's
+share of the machine and 1 GiB per ninja job; a build is never capped below what its jobs need. On
+a machine with no user scope to be had — another init, no session bus, an undelegated container —
+the run says so up front rather than pretending.
+
+The lanes are the other half of the same problem: ~90 MB each in a workdir defaulting to `/tmp`,
+which is a tmpfs on most current distributions, so `--lanes` buys memory as much as parallelism.
+The run prints how much room it is about to take and whether that room is RAM, and refuses before
+copying rather than part way through. Core dumps are disabled for the same reason — a crashing
+mutant is an ordinary verdict, and each one would leave ~30 MB in a lane about to be deleted.
+
+`scripts/test_mutate.py` covers the half of the tool that decides what a verdict *means*, and runs
+in CI. It is hermetic: no compiler, no meson, no lanes, no cgroups.
+
 ## Fuzzing
 
 The `fuzz` test suite replays the committed corpora in `data/fuzz/<target>` on every test run, which

--- a/scripts/mutate/bugs/erase-path.txt
+++ b/scripts/mutate/bugs/erase-path.txt
@@ -1,0 +1,83 @@
+# What erase() has to put back before it returns, and what notices when it does not.
+# Erasing touches three things that have to stay in step: the bucket array shifts
+# down so no element is left stranded past its home slot, m_values closes the hole
+# it just made by moving the last element into it, and that moved element's bucket
+# has to be repointed at its new index. Any one of the three can be dropped and the
+# map still answers most questions correctly, which is what makes them worth asking
+# about.
+#
+# Run alongside a sweep over the same functions - the named bugs the tests were
+# written for, and the token-level ones nobody thought to ask:
+#
+#     scripts/mutate/mutate.py --bugs scripts/mutate/bugs/erase-path.txt \
+#                              --lines 1278-1290 --reuse
+#
+# A snapshot against the code as it was: when a block stops applying, that part has
+# been rewritten and these questions want re-deriving rather than repairing.
+
+# no shift down at all: the erased bucket is cleared and its run left stranded
+# Every element that probed past this slot is now unreachable - find() stops at the
+# empty bucket - while still being counted by size() and still walked by iteration.
+<<<
+    void erase_and_shift_down(value_idx_type bucket_idx) {
+        // cache mask in a local so the bucket stores can't alias it
+        auto const mask = m_bucket_mask;
+
+        // shift down until either empty or an element with correct spot is found
+        auto next_bucket_idx = static_cast<value_idx_type>((bucket_idx + 1U) & mask);
+        while (at(m_buckets, next_bucket_idx).m_dist_and_fingerprint >= Bucket::dist_inc * 2) {
+            auto& next_bucket = at(m_buckets, next_bucket_idx);
+            at(m_buckets, bucket_idx) = {dist_dec(next_bucket.m_dist_and_fingerprint), next_bucket.m_value_idx};
+            bucket_idx = std::exchange(next_bucket_idx, static_cast<value_idx_type>((next_bucket_idx + 1U) & mask));
+        }
+        at(m_buckets, bucket_idx) = {};
+    }
+===
+    void erase_and_shift_down(value_idx_type bucket_idx) {
+        at(m_buckets, bucket_idx) = {};
+    }
+>>>
+
+# the shift down moves each element back a slot but keeps its old distance
+# The robin hood invariant is now a lie in one direction: every shifted element
+# claims to be one probe further from home than it is, so a later insert with a
+# genuinely larger distance no longer displaces it.
+<<<
+            at(m_buckets, bucket_idx) = {dist_dec(next_bucket.m_dist_and_fingerprint), next_bucket.m_value_idx};
+===
+            at(m_buckets, bucket_idx) = {next_bucket.m_dist_and_fingerprint, next_bucket.m_value_idx};
+>>>
+
+# the moved element's bucket is left pointing at the slot it came from
+# m_values closed its hole, but one bucket still names the index the erased value
+# used to live at, which now holds a different element entirely.
+<<<
+            at(m_buckets, bucket_idx).m_value_idx = value_idx_to_remove;
+===
+>>>
+
+# the scan for the moved element's bucket looks for an index one past the end
+# No bucket holds it, so the scan walks the whole array; what it does when it comes
+# back round to where it started is the question.
+<<<
+            auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
+===
+            auto const values_idx_back = static_cast<value_idx_type>(m_values.size());
+>>>
+
+# the displaced element is shifted up without its distance being raised
+# The other half of the invariant, on the insert side: an element pushed one slot
+# further from home still claims the distance it had before it was pushed.
+<<<
+            bucket.m_dist_and_fingerprint = dist_inc(bucket.m_dist_and_fingerprint);
+===
+>>>
+
+# extract() hands back the last element rather than the erased one
+# Only visible when they differ, which is every erase but the one that happens to
+# take the element m_values already ends with.
+<<<
+        auto&& erased_value = std::move(m_values[value_idx_to_remove]);
+===
+        auto&& erased_value = std::move(m_values.back());
+>>>

--- a/scripts/mutate/mutate.py
+++ b/scripts/mutate/mutate.py
@@ -1,0 +1,1554 @@
+#!/usr/bin/env python3
+"""Mutation testing for unordered_dense.
+
+Coverage says a line ran. This says something would have noticed it misbehaving.
+It breaks `unordered_dense.h`, rebuilds, runs the suite, and asks whether anything
+went red. What nothing notices is a hole in the tests.
+
+Two ways to use it, and the first is the everyday one.
+
+**Put specific bugs back.** The check that decides whether a new test is worth
+keeping: break the thing it covers and confirm it goes red. Bugs are independent,
+so a batch runs across lanes at once rather than one rebuild after another.
+
+    mutate.py --bugs bugs.txt                  # a file of them, in parallel
+    mutate.py --replace OLD NEW                # one, repeatable
+    mutate.py --reverse HEAD                   # undo a fix, keep today's tests
+    mutate.py --bugs bugs.txt --reuse          # again, against an edited test
+
+`--reuse` keeps the lanes and syncs only what changed next time, which saves the
+copying and the configuring - not the compiling, see below.
+
+A bug file is a name and a block each. Old text must match exactly once, and a
+block that does not apply stops the run - otherwise a typo substitutes nothing,
+the suite stays green, and the report blames your tests for it:
+
+    # the erase moved the last element without fixing up its bucket
+    <<<
+        auto mh = mixed_hash(get_key(m_values.back()));
+    ===
+        auto mh = mixed_hash(get_key(*it));
+    >>>
+
+Bug files worth keeping live in `scripts/mutate/bugs/`. They are snapshots
+against the code as it was, so one that stops applying is not a failure - it is
+the tool saying that part has been rewritten and the questions need re-deriving.
+
+**Or sweep for holes you have not thought of**, mutating one token at a time:
+
+    mutate.py --diff HEAD~1                    # only what this change touched
+    mutate.py --lines 1200-1260                # one function
+    mutate.py                                  # the whole header
+    mutate.py --diff HEAD~1 --dry-run          # how many, and how long
+
+The two compose, and a change is best asked both questions at once - the named
+bugs the tests were written for, and the sweep for what nobody thought to ask:
+
+    mutate.py --bugs bugs.txt --lines 1200-1260 --reuse
+
+Nothing is scored until the suite is green repeatedly, because a flaky test
+counted as a kill inflates the number in the flattering direction. The working
+tree is never touched: every build happens in a throwaway copy, so a run that
+dies half way cannot leave a mutated header behind, and two runs at once get
+their own copies rather than deleting each other's.
+
+Every mutant ends in one of five verdicts, and the difference matters.
+`compiler` means the build refused it - real protection, but not your tests
+doing the work. `caught` means an assertion failed, which is the number worth
+moving. `hang` means it ran forever; a mutated probe step does that rather than
+failing. `oom` means it asked for more memory than it was allowed, which is what
+a mutated growth policy does. `survived` means nothing noticed, which is the
+answer you are looking for. A sixth, `error`, means this tool fell over on that
+mutant; it is left out of the score rather than guessed at, and the rest of the
+run carries on regardless.
+
+Each lane runs inside a cgroup with a memory cap, because `oom` has to be that
+mutant's verdict and not the machine's problem: uncapped, one insert asking for
+a terabyte ends with the kernel choosing a victim, and it is as likely to be
+another lane, the ninja driving one, or this script. `--memory-limit` sets it,
+the default is the smaller of a lane's share of the machine and a gigabyte per
+ninja job, and the run says which up front. Where no cgroup can be had - another
+init, no session bus, an undelegated container - the run says that instead of
+pretending.
+
+The lanes themselves are the other half of that: ~90 MB each, in a workdir that
+defaults to /tmp, which on most current distributions is a tmpfs - so `--lanes`
+buys memory as much as it buys parallelism. The run says how much room it is
+about to take and whether that room is RAM, and refuses before copying rather
+than half way through. Core dumps are turned off for the same reason: a crashing
+mutant is an ordinary verdict here, and each one would otherwise leave ~30 MB in
+a lane that is about to be deleted.
+
+**What a mutant costs here is one full rebuild of the test binary.** Every one of
+the ~90 translation units includes the header, so there is no such thing as an
+incremental mutant build and ccache cannot help either - each mutant is a
+preprocessed source nothing has ever seen. That is around 100 CPU-seconds of
+compiling against 3 of running the suite, which is why the lanes default to one
+job each (the machine is already full) and why a single named bug instead gets
+all the cores to itself. It is also why the -fsyntax-only pre-filter earns its
+keep: half a second to reject what would otherwise cost a full rebuild.
+"""
+
+import argparse
+import bisect
+import concurrent.futures
+import contextlib
+import filecmp
+import json
+import os
+import queue
+import random
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# The library is one header, so that is the default target; --file overrides it.
+HEADER = os.path.join("include", "ankerl", "unordered_dense.h")
+
+# The TU the syntax pre-filter compiles when the header is what is being mutated.
+# It wants to be a file that *instantiates* the map rather than merely including
+# it - a mutation inside a member template is a parse error either way, but one
+# that only breaks type checking is not seen until something instantiates it.
+# fuzz_api touches most of the API surface for about the same half second as any
+# other unit file.
+SYNTAX_TU = os.path.join("test", "unit", "fuzz_api.cpp")
+
+# What meson builds and what the doctest binary is called inside a lane.
+TEST_BINARY = os.path.join("test", "udm-test")
+
+# Copied per lane, so this is about keeping the copy to the sources and the fuzz
+# corpora. `subprojects` deliberately stays: it holds the already-downloaded
+# doctest and the packagecache, and a lane without them tries to fetch a release
+# tarball per lane - slow where that works at all and fatal where it does not.
+LANE_IGNORE = shutil.ignore_patterns(".git", "__pycache__", ".cache", ".ccache",
+                                     ".vscode", "fuzz-findings", "*.pcm", "*.o",
+                                     "a.out", "compile_commands.json")
+
+# Build directories, which only exist at the top level. Matched there rather than
+# everywhere, because `build*` as a global pattern also eats `scripts/build.py`.
+ROOT_IGNORE = ("builddir", "build", "_build")
+
+# Wall seconds per mutant, and this differs from a single-TU project in a way
+# worth stating: the cost is ~100 CPU-seconds of compiling that no amount of
+# lanes creates or removes, plus a link and a suite run that are serial inside
+# whichever lane they happen in. So the compiling is divided by the *machine*
+# and only the tail is divided by the lanes.
+#
+# Measured on a 32-thread machine, g++ at -O0: 99 CPU-seconds to rebuild all 90
+# TUs and 3.4 to run the suite. Mutants the pre-filter rejects cost half a second
+# instead of all of that, and the estimate does not model them - so --dry-run
+# reads high on a sweep, which is the direction to be wrong in.
+CPU_SECONDS_PER_MUTANT = 100.0
+TAIL_SECONDS_PER_MUTANT = 4.0
+SECONDS_OF_SETUP = 20.0
+SECONDS_OF_SETUP_PER_LANE = 1.5
+
+VERDICTS = ("caught", "compiler", "hang", "oom", "survived", "error")
+
+MIB = 1024 * 1024
+GIB = 1024 * MIB
+
+
+def lane_ignore(directory, names):
+    skip = list(LANE_IGNORE(directory, names))
+    if os.path.abspath(directory) == REPO:
+        skip.extend(ROOT_IGNORE)
+    return skip
+
+
+def sync_tree(src, dst):
+    """Bring an existing lane back in line with the repo, copying only what
+    actually changed.
+
+    The point is the mtimes. A wholesale re-copy would restamp every source and
+    cost a full rebuild in every lane, which is most of what reuse was meant to
+    save - so a file that matches is left alone, and ninja rebuilds exactly what
+    the working tree touched since last time.
+
+    Sameness is decided by *content*, and a file that differs is stamped with
+    the current time rather than the repo's. Both halves are load-bearing.
+    Comparing mtimes would call the previous run's mutated header a change on
+    every file in the tree; and copying the repo's older mtime onto it would
+    leave the lane's object files looking newer than their source, so ninja
+    would build nothing and the suite would run against the last mutant."""
+    for root, dirs, files in os.walk(src):
+        skip = set(lane_ignore(root, dirs + files))
+        dirs[:] = [d for d in dirs if d not in skip]
+        rel = os.path.relpath(root, src)
+        target = dst if "." == rel else os.path.join(dst, rel)
+        os.makedirs(target, exist_ok=True)
+        wanted = set()
+        for name in files:
+            if name in skip:
+                continue
+            wanted.add(name)
+            source, copy = os.path.join(root, name), os.path.join(target, name)
+            if os.path.exists(copy) and filecmp.cmp(source, copy, shallow=False):
+                continue
+            shutil.copyfile(source, copy)
+            os.utime(copy, None)
+        # A file deleted from the repo has to go, or it keeps being compiled.
+        # Only files: the lane's build directory is a directory and is not in
+        # the source tree, so it is never a candidate.
+        for name in os.listdir(target):
+            stale = os.path.join(target, name)
+            if os.path.isfile(stale) and name not in wanted:
+                os.remove(stale)
+
+
+def estimate_seconds(count, lanes, cores):
+    lanes, cores = max(1, lanes), max(1, cores)
+    return (SECONDS_OF_SETUP + SECONDS_OF_SETUP_PER_LANE * lanes
+            + count * (CPU_SECONDS_PER_MUTANT / cores
+                       + TAIL_SECONDS_PER_MUTANT / lanes))
+
+
+def estimate(count, lanes, cores):
+    seconds = estimate_seconds(count, lanes, cores)
+    if seconds > 5400:
+        return "%.1f h" % (seconds / 3600)
+    return "%.0f min" % (seconds / 60) if seconds > 90 else "%.0f s" % seconds
+
+
+# ---------------------------------------------------------------- memory
+
+# Why there is a cap at all, because it is not the obvious one. The suite is
+# tiny - all 501 cases green peak at 14 MB - and a single g++ -O0 translation
+# unit peaks at ~185 MB. Nothing honest here needs a gigabyte. What needs the
+# cap is the mutant: a growth policy, a bucket mask or a shift amount moved by
+# one turns an insert into a request for more memory than the machine has, and
+# uncapped that ends with the kernel's OOM killer choosing a victim - as likely
+# to be another lane, the ninja driving one, or this script as the mutant that
+# caused it. One runaway mutant then corrupts every verdict running beside it,
+# which is the failure this tool exists to avoid.
+#
+# The second reason is quieter: lanes are sized off the core count without
+# anyone asking what that costs in RAM, and 32 lanes each building is 32
+# compilers at once. Capping each lane at its share of the machine makes that
+# arithmetic explicit instead of hoping.
+
+# What a build is never capped below, whatever the cap says. Every ninja job is
+# a compiler and a translation unit here peaks at ~185 MB, so a cap under that
+# would report `oom` for every mutant and blame a growth policy for this tool's
+# own arithmetic. Half a gigabyte a job is that figure with room for the link,
+# which is the one step holding all of it at once.
+MEMORY_PER_JOB = 512 * MIB
+
+SIZE = re.compile(r"^(\d+(?:\.\d+)?)\s*([KMGT]?)(?:i?B)?$", re.IGNORECASE)
+SIZE_UNITS = {"": 1, "K": 1024, "M": MIB, "G": GIB, "T": 1024 * GIB}
+
+
+def parse_size(text):
+    """A size like `4G`, `512M` or `0`, in bytes. Bare digits are bytes."""
+    m = SIZE.match(text.strip())
+    if not m:
+        raise argparse.ArgumentTypeError(
+            "%r is not a size - write it as 4G, 512M or 0" % text)
+    return int(float(m.group(1)) * SIZE_UNITS[m.group(2).upper()])
+
+
+def human(size):
+    if not size:
+        return "off"
+    return ("%.1f GiB" % (size / GIB)) if size >= GIB else ("%.0f MiB" % (size / MIB))
+
+
+def total_memory():
+    """Bytes this machine will actually hand out, or 0 if it will not say."""
+    limits = []
+    try:
+        limits.append(os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES"))
+    except (ValueError, OSError, AttributeError):
+        pass
+    # Inside a container the cgroup limit is the real answer and physical RAM is
+    # the host's. `memory.max` is readable at this path only when the cgroup
+    # namespace root is our own cgroup - which is exactly when that is the case.
+    try:
+        with open("/sys/fs/cgroup/memory.max", encoding="utf-8") as f:
+            limits.append(int(f.read().strip()))
+    except (OSError, ValueError):
+        pass
+    return min(limits) if limits else 0
+
+
+def default_memory_limit(lanes, jobs, total=None):
+    """What one lane may use: the smaller of its share of the machine and what a
+    lane can honestly need.
+
+    The share is what keeps the lanes together inside the machine; four fifths
+    of it, because the page cache holding ~90 objects per lane is not free
+    either. The honest figure is a gigabyte per ninja job - twice the floor a
+    build is never capped below, so an ordinary one never comes near it.
+    Whichever is smaller is still orders of magnitude above the 14 MB the suite
+    itself uses, which is the only number a mutant has to beat to be called
+    runaway.
+    """
+    limits = [max(2, jobs) * 2 * MEMORY_PER_JOB]
+    total = total_memory() if total is None else total
+    if total:
+        limits.append(int(0.8 * total) // max(1, lanes))
+    return max(GIB, min(limits))
+
+
+def build_memory_limit(limit, jobs):
+    """The cap a build gets, which is the lane's unless its jobs need more.
+
+    Raising it here rather than raising the lane's keeps the two questions
+    apart. What a build needs is known - it is the job count times a compiler -
+    and what a mutant needs is the thing being asked about, so an explicit
+    `--memory-limit` tightens the second without breaking the first. In
+    aggregate nothing is given away either: lanes times jobs is the core count,
+    so every lane building at its floor at once is what a plain `ninja` on this
+    machine would use anyway.
+    """
+    return max(limit, jobs * MEMORY_PER_JOB) if limit else 0
+
+
+def memory_capped(argv, limit):
+    """`argv` inside a cgroup that caps it, when there is one to be had.
+
+    `systemd-run --scope` puts the command - and everything it goes on to spawn,
+    so ninja's compilers too - into a transient cgroup with MemoryMax set, and
+    the kernel stops the lot the moment they exceed it. Swap is pinned to zero
+    as well: without that a runaway first fills whatever swap the machine has,
+    and on a box already swapping that is minutes of thrashing slowing every
+    other lane down before anything is killed at all.
+
+    A scope rather than a service, which is what makes this a wrapper and not a
+    different way of running things: the command stays a child of this process,
+    so its stdout, its environment, its working directory and its exit status
+    all arrive exactly as they would without it.
+    """
+    if not limit:
+        return list(argv)
+    return ["systemd-run", "--user", "--scope", "--quiet", "--collect",
+            "-p", "MemoryMax=%d" % limit, "-p", "MemorySwapMax=0",
+            "--"] + list(argv)
+
+
+def memory_cap_reason(limit):
+    """Why the cap cannot be had here, or "" when it can.
+
+    It needs systemd, a session bus and the memory controller delegated to the
+    user - a container, a CI runner or a machine with another init has some
+    subset of those. Asking by trying beats testing for the pieces one at a
+    time, and it costs one 5 ms scope for the whole run.
+    """
+    try:
+        r = subprocess.run(memory_capped(["true"], limit), capture_output=True,
+                           text=True, timeout=60)
+    except FileNotFoundError:
+        return "systemd-run is not on PATH"
+    except (OSError, subprocess.SubprocessError) as e:
+        return "systemd-run: %s" % e
+    if r.returncode == 0:
+        return ""
+    # Its own complaint says which piece is missing - "Failed to connect to bus"
+    # on a machine with no session, a delegation error on a container - and that
+    # is more use than anything this could say in its place.
+    said = (r.stderr or r.stdout).strip()
+    return said.splitlines()[-1][:100] if said \
+        else "systemd-run --user --scope exited %d" % r.returncode
+
+
+# A cgroup that goes over its limit is stopped, and which signal arrives says
+# only which half of the kernel got there first. The kernel OOM-kills the
+# offending process outright (-9); when that process was not the one we are
+# waiting on, systemd sees a member die and stops the rest of the scope, which
+# is a SIGTERM (-15). Nothing this tool runs sends either signal itself, so both
+# mean the same thing here: it asked for more than it was allowed.
+MEMORY_KILL_SIGNALS = (-9, -15)
+
+
+def killed_for_memory(proc):
+    return proc is not None and proc.returncode in MEMORY_KILL_SIGNALS
+
+
+def drop_core_dumps():
+    """Stop the lanes filling up with cores, which they otherwise do quickly.
+
+    A crashing mutant is an ordinary verdict here - a segfault is one of the
+    ways the suite notices - and the default `core_pattern` writes the dump into
+    the crashing process's working directory, which is the lane. That is ~30 MB
+    of a mutated binary that no longer exists, once per crash, in a directory
+    that on most machines is under /tmp and therefore in RAM. Nothing reads
+    them: the lane is deleted at the end of the run and the binary they refer to
+    was overwritten by the next mutant.
+
+    Lowering a soft limit needs no privilege, and the children inherit it.
+    """
+    try:
+        import resource  # noqa: PLC0415 - POSIX only, and not needed elsewhere
+        _, hard = resource.getrlimit(resource.RLIMIT_CORE)
+        resource.setrlimit(resource.RLIMIT_CORE, (0, hard))
+    except (ImportError, ValueError, OSError):
+        pass
+
+
+LANE_BYTES = 90 * MIB  # ~21 MB of sources and corpora, ~64 MB of build directory
+
+
+def memory_backed(path):
+    """Whether writing to `path` costs RAM rather than disk.
+
+    /tmp is a tmpfs on most current distributions, so the default workdir
+    usually is - and a lane there is not free the way a directory normally is.
+    """
+    try:
+        with open("/proc/mounts", encoding="utf-8") as f:
+            mounts = [line.split()[1:3] for line in f if len(line.split()) > 2]
+    except OSError:
+        return False
+    path, deepest = os.path.abspath(path), ("", "")
+    for point, kind in mounts:
+        point = point.replace("\\040", " ")
+        under = path == point or path.startswith(point.rstrip("/") + "/")
+        if under and len(point) >= len(deepest[0]):
+            deepest = (point, kind)
+    return deepest[1] in ("tmpfs", "ramfs")
+
+
+# ---------------------------------------------------------------- lexing
+
+def code_mask(src):
+    """True for every byte that is real code.
+
+    False inside comments, string/char/raw-string literals and preprocessor
+    directives. Mutating those is the main way a token-level mutator wastes its
+    budget: a third of this header is prose, and the `#define` lines hold the
+    version macros that a lint job checks separately.
+    """
+    mask = bytearray(b"\x01" * len(src))
+
+    def blank(start, end):
+        end = min(end, len(src))
+        mask[start:end] = b"\x00" * max(0, end - start)
+
+    i, n = 0, len(src)
+    at_line_start = True
+    while i < n:
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < n else ""
+
+        if c in " \t":
+            i += 1
+            continue
+
+        if c == "\n":
+            at_line_start = True
+            i += 1
+            continue
+
+        # preprocessor directive: the whole logical line, continuations included
+        if at_line_start and c == "#":
+            j = i
+            while j < n:
+                if src[j] == "\n" and not (j > 0 and src[j - 1] == "\\"):
+                    break
+                j += 1
+            blank(i, j)
+            i = j
+            continue
+
+        at_line_start = False
+
+        if c == "/" and nxt == "/":
+            j = src.find("\n", i)
+            j = n if j < 0 else j
+            blank(i, j)
+            i = j
+            continue
+
+        if c == "/" and nxt == "*":
+            j = src.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            blank(i, j)
+            i = j
+            continue
+
+        # raw string: R"delim( ... )delim"
+        if c == "R" and nxt == '"':
+            m = re.compile(r'R"([^(]*)\(').match(src, i)
+            if m:
+                close = ')' + m.group(1) + '"'
+                j = src.find(close, m.end())
+                j = n if j < 0 else j + len(close)
+                blank(i, j)
+                i = j
+                continue
+
+        if c in '"\'':
+            quote = c
+            j = i + 1
+            while j < n:
+                if src[j] == "\\":
+                    j += 2
+                    continue
+                if src[j] == quote:
+                    j += 1
+                    break
+                if src[j] == "\n":  # unterminated, do not run away
+                    break
+                j += 1
+            blank(i, j)
+            i = j
+            continue
+
+        i += 1
+
+    return mask
+
+
+# ------------------------------------------------------------- operators
+
+# Longest first, so `<=` is never split into `<`. Shifts, `->` and `::` are left
+# alone on purpose: mutating them is a compile error essentially every time, and
+# a mutant that cannot build costs a rebuild to tell us nothing. Shifts are the
+# painful exclusion here - this header shifts to build the fingerprint and to
+# size the bucket array - but `<<` to `>>` is caught by the compiler in the
+# places it is not caught by every test at once, and a shift *amount* is a
+# number, which is mutated.
+OPERATOR_MUTATIONS = [
+    ("<<=", []), (">>=", []), ("<<", []), (">>", []), ("->", []), ("::", []),
+    ("<=", ["<", ">=", "=="]),
+    (">=", [">", "<=", "=="]),
+    ("==", ["!="]),
+    ("!=", ["=="]),
+    ("&&", ["||"]),
+    ("||", ["&&"]),
+    ("++", ["--"]),
+    ("--", ["++"]),
+    ("+=", ["-="]),
+    ("-=", ["+="]),
+    ("*=", ["/="]),
+    ("/=", ["*="]),
+    ("<", ["<=", ">"]),
+    (">", [">=", "<"]),
+    ("+", ["-"]),
+    ("-", ["+"]),
+    ("*", ["/"]),
+    ("/", ["*"]),
+]
+
+IDENT = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
+# integer literal, not part of an identifier or a float/exponent
+NUMBER = re.compile(r"\b(\d+)([uUlL]*)\b")
+
+WORD_MUTATIONS = {"true": ["false"], "false": ["true"]}
+
+
+def is_comparison(src, offset, op):
+    """Whether a bare `<`/`>` is a comparison rather than a template bracket.
+
+    Most sites are angle brackets - `std::is_same<`, `static_cast<size_t>`,
+    `template <class Key>` - and mutating one is a compile error every time.
+    They are not free: each costs a syntax check, and they swamp the `compiler`
+    bucket, which is the one the report explicitly calls not the number worth
+    moving. The header is clang-formatted, so a comparison always has a space on
+    both sides and a template bracket never does.
+    """
+    if op not in ("<", ">"):
+        return True
+    before = src[offset - 1] if offset else ""
+    after = src[offset + 1] if offset + 1 < len(src) else ""
+    return before == " " and after == " "
+
+
+def line_starts(src):
+    starts = [0]
+    start = src.find("\n")
+    while start >= 0:
+        starts.append(start + 1)
+        start = src.find("\n", start + 1)
+    return starts
+
+
+def mutation_sites(src, mask, line_filter=None):
+    """Every single-token change worth trying, as {offset, original, ...} dicts."""
+    sites = []
+    n = len(src)
+    starts = line_starts(src)
+
+    def line_of(off):
+        return bisect.bisect_right(starts, off)
+
+    def add(offset, original, replacement):
+        line = line_of(offset)
+        if line_filter is not None and line not in line_filter:
+            return
+        sites.append(dict(offset=offset, original=original,
+                          replacement=replacement, line=line,
+                          description="%s -> %s" % (original, replacement)))
+
+    i = 0
+    while i < n:
+        if not mask[i]:
+            i += 1
+            continue
+
+        m = IDENT.match(src, i)
+        if m:
+            for rep in WORD_MUTATIONS.get(m.group(0), ()):
+                add(i, m.group(0), rep)
+            i = m.end()
+            continue
+
+        m = NUMBER.match(src, i)
+        if m:
+            # A float like 1.5 or 0.8 must not be picked apart into an int. A
+            # number at the very start or end of the file has no neighbour, and
+            # the sentinel is what stands in for one: `"" in ".0123456789"` is
+            # True, so an empty string here would reject the mutation instead.
+            before = src[i - 1] if i else "\n"
+            after = src[m.end()] if m.end() < n else "\n"
+            if before not in ".0123456789" and after not in ".eE0123456789":
+                value, suffix = int(m.group(1)), m.group(2)
+                for rep_val in (value + 1, value - 1):
+                    if rep_val >= 0:
+                        add(i, m.group(0), "%d%s" % (rep_val, suffix))
+            i = m.end()
+            continue
+
+        for op, reps in OPERATOR_MUTATIONS:
+            if src.startswith(op, i):
+                if is_comparison(src, i, op):
+                    for rep in reps:
+                        add(i, op, rep)
+                i += len(op)
+                break
+        else:
+            i += 1
+
+    return sites
+
+
+def changed_lines(ref, path):
+    """Line numbers of `path` touched since `ref`, for the fast daily mode."""
+    out = subprocess.run(
+        ["git", "diff", "--unified=0", ref, "--", path],
+        cwd=REPO, capture_output=True, text=True, check=True).stdout
+    lines = set()
+    for hunk in re.finditer(r"^@@ -\S+ \+(\d+)(?:,(\d+))? @@", out, re.M):
+        start = int(hunk.group(1))
+        count = int(hunk.group(2) or 1)
+        lines.update(range(start, start + count))
+    return lines
+
+
+# ---------------------------------------------------------------- running
+
+def count_test_cases(stdout):
+    """How many cases doctest actually ran, or None if it never got that far.
+
+    The number this guards against is zero. doctest's suites are the ones a
+    `TEST_SUITE` names - `fuzz` and `stochastic` here - and not meson's, which
+    call the whole binary `unit`; ask for `-ts=unit` and doctest skips all 528
+    cases and exits 0. Every mutant then comes back `survived` and the report
+    reads as a suite full of holes.
+    """
+    m = re.search(r"^\[doctest\] test cases:\s*(\d+)", stdout, re.M)
+    return int(m.group(1)) if m else None
+
+
+def parse_test_output(proc):
+    """Which tests went red, given a finished run of the suite.
+
+    Kept out of Lane so that spawning a process and interpreting doctest's
+    output stay separable - the second is the part that changes when a mutant
+    dies in a way doctest has no vocabulary for.
+    """
+    if proc.returncode == 0:
+        return []
+
+    # doctest prints a `TEST CASE:` banner for anything that produces output, a
+    # passing MESSAGE included, so the banners alone are not failures - only one
+    # with an assertion error under it counts.
+    failing, current = [], None
+    for line in proc.stdout.splitlines():
+        banner = re.match(r"^TEST CASE:\s*(.+)$", line)
+        if banner:
+            current = banner.group(1).strip()
+        elif ("ERROR" in line or "FAILED" in line) and current:
+            if current not in failing:
+                failing.append(current)
+    if failing:
+        return failing
+
+    # Nonzero exit with no failed assertion: a sanitizer abort, a crash or a
+    # signal. Naming it beats reporting "unknown" - under -Db_sanitize the thing
+    # that noticed is often not a test at all, and which runtime complained is
+    # the whole answer.
+    for stream in (proc.stderr, proc.stdout):
+        for pattern in (r"^SUMMARY: (\w+Sanitizer): (.+)$", r"runtime error: (.+)$"):
+            m = re.search(pattern, stream, re.M)
+            if m:
+                return [" ".join(m.groups())[:120]]
+    return ["exit %d, no assertion failed" % proc.returncode]
+
+
+def short_test_name(name, limit=52):
+    """A doctest case name, shortened for a terminal.
+
+    Most of the suite is `TEST_CASE_TEMPLATE`, so a name arrives as
+    `a_hash_survives_rehashing<ankerl::unordered_dense::v4_9_1::detail::table<
+    std::__cxx11::basic_string<char>, int, ...>>` - 300 characters of which the
+    first 25 are the part that says what broke. The instantiation is kept as a
+    marker rather than dropped, because which one of a template's instantiations
+    failed is occasionally the answer, and the full names stay in --json.
+    """
+    depth, out = 0, []
+    for ch in name:
+        if ch == "<":
+            depth += 1
+            if depth == 1:
+                out.append("<...>")
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif depth == 0:
+            out.append(ch)
+    short = "".join(out)
+    return short if len(short) <= limit else short[:limit - 3] + "..."
+
+
+def render_caught(caught_by, most=3):
+    """The tests that noticed, as much of them as is worth printing."""
+    if not caught_by:
+        return ""
+    shown = ", ".join(short_test_name(t) for t in caught_by[:most])
+    extra = len(caught_by) - most
+    return shown + (" (+%d more)" % extra if extra > 0 else "")
+
+
+class Lane:
+    """One throwaway copy of the repo, configured once and reused per mutant."""
+
+    def __init__(self, root, index, args):
+        self.dir = os.path.join(root, "lane%d" % index)
+        self.build = os.path.join(self.dir, "builddir")
+        self.target = os.path.join(self.dir, args.file)
+        self.jobs = args.jobs
+        self.memory = args.memory_limit
+        self.setup_args = meson_setup_args(args)
+        self.test_args = []
+        if args.test_suite:
+            self.test_args.append("-ts=" + args.test_suite)
+        if args.exclude_suite:
+            self.test_args.append("-tse=" + args.exclude_suite)
+        if args.test_filter:
+            self.test_args.append("-tc=" + args.test_filter)
+        self.syntax_cmd = None
+        self.syntax_file = args.syntax_tu
+
+        self.env = dict(os.environ)
+        # The corpus replay walks up from the working directory looking for
+        # `.fuzz-corpus-base-dir`, which would find the lane's copy anyway. Said
+        # outright because it is the one input the suite reads from outside the
+        # binary, and a lane silently replaying nothing would show up as a wall
+        # of survivors in exactly the code the fuzzers cover best.
+        self.env["FUZZ_CORPUS_BASE_DIR"] = os.path.join(self.dir, "data", "fuzz")
+        # ccache keys on the compiler command line, and every lane's -I is a
+        # different absolute path - base_dir rewrites absolute paths beneath it
+        # to relative ones so that every lane hashes the same as the developer's
+        # own build. Read-only on purpose: the baseline build is then nearly
+        # free, while the mutants - each a preprocessed source nothing will ever
+        # see again - do not get to evict a real cache with ~90 objects apiece.
+        self.env["CCACHE_BASEDIR"] = os.path.abspath(self.dir)
+        self.env["CCACHE_READONLY"] = "1"
+        # Set unconditionally, exactly as the CI legs do: only a sanitizer
+        # runtime reads these, so on an ordinary build they do nothing. Without
+        # halt_on_error UBSan prints the error and the binary still exits 0 -
+        # and a mutant that only UBSan can see is then reported as a survivor,
+        # which is the one way this tool must never be wrong.
+        self.env.setdefault("ASAN_OPTIONS", "detect_stack_use_after_return=1")
+        self.env.setdefault("UBSAN_OPTIONS",
+                            "print_stacktrace=1:halt_on_error=1")
+
+    def setup(self):
+        if os.path.isdir(self.dir):
+            sync_tree(REPO, self.dir)
+            # The mutated file is the one thing whose *content* can be right
+            # while the build behind it is wrong: a run that ended with a mutant
+            # applied, and was then restored, leaves a binary built from the
+            # mutant and a source that matches the repo again. Nothing in a
+            # content comparison can see that, so the file that every mutant
+            # rewrites is stamped unconditionally. It costs the one rebuild that
+            # was going to happen anyway.
+            os.utime(self.target, None)
+        else:
+            shutil.copytree(REPO, self.dir, ignore=lane_ignore)
+        # Always, even when reusing: it is a second, and it is what picks up a
+        # new test file added to test/meson.build. The sources are listed there
+        # by hand, so skipping this would build the previous run's set and score
+        # mutants against tests that are not in it.
+        configured = os.path.exists(os.path.join(self.build, "build.ninja"))
+        cmd = (["meson", "setup"] + self.setup_args
+               + (["--reconfigure"] if configured else [])
+               + [self.build, self.dir])
+        r = subprocess.run(cmd, cwd=self.dir, capture_output=True, text=True,
+                           env=self.env)
+        if r.returncode != 0:
+            raise RuntimeError("meson setup failed in lane:\n" + r.stdout + r.stderr)
+        self.syntax_cmd = self._syntax_command()
+
+    def _syntax_command(self):
+        """The compile line meson would use for one TU, turned into a syntax check.
+
+        Taken from compile_commands.json rather than reassembled by hand: the
+        flags that matter here are the ones the real build uses, -Werror very
+        much included, and a hand-written approximation of them drifts the day
+        someone adds a warning to meson.build.
+        """
+        if not self.syntax_file:
+            return None
+        path = os.path.join(self.build, "compile_commands.json")
+        with open(path, encoding="utf-8") as f:
+            entries = json.load(f)
+        wanted = os.path.normpath(os.path.join(self.dir, self.syntax_file))
+        for entry in entries:
+            resolved = os.path.normpath(
+                os.path.join(entry["directory"], entry["file"]))
+            if resolved != wanted:
+                continue
+            argv, out, i = shlex.split(entry["command"]), [], 0
+            while i < len(argv):
+                arg = argv[i]
+                # -MF/-MQ name ninja's depfile for this object: writing it from
+                # here would leave the real build's dependency information
+                # describing a compile that never produced an object.
+                if arg in ("-o", "-MF", "-MQ", "-MT"):
+                    i += 2
+                    continue
+                if arg not in ("-c", "-MD", "-MMD"):
+                    out.append(arg)
+                i += 1
+            # ccache refuses -fsyntax-only outright, and there is nothing to
+            # cache in a compile that produces no object anyway.
+            if out and os.path.basename(out[0]) == "ccache":
+                out = out[1:]
+            out.insert(1, "-fsyntax-only")
+            return dict(argv=out, cwd=entry["directory"])
+        return None
+
+    def write_target(self, text):
+        with open(self.target, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    def run_syntax_check(self, timeout):
+        """Cheap reject. Plenty of operator mutants are simply not valid C++, and
+        this answers that in half a second instead of ~90 translation units."""
+        return self._run(self.syntax_cmd["argv"], cwd=self.syntax_cmd["cwd"],
+                         timeout=timeout, env=self.env)
+
+    def run_build(self, timeout, jobs=None):
+        # jobs is overridden for the baseline, which is the one build that has
+        # the machine to itself - and the cap follows it, so that build is not
+        # measured against a share of the machine it is not sharing.
+        jobs = jobs or self.jobs
+        return self._run(["ninja", "-C", self.build, "-j", str(jobs)],
+                         timeout=timeout, env=self.env,
+                         memory=build_memory_limit(self.memory, jobs))
+
+    def run_tests(self, timeout):
+        cmd = [os.path.join(self.build, TEST_BINARY)] + self.test_args
+        return self._run(cmd, cwd=self.dir, timeout=timeout, env=self.env)
+
+    def _run(self, cmd, timeout, cwd=None, env=None, memory=None):
+        # errors="replace" because a mutant's whole job is to make the library
+        # misbehave, and a mutated size or hash prints whatever bytes it likes.
+        # Strict decoding would turn one such byte into a traceback that kills
+        # the pool and loses the whole sweep.
+        capped = memory_capped(cmd, self.memory if memory is None else memory)
+        try:
+            return subprocess.run(capped, cwd=cwd or self.dir, capture_output=True,
+                                  text=True, errors="replace", timeout=timeout,
+                                  env=env)
+        except subprocess.TimeoutExpired:
+            return None
+        except FileNotFoundError as e:
+            raise RuntimeError("missing tool: %s" % e)
+
+
+def evaluate(lane, mutant, args):
+    """Run one mutant. Returns (verdict, tests that caught it).
+
+    The order the checks come in is the order they get cheaper to be wrong
+    about: a mutant killed at the memory cap is asked about before the exit
+    status is read, because a stopped build looks like a build that failed and
+    "the compiler refused it" is the one thing it definitely does not mean.
+    """
+    lane.write_target(mutant["text"])
+    if args.quick_reject and lane.syntax_cmd:
+        proc = lane.run_syntax_check(args.build_timeout)
+        if killed_for_memory(proc):
+            return "oom", []
+        if proc is None or proc.returncode != 0:
+            return "compiler", []
+    proc = lane.run_build(args.build_timeout)
+    if killed_for_memory(proc):
+        return "oom", []
+    if proc is None or proc.returncode != 0:
+        return "compiler", []
+    proc = lane.run_tests(args.test_timeout)
+    if proc is None:
+        return "hang", []
+    if killed_for_memory(proc):
+        return "oom", []
+    failing = parse_test_output(proc)
+    return ("caught", failing) if failing else ("survived", [])
+
+
+# ------------------------------------------------------------- mutants
+
+def parse_bug_file(path):
+    """Bugs to reintroduce, one block each:
+
+        # name of the bug
+        <<<
+        the code as it is today
+        ===
+        the code with the bug back
+        >>>
+
+    A block format rather than a diff so that multi-line bodies need no escaping
+    and no leading-character rules - these are C++ fragments, and `-` is an
+    operator.
+
+    The name is the *first* line of a run of comments, so the ones after it are
+    room to explain the bug without any of it ending up in the report. A blank
+    line starts a new run, which is what lets a file open with a header of its
+    own.
+    """
+    bugs, name, state, old, new = [], None, None, [], []
+    with open(path, encoding="utf-8") as f:
+        for lineno, raw in enumerate(f, 1):
+            line = raw.rstrip("\n")
+            stripped = line.strip()
+            if state is None:
+                if not stripped:
+                    name = None
+                elif stripped.startswith("#"):
+                    if name is None:
+                        name = stripped.lstrip("#").strip()
+                elif stripped == "<<<":
+                    state, old, new = "old", [], []
+                else:
+                    raise RuntimeError("%s:%d: expected '#' or '<<<'" % (path, lineno))
+            elif stripped == "===" and state == "old":
+                state = "new"
+            elif stripped == ">>>" and state == "new":
+                bugs.append(dict(name=name or "bug %d" % (len(bugs) + 1),
+                                 old="\n".join(old), new="\n".join(new)))
+                name, state = None, None
+            elif state == "old":
+                old.append(line)
+            else:
+                new.append(line)
+    if state is not None:
+        raise RuntimeError("%s: unterminated block, missing '>>>'" % path)
+    return bugs
+
+
+def bug_mutants(bugs, original):
+    """Substitutions to mutated sources, refusing any that does not apply.
+
+    A typo in the `old` text would otherwise substitute nothing, the suite would
+    stay green, and the report would say the bug survived - a false alarm about
+    the tests when the fault is in the bug list.
+    """
+    problems = []
+    for bug in bugs:
+        count = original.count(bug["old"])
+        if count != 1:
+            problems.append("  %-40s matches %d times, needs exactly 1"
+                            % (bug["name"], count))
+        elif bug["old"] == bug["new"]:
+            problems.append("  %-40s is a no-op" % bug["name"])
+    if problems:
+        raise RuntimeError("these bugs do not apply:\n" + "\n".join(problems))
+    return [dict(name=bug["name"], text=original.replace(bug["old"], bug["new"]))
+            for bug in bugs]
+
+
+def site_mutants(sites, original):
+    return [dict(name=site["description"], line=site["line"],
+                 offset=site["offset"], description=site["description"],
+                 text=(original[:site["offset"]] + site["replacement"]
+                       + original[site["offset"] + len(site["original"]):]))
+            for site in sites]
+
+
+def reverse_commit_mutant(ref, original, target):
+    """One bug, expressed as 'undo what this commit did to the file'.
+
+    Applied to a scratch copy rather than a lane, so that every mode has produced
+    its mutants before any lane exists - otherwise --dry-run has nothing to show
+    and the lane count cannot be sized from the number of bugs.
+    """
+    # --format= drops the commit header, which `git show` prints even when the
+    # path it was given is untouched - leaving output that is not empty but
+    # holds no patch, so the failure surfaces from `git apply` instead of here.
+    diff = subprocess.run(["git", "show", "--format=", ref, "--", target],
+                          cwd=REPO, capture_output=True, text=True,
+                          check=True).stdout
+    if "diff --git" not in diff:
+        raise RuntimeError("%s does not touch %s" % (ref, target))
+    with tempfile.TemporaryDirectory(prefix="udm-reverse-") as scratch:
+        staged = os.path.join(scratch, target)
+        os.makedirs(os.path.dirname(staged), exist_ok=True)
+        with open(staged, "w", encoding="utf-8") as f:
+            f.write(original)
+        r = subprocess.run(["git", "apply", "-R", "--unsafe-paths",
+                            "--directory", ".", "-p1", "-"],
+                           cwd=scratch, input=diff, capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError("could not reverse %s:\n%s" % (ref, r.stderr))
+        with open(staged, encoding="utf-8") as f:
+            text = f.read()
+    if text == original:
+        raise RuntimeError("reversing %s changes nothing" % ref)
+    return dict(name="reverse of %s" % ref, text=text)
+
+
+# ------------------------------------------------------------- the run
+
+def meson_setup_args(args):
+    """What every lane is configured with.
+
+    `-Ddebug=false` is not about debugging: meson's `debug` buildtype means -O0
+    *and* -g, and the debug info is a third of the compile time and two thirds of
+    the 60 MB each lane's build directory would otherwise be - times however many
+    lanes. Nothing here reads a symbol. Skipped if --meson-arg says otherwise, so
+    it stays overridable rather than baked in.
+    """
+    extra = ["--buildtype", args.buildtype]
+    if not any(a.startswith("-Ddebug=") for a in args.meson_arg):
+        extra.append("-Ddebug=false")
+    return extra + list(args.meson_arg)
+
+
+def plan(args, wanted):
+    """Lanes, jobs each, and memory each - settled before anything is copied.
+
+    Together these are most of what a verdict depends on, so they are decided in
+    one place and stated in the fingerprint rather than emerging from whichever
+    function needed them first.
+    """
+    args.lanes = max(1, min(args.lanes, wanted))
+    # One job per lane once the lanes fill the machine, but all of it for a
+    # single named bug - which is the difference between a --replace answering
+    # in 20 seconds and in three minutes, given that every mutant rebuilds every
+    # translation unit.
+    if args.jobs is None:
+        args.jobs = max(1, (os.cpu_count() or 4) // args.lanes)
+    if args.memory_limit is None:
+        args.memory_limit = default_memory_limit(args.lanes, args.jobs)
+    args.memory_note = memory_cap_reason(args.memory_limit) if args.memory_limit else ""
+    if args.memory_note:
+        args.memory_limit = 0
+
+
+def fingerprint(args):
+    """What this run could actually observe.
+
+    A verdict is only meaningful for the build that produced it, and the way that
+    goes wrong quietly is memory safety: an off-by-one in a bucket index or a
+    dangling reference after a rehash is invisible to a plain build unless it
+    happens to corrupt something a test then checks. Without a sanitizer those
+    come back `survived` however good the tests are.
+    """
+    compiler = os.environ.get("CXX")
+    if compiler is None:
+        try:
+            compiler = subprocess.run(["c++", "--version"], capture_output=True,
+                                      text=True).stdout.splitlines()[0]
+        except (OSError, IndexError):
+            compiler = "unknown"
+    setup_args = meson_setup_args(args)
+    sanitizer = next((a.split("=", 1)[1] for a in setup_args
+                      if a.startswith("-Db_sanitize=")), "none")
+    tests = " ".join(filter(None, [args.test_suite and "-ts=" + args.test_suite,
+                                   args.exclude_suite and "-tse=" + args.exclude_suite,
+                                   args.test_filter and "-tc=" + args.test_filter]))
+    return dict(compiler=compiler, sanitizer=sanitizer, cores=os.cpu_count(),
+                meson=setup_args, tests=tests or "all", file=args.file,
+                ccache=shutil.which("ccache") is not None,
+                lanes=args.lanes, jobs=args.jobs, memory=args.memory_limit,
+                memory_note=args.memory_note)
+
+
+def render_fingerprint(facts):
+    lines = ["compiler        %s" % facts["compiler"],
+             "cores           %s" % (facts["cores"] or "?"),
+             "lanes           %d, %d job%s each"
+             % (facts["lanes"], facts["jobs"], "" if facts["jobs"] == 1 else "s"),
+             "memory          %s per lane" % human(facts["memory"]),
+             "meson setup     %s" % " ".join(facts["meson"]),
+             "sanitizer       %s" % facts["sanitizer"],
+             "mutating        %s" % facts["file"],
+             "tests           %s" % facts["tests"]]
+    if not facts["memory"]:
+        lines += ["",
+                  "NOTE: nothing caps what a mutant may allocate in this run%s."
+                  % (": " + facts["memory_note"] if facts["memory_note"] else ""),
+                  "      A mutated growth policy can ask for more memory than",
+                  "      the machine has, and the kernel then picks the victim -",
+                  "      as likely another lane as the mutant that caused it, so",
+                  "      the verdicts around it are no longer trustworthy."]
+    if facts["sanitizer"] == "none":
+        lines += ["",
+                  "NOTE: no sanitizer in this build, so a mutant that reads one",
+                  "      slot too far or keeps a reference across a rehash is",
+                  "      only seen if it happens to corrupt something a test",
+                  "      checks. Re-run a survivor you cannot explain with",
+                  "      --meson-arg=-Db_sanitize=address,undefined before",
+                  "      concluding the hole is in the tests."]
+    if not facts["ccache"]:
+        lines += ["",
+                  "NOTE: no ccache on PATH. Only the baseline build would have",
+                  "      hit it - every mutant is a compile nothing has seen -",
+                  "      so this costs one full build, not a slower run."]
+    return "\n".join(lines)
+
+
+def baseline(lane, args, log):
+    """Refuse to score anything until the suite is green repeatedly.
+
+    A flaky test scored as a kill inflates the number in the flattering
+    direction, which is the worst way for this tool to be wrong.
+
+    Returns how long a green run takes, which is what the per-mutant timeouts
+    are derived from - a fixed generous timeout makes every hung mutant cost
+    many times what a real one does, and hangs are an expected verdict here.
+    """
+    log("baseline: building")
+    proc = lane.run_build(args.build_timeout, jobs=os.cpu_count() or 4)
+    if killed_for_memory(proc):
+        raise RuntimeError(
+            "the baseline build was killed at the memory cap, and that is this "
+            "tree's own build rather than any mutant - raise --memory-limit, or "
+            "pass 0 to turn the cap off.")
+    if proc is None or proc.returncode != 0:
+        raise RuntimeError("baseline build failed - fix the tree first")
+    slowest = 0.0
+    for attempt in range(args.baseline_runs):
+        started = time.time()
+        proc = lane.run_tests(args.test_timeout)
+        slowest = max(slowest, time.time() - started)
+        if proc is None:
+            raise RuntimeError("baseline run %d timed out" % (attempt + 1))
+        # The unmutated suite peaks at a few tens of megabytes, so this says the
+        # cap is set below what an honest run needs - and every mutant under it
+        # would come back `oom` no matter what the tests do.
+        if killed_for_memory(proc):
+            raise RuntimeError(
+                "baseline run %d was killed at the memory cap (%s). That is the "
+                "suite the mutants are measured against, so the cap is too low "
+                "to tell anything apart - raise --memory-limit."
+                % (attempt + 1, human(lane.memory)))
+        failing, ran = parse_test_output(proc), count_test_cases(proc.stdout)
+        if failing:
+            raise RuntimeError(
+                "baseline run %d failed (%s). The suite must be green and "
+                "deterministic before mutants mean anything."
+                % (attempt + 1, ", ".join(short_test_name(t) for t in failing)))
+        # A filter that matches nothing is green, and every mutant under it
+        # survives. Refusing here is the difference between "your filter names
+        # no doctest suite" and a report claiming the suite covers nothing.
+        if ran == 0:
+            raise RuntimeError(
+                "baseline run %d passed 0 test cases (%s). doctest's suites are "
+                "the ones TEST_SUITE names - 'fuzz' and 'stochastic' - not "
+                "meson's, which calls the whole binary 'unit'."
+                % (attempt + 1, " ".join(lane.test_args) or "no filter"))
+        log("baseline: run %d/%d green, %s case%s"
+            % (attempt + 1, args.baseline_runs, "?" if ran is None else ran,
+               "" if ran == 1 else "s"))
+    return slowest
+
+
+def check_room_for(workdir, new_lanes, log):
+    """Refuse before copying rather than half way through it.
+
+    A lane is a copy of the tree and a build directory of its own, and the count
+    comes off the core count without anyone having been asked. Running out part
+    way leaves a meson setup failing for a reason that does not mention disk -
+    and where the workdir is a tmpfs, which is where /tmp usually is, running
+    out means the machine running out of memory rather than of disk.
+    """
+    needed = new_lanes * LANE_BYTES
+    if not needed:
+        return
+    free = shutil.disk_usage(workdir).free
+    in_ram = memory_backed(workdir)
+    log("%d new lane%s of about %s in %s, %s free%s"
+        % (new_lanes, "" if new_lanes == 1 else "s", human(needed), workdir,
+           human(free), " - and it is a tmpfs, so that is memory" if in_ram else ""))
+    if needed > free:
+        raise RuntimeError(
+            "%s has %s free and %d lane%s want about %s%s. Use fewer --lanes, or "
+            "--workdir somewhere with room."
+            % (workdir, human(free), new_lanes, "" if new_lanes == 1 else "s",
+               human(needed),
+               " - and it is a tmpfs, so that room is memory" if in_ram else ""))
+
+
+@contextlib.contextmanager
+def lanes_for(args, wanted, log):
+    """Copied trees, configured and baselined, cleaned up whatever happens."""
+    if args.reuse:
+        workdir = args.workdir or os.path.join(tempfile.gettempdir(),
+                                               "udm-mutate-reuse")
+        os.makedirs(workdir, exist_ok=True)
+    else:
+        workdir = args.workdir or tempfile.mkdtemp(prefix="udm-mutate-")
+        if args.workdir:
+            shutil.rmtree(workdir, ignore_errors=True)
+            os.makedirs(workdir)
+    try:
+        count = args.lanes  # settled by plan(), along with jobs and memory
+        lanes = [Lane(workdir, i, args) for i in range(count)]
+        existing = sum(1 for lane in lanes if os.path.isdir(lane.build))
+        log("preparing %d lane%s%s, %d job%s each"
+            % (count, "" if count == 1 else "s",
+               " (%d reused)" % existing if existing else "",
+               args.jobs, "" if args.jobs == 1 else "s"))
+        check_room_for(workdir, count - existing, log)
+        started = time.time()
+        with concurrent.futures.ThreadPoolExecutor(count) as pool:
+            list(pool.map(lambda lane: lane.setup(), lanes))
+        log("lanes ready in %.1fs" % (time.time() - started))
+        started = time.time()
+        green_seconds = baseline(lanes[0], args, log)
+        log("baseline in %.1fs" % (time.time() - started))
+        if args.test_timeout is None:
+            args.test_timeout = max(20, int(6 * green_seconds))
+            log("test timeout %ds, from a %.1fs green run"
+                % (args.test_timeout, green_seconds))
+        yield lanes
+    finally:
+        if not args.reuse:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def run_mutants(lanes, mutants, args, log):
+    """Every mutant through a lane, reported in the order they were produced."""
+    pending, results, lock = queue.Queue(), [], threading.Lock()
+    for index, mutant in enumerate(mutants):
+        pending.put((index, mutant))
+
+    def worker(lane):
+        while True:
+            try:
+                index, mutant = pending.get_nowait()
+            except queue.Empty:
+                return
+            # One mutant that blows up must not take the sweep with it: at
+            # several seconds each these runs are an hour long, and losing the
+            # other verdicts to salvage nothing is the worst possible trade. An
+            # 'error' of its own rather than a silent 'survived' - a swallowed
+            # exception would flatter the tests, which is the one direction this
+            # tool must never be wrong in.
+            try:
+                verdict, caught_by = evaluate(lane, mutant, args)
+            except Exception as e:  # noqa: BLE001 - deliberately total
+                verdict, caught_by = "error", ["%s: %s" % (type(e).__name__, e)]
+            with lock:
+                results.append(dict(mutant, index=index, verdict=verdict,
+                                    caught_by=caught_by))
+                log("[%d/%d] %-46s %s%s"
+                    % (len(results), len(mutants), mutant["name"][:46], verdict,
+                       " (%s)" % render_caught(caught_by) if caught_by else ""))
+
+    with concurrent.futures.ThreadPoolExecutor(len(lanes)) as pool:
+        list(pool.map(worker, lanes))
+
+    results.sort(key=lambda r: r["index"])
+    for r in results:
+        r.pop("text", None)  # a whole mutated header per result helps nobody
+        r.pop("index", None)
+    return results
+
+
+def report(results, args, original):
+    """One summary for both modes. Only the framing differs, not the verdicts."""
+    counts = {v: sum(1 for r in results if r["verdict"] == v) for v in VERDICTS}
+    survivors = [r for r in results if r["verdict"] == "survived"]
+
+    print("\n" + "=" * 72)
+    width = max(len(r["name"]) for r in results)
+    if len(results) <= 40:
+        for r in results:
+            print("%-*s  %-9s  %s"
+                  % (width, r["name"], r["verdict"], render_caught(r["caught_by"]) or "-"))
+        print()
+
+    tally = ["%d caught by a test" % counts["caught"],
+             "%d by the compiler only" % counts["compiler"],
+             "%d hung" % counts["hang"]]
+    # Only when it happened: on a header where nothing controls an allocation
+    # size this is always zero, and a permanent 0 reads as noise.
+    if counts["oom"]:
+        tally.append("%d killed at the memory cap" % counts["oom"])
+    tally.append("%d SURVIVED" % counts["survived"])
+    print(", ".join(tally))
+    # Errors are not scored either way. Counting them as killed would inflate
+    # the number, and as survived would invent holes that may not be there.
+    scored = len(results) - counts["error"]
+    if counts["error"]:
+        print("%d could not be scored - the tool failed, not the tests:"
+              % counts["error"])
+        for r in results:
+            if r["verdict"] == "error":
+                print("  %-46s %s" % (r["name"][:46], ", ".join(r["caught_by"])))
+    if scored > 1:
+        print("score            %.0f%% killed, %.0f%% by a test"
+              % (100.0 * (scored - counts["survived"]) / scored,
+                 100.0 * counts["caught"] / scored))
+
+    if survivors:
+        print("\nnothing noticed these - whatever covers them is decoration:")
+        source = original.splitlines()
+        for r in survivors:
+            if "line" in r:
+                text = source[r["line"] - 1].strip() if r["line"] <= len(source) else ""
+                print("  %s:%d  %s\n      %s" % (args.file, r["line"], r["name"],
+                                                 text[:100]))
+            else:
+                print("  %s" % r["name"])
+    return counts
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--replace", nargs=2, metavar=("OLD", "NEW"), action="append",
+                   help="put a specific bug back: substitute OLD with NEW (must "
+                        "match exactly once) and report which tests notice. "
+                        "Repeatable - a batch runs across lanes in parallel")
+    p.add_argument("--bugs", metavar="FILE",
+                   help="a file of bugs to reintroduce, '# name' then a "
+                        "<<< old === new >>> block each. Runs in parallel")
+    p.add_argument("--reverse", metavar="REF",
+                   help="put one bug back by reverse-applying REF's changes to "
+                        "the file, keeping today's tests")
+    p.add_argument("--diff", metavar="REF",
+                   help="only mutate lines changed since REF (the fast sweep). "
+                        "Adds to --bugs or --replace rather than replacing "
+                        "them, so one run can ask both questions")
+    p.add_argument("--lines", metavar="A-B",
+                   help="only mutate lines A..B, and the same: it adds a sweep "
+                        "to whatever bugs were named")
+    p.add_argument("--file", metavar="PATH", default=HEADER,
+                   help="repo-relative file to mutate (default the header)")
+    p.add_argument("--lanes", type=int, default=os.cpu_count() or 4,
+                   help="parallel build+test lanes (default: one per hardware "
+                        "thread, %d here). Each is a copy of the repo plus its "
+                        "own build directory, so it is disk as well as cores"
+                        % (os.cpu_count() or 4))
+    p.add_argument("--jobs", type=int, default=None,
+                   help="ninja parallelism inside one lane (default: the cores "
+                        "divided by the lanes actually used, so a single bug "
+                        "gets the whole machine and a sweep gets one job each)")
+    p.add_argument("--buildtype", default="debug",
+                   help="meson buildtype for every lane (default debug, which "
+                        "is -O0: a mutant costs one rebuild of every TU, and at "
+                        "-O3 that is twice the compiling to answer the same "
+                        "question. Use release when the question is about what "
+                        "the optimizer does)")
+    p.add_argument("--memory-limit", type=parse_size, default=None, metavar="SIZE",
+                   help="how much memory one lane may use, as 4G, 512M or a "
+                        "plain byte count (default: the smaller of the lane's "
+                        "share of the machine and 1G per ninja job). A mutated "
+                        "growth policy turns an insert into a request for more "
+                        "memory than the machine has; capped, that mutant dies "
+                        "alone and is reported as 'oom', uncapped the kernel "
+                        "picks a victim and it is as likely to be another lane. "
+                        "0 turns the cap off")
+    p.add_argument("--limit", type=int, help="stop after N mutants")
+    p.add_argument("--shuffle-seed", type=int, default=0,
+                   help="sample mutants deterministically when using --limit")
+    p.add_argument("--build-timeout", type=int, default=900)
+    p.add_argument("--test-timeout", type=int, default=None,
+                   help="seconds before a mutant counts as hung (default: six "
+                        "times the measured green run)")
+    p.add_argument("--baseline-runs", type=int, default=2)
+    p.add_argument("--no-quick-reject", dest="quick_reject",
+                   action="store_false", default=True,
+                   help="skip the -fsyntax-only pre-filter")
+    p.add_argument("--meson-arg", metavar="ARG", action="append", default=[],
+                   help="extra `meson setup` argument for every lane, "
+                        "repeatable. This is how you ask a different question: "
+                        "whether some other leg catches the bug, which the "
+                        "default build cannot answer. Needs the '=' form, "
+                        "because the value starts with a dash: "
+                        "--meson-arg=-Db_sanitize=address,undefined "
+                        "--meson-arg=-Dcpp_std=c++20")
+    p.add_argument("--test-suite", metavar="NAME",
+                   help="run only this doctest suite. These are the ones a "
+                        "TEST_SUITE names - 'fuzz' and 'stochastic' - and not "
+                        "meson's suites, so there is no 'unit' to ask for; the "
+                        "bulk of the cases are in no suite at all")
+    p.add_argument("--exclude-suite", metavar="NAME",
+                   help="skip a doctest suite. 'fuzz' is the one worth "
+                        "skipping when a run is long: replaying the corpora is "
+                        "six sevenths of the suite's runtime, though it is also "
+                        "some of its best coverage of the map internals - so "
+                        "confirm a survivor without it before believing it")
+    p.add_argument("--test-filter", metavar="PATTERN",
+                   help="run only matching doctest cases")
+    p.add_argument("--syntax-tu", metavar="PATH", default=None,
+                   help="repo-relative TU the -fsyntax-only pre-filter compiles "
+                        "(default: the file being mutated if it is itself a TU, "
+                        "otherwise %s)" % SYNTAX_TU)
+    p.add_argument("--dry-run", action="store_true",
+                   help="list the mutants and the likely runtime, then stop")
+    p.add_argument("--workdir", default=None, help="where lanes are copied")
+    p.add_argument("--reuse", action="store_true",
+                   help="keep the lanes afterwards and reuse them next time, "
+                        "syncing only what changed. Saves the copying and the "
+                        "configuring, not the compiling - every mutant rebuilds "
+                        "every TU either way. Uses a fixed workdir unless "
+                        "--workdir says otherwise, so two concurrent runs need "
+                        "different ones")
+    p.add_argument("--json", metavar="FILE", help="write the full result set")
+    args = p.parse_args()
+
+    modes = [bool(args.replace), bool(args.bugs), bool(args.reverse)]
+    if sum(modes) > 1:
+        p.error("--replace, --bugs and --reverse are three ways to say the same "
+                "thing; pick one")
+
+    target_path = os.path.join(REPO, args.file)
+    if not os.path.exists(target_path):
+        p.error("no such file: %s" % args.file)
+    with open(target_path, encoding="utf-8") as f:
+        original = f.read()
+
+    # The pre-filter compiles one TU. Mutating a header it includes is the case
+    # it was built for; mutating a TU means checking that TU itself; and against
+    # anything else it would compile something the mutation cannot reach, pass
+    # every time, and quietly stop filtering.
+    if args.syntax_tu is None:
+        if args.file == HEADER:
+            args.syntax_tu = SYNTAX_TU
+        elif args.file.endswith(".cpp"):
+            args.syntax_tu = args.file
+        else:
+            args.quick_reject = False
+    if not args.quick_reject:
+        args.syntax_tu = None
+
+    # The two kinds compose, and asking for both in one run is worth doing: they
+    # answer different questions over the same code, and everything a second
+    # invocation would repeat - copying the lanes, building the baseline, running
+    # the suite green twice - is paid once instead. The named bugs come first in
+    # the report, which is the order they are read in.
+    mutants = []
+    if args.bugs:
+        mutants = bug_mutants(parse_bug_file(args.bugs), original)
+    elif args.replace:
+        mutants = bug_mutants(
+            [dict(name="%s -> %s" % (old.strip()[:34], new.strip()[:34]),
+                  old=old, new=new) for old, new in args.replace], original)
+    elif args.reverse:
+        mutants = [reverse_commit_mutant(args.reverse, original, args.file)]
+
+    # A sweep is asked for by --diff or --lines, and with nothing named at all it
+    # is the whole file - which is what this does when given no arguments.
+    if args.diff or args.lines or not mutants:
+        line_filter = None
+        if args.diff:
+            line_filter = changed_lines(args.diff, args.file)
+        elif args.lines:
+            a, _, b = args.lines.partition("-")
+            line_filter = set(range(int(a), int(b or a) + 1))
+        if args.diff and not line_filter:
+            # Nothing to sweep. Only an error when it was the whole request:
+            # alongside a bug file it is a note, not a reason to run nothing.
+            print("no changed lines in %s since %s" % (args.file, args.diff))
+            if not mutants:
+                return 0
+        else:
+            sweep = site_mutants(
+                mutation_sites(original, code_mask(original), line_filter), original)
+            if args.limit and len(sweep) > args.limit:
+                random.Random(args.shuffle_seed).shuffle(sweep)
+                sweep = sweep[:args.limit]
+                sweep.sort(key=lambda m: m["offset"])
+            mutants += sweep
+
+    if not mutants:
+        # Reached by a sweep whose lines hold no code: a comment reflow, a
+        # version bump, a `#define`. Saying which is the difference between a
+        # clear answer and someone re-running it to find out why.
+        print("nothing to mutate in %s - the lines asked for are comments, "
+              "preprocessor or whitespace" % args.file)
+        return 0
+
+    plan(args, len(mutants))
+
+    if args.dry_run:
+        for mutant in mutants:
+            print("  %s%s" % ("line %d: " % mutant["line"] if "line" in mutant
+                              else "", mutant["name"]))
+        print("\n%d mutant%s over %d lane%s, roughly %s, %s"
+              % (len(mutants), "" if len(mutants) == 1 else "s", args.lanes,
+                 "" if args.lanes == 1 else "s",
+                 estimate(len(mutants), args.lanes, os.cpu_count() or 4),
+                 "%s of memory each" % human(args.memory_limit)
+                 if args.memory_limit else "no memory cap available here"))
+        return 0
+
+    facts = fingerprint(args)
+    print(render_fingerprint(facts) + "\n")
+
+    # Before any lane exists, because it is the lanes the cores would land in.
+    drop_core_dumps()
+
+    print_lock = threading.Lock()
+
+    def log(message):
+        with print_lock:
+            print(message, flush=True)
+
+    started = time.time()
+    with lanes_for(args, len(mutants), log) as lanes:
+        log("%d mutant%s over %d lane%s"
+            % (len(mutants), "" if len(mutants) == 1 else "s",
+               len(lanes), "" if len(lanes) == 1 else "s"))
+        results = run_mutants(lanes, mutants, args, log)
+
+    counts = report(results, args, original)
+    print("\n%d mutant%s in %.0fs"
+          % (len(results), "" if len(results) == 1 else "s", time.time() - started))
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(dict(environment=facts, counts=counts, results=results),
+                      f, indent=2)
+        print("wrote %s" % args.json)
+
+    return 1 if counts["survived"] else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except RuntimeError as e:
+        # Every RuntimeError raised here is the tool refusing to answer: a bug
+        # block that does not apply, a baseline that is not green, a filter that
+        # matches no test. The message is the whole point of those, and a
+        # traceback down through the thread pool buries it. Exit 2 keeps them
+        # apart from the 1 that means survivors were found.
+        print("\n%s" % e, file=sys.stderr)
+        sys.exit(2)
+    except KeyboardInterrupt:
+        print("\ninterrupted", file=sys.stderr)
+        sys.exit(130)

--- a/scripts/test_mutate.py
+++ b/scripts/test_mutate.py
@@ -1,0 +1,910 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/mutate/mutate.py.
+
+    scripts/test_mutate.py            # run them
+    scripts/test_mutate.py -v         # ... naming each one
+
+Every test here is hermetic: no compiler, no meson, no lanes, and nothing written outside a
+temporary directory. What that leaves out is the half of the tool that is a build -- whether meson
+configures, whether ninja rebuilds what the mutant touched, whether a hang is really a hang. What
+it covers is the half that decides what a verdict *means*, and every way that half has been wrong
+so far has been silent: a bug block that substitutes nothing, a filter that matches no test, a
+sync that leaves yesterday's binary in place. None of those fail loudly. They come back "survived"
+and read as a hole in the tests.
+
+So the rule these encode is the one from the tool's own docstring -- when it is wrong, it must not
+be wrong in the direction that flatters or defames the suite.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "mutate" / "mutate.py"
+
+
+def load_script():
+    """A fresh module object, so a test that patches a global cannot leak into the next one."""
+    spec = importlib.util.spec_from_file_location("mutate_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mutate = load_script()
+
+
+def sites(src, line_filter=None):
+    """Every mutation the sweep would try on `src`, as 'old -> new' strings."""
+    return [s["description"]
+            for s in mutate.mutation_sites(src, mutate.code_mask(src), line_filter)]
+
+
+def finished(returncode, stdout="", stderr=""):
+    """A stand-in for a finished subprocess, which is all parse_test_output reads."""
+    return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestCodeMask(unittest.TestCase):
+    """What the sweep is allowed to touch. Everything here is budget: a mutant in a comment
+    costs a full rebuild of ~90 translation units to prove that a comment does not matter."""
+
+    def masked(self, src):
+        mask = mutate.code_mask(src)
+        return "".join(c if mask[i] else " " for i, c in enumerate(src))
+
+    def test_line_comment_is_not_code(self):
+        self.assertEqual(self.masked("a + b // c + d"), "a + b         ")
+
+    def test_block_comment_is_not_code(self):
+        self.assertEqual(self.masked("a /* + */ b"), "a         b")
+
+    def test_string_literal_is_not_code(self):
+        self.assertEqual(self.masked('f("a+b") + c'), 'f(     ) + c')
+
+    def test_char_literal_is_not_code(self):
+        self.assertEqual(self.masked("c == '+'"), "c ==    ")
+
+    def test_escaped_quote_does_not_end_the_string(self):
+        self.assertEqual(self.masked(r'"a\"+b" + c'), '        + c')
+
+    def test_unterminated_string_stops_at_the_newline(self):
+        # Not valid C++, but a mutant is allowed to produce it, and running away
+        # to the end of the header would blank everything after it.
+        self.assertEqual(self.masked('"oops\nx + y'), '     \nx + y')
+
+    def test_raw_string_is_not_code(self):
+        self.assertEqual(self.masked('R"x(a + b)x" + c'), '             + c')
+
+    def test_preprocessor_line_is_not_code(self):
+        # The version macros live on these lines and a lint job checks them.
+        self.assertEqual(self.masked("#define X 1\ny + 1"), "           \ny + 1")
+
+    def test_preprocessor_continuation_is_not_code(self):
+        # The whole logical line, its embedded newline included -- a `#define`
+        # is one directive however many source lines it is spread over.
+        self.assertEqual(self.masked("#define X \\\n  1 + 2\ny"), "                   \ny")
+
+    def test_a_hash_that_is_not_at_the_line_start_is_code(self):
+        self.assertEqual(self.masked("a + b # c"), "a + b # c")
+
+
+class TestMutationSites(unittest.TestCase):
+    def test_comparison_operators(self):
+        self.assertEqual(sites("a <= b"), ["<= -> <", "<= -> >=", "<= -> =="])
+
+    def test_longest_operator_wins(self):
+        # `<=` split into `<` would offer `< -> <=`, which substitutes nothing.
+        self.assertNotIn("< -> <=", sites("a <= b"))
+
+    def test_shifts_are_left_alone(self):
+        self.assertEqual(sites("a << b"), [])
+        self.assertEqual(sites("a >>= b"), [])
+
+    def test_template_brackets_are_left_alone(self):
+        # The header is clang-formatted: a comparison has spaces, a template
+        # argument list does not. Half the `<` in this file are the latter.
+        self.assertEqual(sites("static_cast<size_t>(x)"), [])
+        self.assertEqual(sites("std::conditional<a, b, c>::type"), [])
+
+    def test_arrow_and_scope_are_left_alone(self):
+        self.assertEqual(sites("a->b"), [])
+        self.assertEqual(sites("a::b"), [])
+
+    def test_integers_move_by_one_in_both_directions(self):
+        self.assertEqual(sites("x = 7"), ["7 -> 8", "7 -> 6"])
+
+    def test_a_suffix_is_kept(self):
+        self.assertEqual(sites("x = 8U"), ["8U -> 9U", "8U -> 7U"])
+
+    def test_zero_does_not_go_negative(self):
+        self.assertEqual(sites("x = 0"), ["0 -> 1"])
+
+    def test_a_float_is_not_picked_apart(self):
+        self.assertEqual(sites("x = 0.8"), [])
+        self.assertEqual(sites("x = 1e9"), [])
+
+    def test_a_number_with_no_neighbour_is_still_a_number(self):
+        # The float guard asks what is on either side of the digits, and at the
+        # start or the end of the file there is nothing there. `"" in ".0123"`
+        # is True, so an empty neighbour reads as "part of a float" and drops
+        # the mutation -- silently, which is the way this tool must not be wrong.
+        self.assertEqual(sites("7"), ["7 -> 8", "7 -> 6"])
+        self.assertEqual(sites("x + 7"), ["+ -> -", "7 -> 8", "7 -> 6"])
+
+    def test_booleans_flip(self):
+        self.assertEqual(sites("x = true"), ["true -> false"])
+
+    def test_an_identifier_holding_a_keyword_is_not_a_keyword(self):
+        self.assertEqual(sites("truexyz"), [])
+
+    def test_line_filter_keeps_only_the_lines_asked_for(self):
+        src = "a + b\nc + d\ne + f\n"
+        self.assertEqual(sites(src, line_filter={2}), ["+ -> -"])
+
+    def test_a_site_carries_the_line_it_is_on(self):
+        found = mutate.mutation_sites("a\nb\nc + d", mutate.code_mask("a\nb\nc + d"))
+        self.assertEqual([s["line"] for s in found], [3])
+
+
+class TestSiteMutants(unittest.TestCase):
+    def test_the_replacement_lands_where_the_site_says(self):
+        src = "x = a + b;"
+        mutants = mutate.site_mutants(
+            mutate.mutation_sites(src, mutate.code_mask(src)), src)
+        self.assertEqual([m["text"] for m in mutants], ["x = a - b;"])
+
+    def test_a_multi_character_operator_is_replaced_whole(self):
+        src = "if (a <= b) {}"
+        texts = [m["text"] for m in mutate.site_mutants(
+            mutate.mutation_sites(src, mutate.code_mask(src)), src)]
+        self.assertEqual(texts, ["if (a < b) {}", "if (a >= b) {}", "if (a == b) {}"])
+
+
+class TestBugFiles(unittest.TestCase):
+    def parse(self, text):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bugs.txt"
+            path.write_text(text)
+            return mutate.parse_bug_file(str(path))
+
+    def test_a_block_becomes_a_bug(self):
+        bugs = self.parse("# the name\n<<<\nold line\n===\nnew line\n>>>\n")
+        self.assertEqual(bugs, [dict(name="the name", old="old line", new="new line")])
+
+    def test_the_name_is_the_first_comment_line_of_a_run(self):
+        # The lines after it are room to explain the bug without any of it
+        # reaching the report.
+        bugs = self.parse("# the name\n# why it matters\n<<<\na\n===\nb\n>>>\n")
+        self.assertEqual(bugs[0]["name"], "the name")
+
+    def test_a_blank_line_starts_a_new_run_of_comments(self):
+        # Which is what lets a file open with a header of its own.
+        bugs = self.parse("# file header\n\n# the name\n<<<\na\n===\nb\n>>>\n")
+        self.assertEqual(bugs[0]["name"], "the name")
+
+    def test_multi_line_bodies_need_no_escaping(self):
+        bugs = self.parse("# n\n<<<\nline 1\nline 2\n===\nline 3\n>>>\n")
+        self.assertEqual(bugs[0]["old"], "line 1\nline 2")
+
+    def test_an_empty_side_is_a_deletion(self):
+        bugs = self.parse("# n\n<<<\ngone\n===\n>>>\n")
+        self.assertEqual(bugs[0]["new"], "")
+
+    def test_an_unnamed_block_still_gets_a_name(self):
+        self.assertEqual(self.parse("<<<\na\n===\nb\n>>>\n")[0]["name"], "bug 1")
+
+    def test_an_unterminated_block_is_an_error(self):
+        with self.assertRaises(RuntimeError):
+            self.parse("# n\n<<<\na\n===\nb\n")
+
+    def test_stray_text_outside_a_block_is_an_error(self):
+        with self.assertRaises(RuntimeError):
+            self.parse("this is not a comment\n<<<\na\n===\nb\n>>>\n")
+
+
+class TestBugMutants(unittest.TestCase):
+    """The guard that keeps this tool from blaming the tests for its own typo.
+
+    A block whose `old` text does not appear substitutes nothing; the suite then stays green and
+    the report says the bug survived. Every one of these is that failure mode."""
+
+    def test_a_bug_that_applies_produces_the_mutated_source(self):
+        got = mutate.bug_mutants([dict(name="n", old="a + b", new="a - b")], "x = a + b;")
+        self.assertEqual(got[0]["text"], "x = a - b;")
+
+    def test_a_bug_that_does_not_apply_is_refused(self):
+        with self.assertRaises(RuntimeError) as e:
+            mutate.bug_mutants([dict(name="n", old="nowhere", new="x")], "x = a + b;")
+        self.assertIn("matches 0 times", str(e.exception))
+
+    def test_an_ambiguous_bug_is_refused(self):
+        with self.assertRaises(RuntimeError) as e:
+            mutate.bug_mutants([dict(name="n", old="a", new="b")], "a + a")
+        self.assertIn("matches 2 times", str(e.exception))
+
+    def test_a_no_op_bug_is_refused(self):
+        with self.assertRaises(RuntimeError) as e:
+            mutate.bug_mutants([dict(name="n", old="a", new="a")], "a")
+        self.assertIn("no-op", str(e.exception))
+
+    def test_every_problem_is_reported_at_once(self):
+        with self.assertRaises(RuntimeError) as e:
+            mutate.bug_mutants([dict(name="first", old="nowhere", new="x"),
+                                dict(name="second", old="elsewhere", new="y")], "src")
+        self.assertIn("first", str(e.exception))
+        self.assertIn("second", str(e.exception))
+
+
+class TestTestOutput(unittest.TestCase):
+    def test_a_green_run_has_no_failures(self):
+        self.assertEqual(mutate.parse_test_output(finished(0, "anything at all")), [])
+
+    def test_a_failed_assertion_names_its_test_case(self):
+        out = ("TEST CASE:  erase_the_last_element\n"
+               "some/file.cpp:12: ERROR: CHECK( a == b ) is NOT correct!\n")
+        self.assertEqual(mutate.parse_test_output(finished(1, out)),
+                         ["erase_the_last_element"])
+
+    def test_a_banner_without_an_error_is_not_a_failure(self):
+        # doctest prints the banner for anything that produces output, a passing
+        # MESSAGE included. Counting those would report a kill that never was.
+        out = ("TEST CASE:  chatty_but_passing\n"
+               "some/file.cpp:12: MESSAGE: hello\n"
+               "TEST CASE:  the_real_one\n"
+               "some/file.cpp:13: ERROR: CHECK( x ) is NOT correct!\n")
+        self.assertEqual(mutate.parse_test_output(finished(1, out)), ["the_real_one"])
+
+    def test_a_case_is_named_once_however_many_assertions_it_failed(self):
+        out = ("TEST CASE:  noisy\n"
+               "f.cpp:1: ERROR: a\n"
+               "f.cpp:2: ERROR: b\n")
+        self.assertEqual(mutate.parse_test_output(finished(1, out)), ["noisy"])
+
+    def test_a_sanitizer_abort_names_the_sanitizer(self):
+        # Nonzero exit with no failed assertion. Under -Db_sanitize the thing
+        # that noticed is not a test at all, and which runtime complained is the
+        # whole answer.
+        err = "SUMMARY: AddressSanitizer: heap-buffer-overflow /src/x.h:99 in foo\n"
+        self.assertEqual(mutate.parse_test_output(finished(1, "", err)),
+                         ["AddressSanitizer heap-buffer-overflow /src/x.h:99 in foo"])
+
+    def test_a_ubsan_runtime_error_is_recognised(self):
+        err = "/src/x.h:12:7: runtime error: index 8 out of bounds\n"
+        self.assertEqual(mutate.parse_test_output(finished(1, "", err)),
+                         ["index 8 out of bounds"])
+
+    def test_a_bare_crash_still_counts_as_caught(self):
+        got = mutate.parse_test_output(finished(-11))
+        self.assertEqual(got, ["exit -11, no assertion failed"])
+        self.assertTrue(got, "a crash must not read as an empty failure list")
+
+
+class TestCountTestCases(unittest.TestCase):
+    """The guard against a filter that matches nothing.
+
+    doctest's suites are the ones TEST_SUITE names; meson's are not. `-ts=unit` names a meson
+    suite, runs zero cases, exits 0 -- and every mutant under it comes back survived."""
+
+    def test_the_summary_is_read(self):
+        out = "[doctest] test cases:     501 |     501 passed | 0 failed | 27 skipped\n"
+        self.assertEqual(mutate.count_test_cases(out), 501)
+
+    def test_a_filter_that_matched_nothing_counts_zero(self):
+        out = "[doctest] test cases: 0 | 0 passed | 0 failed | 528 skipped\n"
+        self.assertEqual(mutate.count_test_cases(out), 0)
+
+    def test_output_without_a_summary_is_unknown_rather_than_zero(self):
+        # A crash before the summary must not be read as "ran no tests", which
+        # would abort the run instead of reporting the kill.
+        self.assertIsNone(mutate.count_test_cases("Segmentation fault\n"))
+
+
+class TestNameRendering(unittest.TestCase):
+    """Most of this suite is TEST_CASE_TEMPLATE, so a name arrives as 300 characters of
+    instantiation with the useful 25 at the front."""
+
+    def test_a_plain_name_is_untouched(self):
+        self.assertEqual(mutate.short_test_name("erase_and_shift_down"), "erase_and_shift_down")
+
+    def test_an_instantiation_is_collapsed_but_kept_as_a_marker(self):
+        self.assertEqual(
+            mutate.short_test_name("bucket_micro<ankerl::unordered_dense::map<int, int>>"),
+            "bucket_micro<...>")
+
+    def test_nested_instantiations_collapse_to_one_marker(self):
+        self.assertEqual(mutate.short_test_name("t<a<b<c>>>"), "t<...>")
+
+    def test_a_long_name_is_truncated(self):
+        self.assertEqual(len(mutate.short_test_name("x" * 200)), 52)
+
+    def test_the_first_few_tests_are_shown_and_the_rest_counted(self):
+        self.assertEqual(mutate.render_caught(["a", "b", "c", "d", "e"]),
+                         "a, b, c (+2 more)")
+
+    def test_exactly_the_limit_is_not_followed_by_a_count(self):
+        self.assertEqual(mutate.render_caught(["a", "b", "c"]), "a, b, c")
+
+    def test_nothing_caught_it_renders_as_nothing(self):
+        self.assertEqual(mutate.render_caught([]), "")
+
+
+class TestMesonSetupArgs(unittest.TestCase):
+    def args(self, **kwargs):
+        return types.SimpleNamespace(buildtype="debug", meson_arg=[], **kwargs)
+
+    def test_debug_info_is_off_by_default(self):
+        # -O0 without -g: a third of the compile time and two thirds of each
+        # lane's build directory, and nothing here reads a symbol.
+        self.assertIn("-Ddebug=false", mutate.meson_setup_args(self.args()))
+
+    def test_an_explicit_debug_option_wins(self):
+        got = mutate.meson_setup_args(
+            types.SimpleNamespace(buildtype="debug", meson_arg=["-Ddebug=true"]))
+        self.assertNotIn("-Ddebug=false", got)
+        self.assertIn("-Ddebug=true", got)
+
+    def test_the_buildtype_is_passed_through(self):
+        got = mutate.meson_setup_args(
+            types.SimpleNamespace(buildtype="release", meson_arg=[]))
+        self.assertEqual(got[:2], ["--buildtype", "release"])
+
+    def test_extra_arguments_come_last_so_they_can_override(self):
+        got = mutate.meson_setup_args(
+            types.SimpleNamespace(buildtype="debug", meson_arg=["-Db_sanitize=address"]))
+        self.assertEqual(got[-1], "-Db_sanitize=address")
+
+
+class TestFingerprint(unittest.TestCase):
+    def facts(self, **kwargs):
+        args = types.SimpleNamespace(buildtype="debug", meson_arg=[], test_suite=None,
+                                     exclude_suite=None, test_filter=None,
+                                     file=mutate.HEADER, lanes=4, jobs=2,
+                                     memory_limit=2 * mutate.GIB, memory_note="")
+        for key, value in kwargs.items():
+            setattr(args, key, value)
+        return mutate.fingerprint(args)
+
+    def test_a_plain_build_says_it_has_no_sanitizer(self):
+        # The one the report must not stay quiet about: without a sanitizer, a
+        # mutant that reads one slot too far comes back survived.
+        self.assertEqual(self.facts()["sanitizer"], "none")
+        self.assertIn("no sanitizer", mutate.render_fingerprint(self.facts()))
+
+    def test_a_sanitizer_build_says_which(self):
+        facts = self.facts(meson_arg=["-Db_sanitize=address,undefined"])
+        self.assertEqual(facts["sanitizer"], "address,undefined")
+        self.assertNotIn("no sanitizer", mutate.render_fingerprint(facts))
+
+    def test_the_test_filters_are_recorded(self):
+        self.assertEqual(self.facts(exclude_suite="fuzz")["tests"], "-tse=fuzz")
+        self.assertEqual(self.facts()["tests"], "all")
+
+    def test_a_capped_run_says_how_much_and_warns_about_nothing(self):
+        self.assertIn("2.0 GiB per lane", mutate.render_fingerprint(self.facts()))
+        self.assertNotIn("nothing caps", mutate.render_fingerprint(self.facts()))
+
+    def test_an_uncapped_run_says_so_and_says_why(self):
+        # The one the report must not stay quiet about either: without a cap a
+        # runaway mutant takes down whatever the kernel picks, and the verdicts
+        # of the lanes beside it are then guesses.
+        facts = self.facts(memory_limit=0, memory_note="Failed to connect to bus")
+        rendered = mutate.render_fingerprint(facts)
+        self.assertIn("memory          off", rendered)
+        self.assertIn("nothing caps", rendered)
+        self.assertIn("Failed to connect to bus", rendered)
+
+    def test_a_cap_turned_off_on_purpose_still_warns(self):
+        # --memory-limit 0 leaves no reason to print, and the warning is about
+        # the consequence rather than the cause.
+        self.assertIn("nothing caps",
+                      mutate.render_fingerprint(self.facts(memory_limit=0)))
+
+
+class TestSyncTree(unittest.TestCase):
+    """Reuse, which is where being wrong is silent.
+
+    Comparing mtimes would call the previous run's mutated header a change on every file; copying
+    the repo's older mtime onto a lane would leave the object files looking newer than their
+    source, ninja would build nothing, and the suite would run against the last mutant."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.src = self.tmp / "src"
+        self.dst = self.tmp / "dst"
+        (self.src / "include").mkdir(parents=True)
+        (self.src / "include" / "h.h").write_text("original\n")
+        (self.src / "keep.txt").write_text("same\n")
+        self._repo = mutate.REPO
+        mutate.REPO = str(self.src)  # lane_ignore keys the root-only skips off this
+        shutil.copytree(self.src, self.dst)
+
+    def tearDown(self):
+        mutate.REPO = self._repo
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_a_changed_file_is_copied_and_stamped_now(self):
+        header = self.src / "include" / "h.h"
+        header.write_text("mutated\n")
+        os.utime(header, (1, 1))  # an old mtime, as a checkout or a git op leaves
+        mutate.sync_tree(str(self.src), str(self.dst))
+        copy = self.dst / "include" / "h.h"
+        self.assertEqual(copy.read_text(), "mutated\n")
+        self.assertGreater(copy.stat().st_mtime, time.time() - 60)
+
+    def test_an_unchanged_file_keeps_its_mtime(self):
+        # The point of the whole function: restamping every source would cost a
+        # full rebuild in every lane, which is most of what reuse saves.
+        keep = self.dst / "keep.txt"
+        os.utime(keep, (1000, 1000))
+        mutate.sync_tree(str(self.src), str(self.dst))
+        self.assertEqual(keep.stat().st_mtime, 1000)
+
+    def test_a_file_with_the_same_size_but_different_bytes_is_copied(self):
+        # filecmp with shallow=True would call these equal on a same-size,
+        # same-mtime pair, and the lane would test the wrong source.
+        (self.src / "keep.txt").write_text("SAME\n")
+        os.utime(self.src / "keep.txt", (1000, 1000))
+        os.utime(self.dst / "keep.txt", (1000, 1000))
+        mutate.sync_tree(str(self.src), str(self.dst))
+        self.assertEqual((self.dst / "keep.txt").read_text(), "SAME\n")
+
+    def test_a_deleted_file_is_removed_from_the_lane(self):
+        # Or it keeps being compiled, and the lane builds a test file that the
+        # working tree no longer has.
+        (self.src / "keep.txt").unlink()
+        mutate.sync_tree(str(self.src), str(self.dst))
+        self.assertFalse((self.dst / "keep.txt").exists())
+
+    def test_a_new_file_arrives(self):
+        (self.src / "new.cpp").write_text("int main() {}\n")
+        mutate.sync_tree(str(self.src), str(self.dst))
+        self.assertTrue((self.dst / "new.cpp").exists())
+
+    def test_the_lane_build_directory_is_not_touched(self):
+        # It is the one directory in the lane with no counterpart in the repo,
+        # and deleting it would turn every reuse into a cold build.
+        build = self.dst / "builddir"
+        build.mkdir()
+        (build / "build.ninja").write_text("rules\n")
+        mutate.sync_tree(str(self.src), str(self.dst))
+        self.assertTrue((build / "build.ninja").exists())
+
+    def test_ignored_directories_are_not_copied(self):
+        (self.src / ".git").mkdir()
+        (self.src / ".git" / "HEAD").write_text("ref\n")
+        (self.src / "builddir").mkdir()
+        (self.src / "builddir" / "junk").write_text("x\n")
+        mutate.sync_tree(str(self.src), str(self.dst))
+        self.assertFalse((self.dst / ".git").exists())
+        self.assertFalse((self.dst / "builddir" / "junk").exists())
+
+    def test_a_build_named_file_outside_the_root_is_kept(self):
+        # `build*` as a global pattern would eat scripts/build.py, which is why
+        # the build directories are matched at the repo root only.
+        (self.src / "scripts").mkdir()
+        (self.src / "scripts" / "build.py").write_text("#!/usr/bin/env python3\n")
+        mutate.sync_tree(str(self.src), str(self.dst))
+        self.assertTrue((self.dst / "scripts" / "build.py").exists())
+
+
+class TestSyntaxCommand(unittest.TestCase):
+    """The pre-filter's compile line, taken from compile_commands.json rather than reassembled.
+
+    Two things have to come off it: -o, or a syntax check writes an object file; and the -M flags,
+    or it overwrites ninja's dependency file for a compile that produced nothing -- after which
+    ninja's idea of what depends on the header is a fiction."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.build = self.tmp / "builddir"
+        self.build.mkdir()
+        (self.tmp / "test" / "unit").mkdir(parents=True)
+        (self.tmp / "test" / "unit" / "fuzz_api.cpp").write_text("int main() {}\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def command_for(self, command):
+        (self.build / "compile_commands.json").write_text(json.dumps([
+            dict(directory=str(self.build), command=command,
+                 file="../test/unit/fuzz_api.cpp")]))
+        lane = mutate.Lane.__new__(mutate.Lane)
+        lane.dir = str(self.tmp)
+        lane.build = str(self.build)
+        lane.syntax_file = os.path.join("test", "unit", "fuzz_api.cpp")
+        return lane._syntax_command()
+
+    def test_the_check_is_asked_for(self):
+        got = self.command_for("/usr/bin/g++ -std=c++17 -c ../test/unit/fuzz_api.cpp")
+        self.assertIn("-fsyntax-only", got["argv"])
+        self.assertNotIn("-c", got["argv"])
+
+    def test_no_object_is_written(self):
+        got = self.command_for("/usr/bin/g++ -o out.o -c ../test/unit/fuzz_api.cpp")
+        self.assertNotIn("-o", got["argv"])
+        self.assertNotIn("out.o", got["argv"])
+
+    def test_ninjas_depfile_is_not_clobbered(self):
+        got = self.command_for("/usr/bin/g++ -MD -MQ out.o -MF out.o.d "
+                               "-c ../test/unit/fuzz_api.cpp")
+        for flag in ("-MD", "-MQ", "-MF", "out.o.d"):
+            self.assertNotIn(flag, got["argv"])
+
+    def test_the_ccache_prefix_is_dropped(self):
+        # ccache refuses -fsyntax-only outright, and there is nothing to cache
+        # in a compile that produces no object.
+        got = self.command_for("/usr/bin/ccache g++ -std=c++17 -c ../test/unit/fuzz_api.cpp")
+        self.assertEqual(got["argv"][0], "g++")
+
+    def test_the_real_flags_are_kept(self):
+        # -Werror above all: a mutant that only produces a warning is refused by
+        # the real build, so the pre-filter has to refuse it too.
+        got = self.command_for("/usr/bin/g++ -Werror -Wall -I../include -std=c++17 "
+                               "-c ../test/unit/fuzz_api.cpp")
+        for flag in ("-Werror", "-Wall", "-I../include", "-std=c++17"):
+            self.assertIn(flag, got["argv"])
+
+    def test_it_runs_where_the_build_does(self):
+        # The flags are relative to the build directory; running from anywhere
+        # else turns every include path into a miss.
+        got = self.command_for("/usr/bin/g++ -c ../test/unit/fuzz_api.cpp")
+        self.assertEqual(got["cwd"], str(self.build))
+
+    def test_a_file_that_is_not_in_the_build_has_no_check(self):
+        # Rather than silently checking some other TU and passing every time.
+        (self.build / "compile_commands.json").write_text(json.dumps([]))
+        lane = mutate.Lane.__new__(mutate.Lane)
+        lane.dir, lane.build = str(self.tmp), str(self.build)
+        lane.syntax_file = os.path.join("test", "unit", "fuzz_api.cpp")
+        self.assertIsNone(lane._syntax_command())
+
+
+class TestMemorySizes(unittest.TestCase):
+    """What one lane is allowed, which is the number standing between one runaway mutant and
+    every verdict running beside it."""
+
+    def test_the_usual_spellings_of_a_size(self):
+        self.assertEqual(mutate.parse_size("4G"), 4 * mutate.GIB)
+        self.assertEqual(mutate.parse_size("512M"), 512 * mutate.MIB)
+        self.assertEqual(mutate.parse_size("1.5G"), mutate.GIB + mutate.GIB // 2)
+        self.assertEqual(mutate.parse_size("2GiB"), 2 * mutate.GIB)
+        self.assertEqual(mutate.parse_size("4096"), 4096)
+
+    def test_zero_is_a_size_and_means_off(self):
+        # Not falsy-by-accident: it is how the cap is turned off on a machine
+        # where it misfires, so it has to parse rather than be refused.
+        self.assertEqual(mutate.parse_size("0"), 0)
+        self.assertEqual(mutate.human(0), "off")
+
+    def test_nonsense_is_refused_rather_than_read_as_bytes(self):
+        # "4GB of RAM" silently becoming 4 bytes would kill every mutant.
+        for text in ("lots", "4 gigs", "-1", "G4", ""):
+            with self.assertRaises(Exception):
+                mutate.parse_size(text)
+
+    def test_the_lanes_together_fit_in_the_machine(self):
+        # The rule the default exists for: 32 lanes on a 64 GiB machine must not
+        # each be allowed 64 GiB.
+        total = 64 * mutate.GIB
+        got = mutate.default_memory_limit(lanes=32, jobs=1, total=total)
+        self.assertLessEqual(got * 32, total)
+
+    def test_a_lane_is_not_given_more_than_it_could_want(self):
+        # A single lane on a huge machine gets what its jobs can use, not the
+        # machine -- a cap far above any honest need catches no runaway.
+        got = mutate.default_memory_limit(lanes=1, jobs=4, total=1024 * mutate.GIB)
+        self.assertEqual(got, 4 * mutate.GIB)
+
+    def test_the_cap_scales_with_the_jobs_in_the_lane(self):
+        # Each ninja job is a compiler, and a translation unit peaks at ~185 MB.
+        many = mutate.default_memory_limit(lanes=1, jobs=32, total=1024 * mutate.GIB)
+        few = mutate.default_memory_limit(lanes=1, jobs=2, total=1024 * mutate.GIB)
+        self.assertGreater(many, few)
+
+    def test_a_tiny_machine_still_leaves_a_lane_something_to_build_with(self):
+        # Squeezing the share to nothing would fail every build instead of
+        # catching anything; below the floor the arithmetic stops.
+        self.assertEqual(mutate.default_memory_limit(lanes=64, jobs=1,
+                                                     total=2 * mutate.GIB),
+                         mutate.GIB)
+
+    def test_a_machine_that_will_not_say_how_much_it_has_still_gets_a_cap(self):
+        self.assertEqual(mutate.default_memory_limit(lanes=8, jobs=1, total=0),
+                         2 * mutate.GIB)
+
+    def test_a_build_is_never_capped_below_what_its_jobs_need(self):
+        # Otherwise an explicit --memory-limit reports `oom` for every mutant --
+        # a build stopped by this tool's own arithmetic, read as a growth policy
+        # asking for the machine.
+        self.assertEqual(mutate.build_memory_limit(mutate.GIB, jobs=32),
+                         32 * mutate.MEMORY_PER_JOB)
+
+    def test_a_cap_above_what_the_jobs_need_is_left_alone(self):
+        # The cap is about the mutant, and a build that fits under it already
+        # has no claim on being given more.
+        self.assertEqual(mutate.build_memory_limit(8 * mutate.GIB, jobs=1),
+                         8 * mutate.GIB)
+
+    def test_turning_the_cap_off_turns_it_off_for_the_build_too(self):
+        self.assertEqual(mutate.build_memory_limit(0, jobs=32), 0)
+
+
+class TestLaneRoom(unittest.TestCase):
+    """A lane is a copy of the tree plus a build directory, and the count of them comes off the
+    core count without anyone being asked. Where that lands is usually /tmp, which is usually a
+    tmpfs -- so running out of room there is the machine running out of memory."""
+
+    def test_a_workdir_that_cannot_hold_the_lanes_is_refused_before_copying(self):
+        # Half a copy leaves meson failing for a reason that never says "disk".
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(RuntimeError) as e:
+                mutate.check_room_for(tmp, 10 ** 6, lambda message: None)
+            self.assertIn("free", str(e.exception))
+            self.assertIn("--lanes", str(e.exception))
+
+    def test_room_for_one_lane_is_not_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mutate.check_room_for(tmp, 1, lambda message: None)
+
+    def test_reusing_every_lane_asks_for_no_room_at_all(self):
+        # And so cannot fail on a workdir already holding exactly what it needs.
+        mutate.check_room_for("/nonexistent", 0, lambda message: None)
+
+    def test_a_tmpfs_workdir_is_named_as_memory(self):
+        # The line about it is the difference between "the disk is full" and
+        # "the machine is out of RAM", which want different answers.
+        real = mutate.memory_backed
+        mutate.memory_backed = lambda path: True
+        try:
+            said = []
+            with tempfile.TemporaryDirectory() as tmp:
+                mutate.check_room_for(tmp, 1, said.append)
+            self.assertIn("memory", said[0])
+        finally:
+            mutate.memory_backed = real
+
+    @unittest.skipUnless(os.path.isdir("/dev/shm") and os.path.exists("/proc/mounts"),
+                         "no /proc/mounts to read a filesystem type from")
+    def test_the_deepest_mount_point_decides(self):
+        # "/" is a prefix of every path, so a shallow match must not win over
+        # the mount the directory is actually on.
+        self.assertTrue(mutate.memory_backed("/dev/shm"))
+        self.assertFalse(mutate.memory_backed("/proc/mounts"))
+
+
+class TestMemoryCap(unittest.TestCase):
+    """The wrapper, which has to be transparent: the command's stdout, exit status, environment
+    and working directory are all read afterwards as if it had been run directly."""
+
+    def test_a_capped_command_is_the_command_inside_a_scope(self):
+        got = mutate.memory_capped(["ninja", "-C", "b"], 2 * mutate.GIB)
+        self.assertEqual(got[:3], ["systemd-run", "--user", "--scope"])
+        self.assertIn("MemoryMax=%d" % (2 * mutate.GIB), got)
+        self.assertEqual(got[got.index("--") + 1:], ["ninja", "-C", "b"])
+
+    def test_swap_is_pinned_to_zero(self):
+        # Or a runaway thrashes through whatever swap the machine has first,
+        # slowing every other lane down for minutes before anything is killed.
+        self.assertIn("MemorySwapMax=0", mutate.memory_capped(["x"], mutate.GIB))
+
+    def test_no_cap_means_no_wrapper_at_all(self):
+        self.assertEqual(mutate.memory_capped(["ninja"], 0), ["ninja"])
+
+    def test_a_kill_at_the_cap_is_told_apart_from_a_crash(self):
+        # -9 is the kernel killing the offender; -15 is systemd stopping the
+        # rest of the scope when the offender was not the process we waited on.
+        self.assertTrue(mutate.killed_for_memory(finished(-9)))
+        self.assertTrue(mutate.killed_for_memory(finished(-15)))
+        self.assertFalse(mutate.killed_for_memory(finished(-11)))  # a segfault
+        self.assertFalse(mutate.killed_for_memory(finished(1)))
+        self.assertFalse(mutate.killed_for_memory(finished(0)))
+
+    def test_a_machine_with_no_systemd_run_says_which_piece_is_missing(self):
+        # The reason reaches the fingerprint, so "FileNotFoundError" would be
+        # the run telling someone to go and find out what it meant.
+        self.assertIn("PATH", self.reason_for(["definitely-not-a-real-binary"]))
+
+    def test_a_systemd_run_that_refuses_is_quoted_rather_than_summarised(self):
+        # Its own complaint names the missing piece -- no session bus, an
+        # undelegated container -- better than anything invented here.
+        reason = self.reason_for(["sh", "-c", "echo 'Failed to connect to bus' >&2; exit 1"])
+        self.assertIn("Failed to connect to bus", reason)
+
+    def test_a_cap_that_works_has_no_reason_to_give(self):
+        self.assertEqual(self.reason_for(["true"]), "")
+
+    def reason_for(self, argv):
+        """`memory_cap_reason` against a stand-in for systemd-run."""
+        real = mutate.memory_capped
+        mutate.memory_capped = lambda cmd, limit: argv
+        try:
+            return mutate.memory_cap_reason(mutate.GIB)
+        finally:
+            mutate.memory_capped = real
+
+    def test_a_lane_raises_the_cap_for_its_build_and_not_for_its_suite(self):
+        # The wiring, because the two halves are only useful together: the build
+        # gets what its jobs need, the suite gets the lane's cap as it stands,
+        # and it is the suite where a runaway mutant shows up.
+        lane = mutate.Lane.__new__(mutate.Lane)
+        lane.dir, lane.build, lane.jobs = "/lane", "/lane/builddir", 8
+        lane.memory, lane.env, lane.test_args = mutate.GIB, {}, []
+        seen = []
+        lane._run = lambda cmd, timeout, cwd=None, env=None, memory=None: seen.append(memory)
+        lane.run_build(timeout=1)
+        lane.run_tests(timeout=1)
+        self.assertEqual(seen, [8 * mutate.MEMORY_PER_JOB, None])  # None: the lane's own
+
+    def test_a_run_that_timed_out_was_not_killed_for_memory(self):
+        # `None` is a hang, and reading it as an oom would report the wrong
+        # cause for the one verdict that has a cause.
+        self.assertFalse(mutate.killed_for_memory(None))
+
+
+class TestEvaluate(unittest.TestCase):
+    """Which verdict a mutant gets, given how its build and its suite ended.
+
+    Every one of these is a way of being wrong that reads as something else: a build stopped at
+    the memory cap looks exactly like a build the compiler refused, and calling it `compiler`
+    would credit the tests with protection they are not providing."""
+
+    class FakeLane:
+        """A lane that returns canned outcomes instead of building anything."""
+
+        def __init__(self, syntax=None, build=None, tests=None, has_syntax_cmd=True):
+            self.syntax_cmd = dict(argv=["cc"], cwd=".") if has_syntax_cmd else None
+            self.canned = dict(syntax=syntax, build=build, tests=tests)
+            self.written = None
+
+        def write_target(self, text):
+            self.written = text
+
+        def run_syntax_check(self, timeout):
+            return self.canned["syntax"]
+
+        def run_build(self, timeout, jobs=None):
+            return self.canned["build"]
+
+        def run_tests(self, timeout):
+            return self.canned["tests"]
+
+    def verdict(self, **canned):
+        args = types.SimpleNamespace(quick_reject=True, build_timeout=1, test_timeout=1)
+        lane = self.FakeLane(**canned)
+        return mutate.evaluate(lane, dict(text="mutated"), args)
+
+    def test_the_mutant_is_written_before_anything_is_run(self):
+        lane = self.FakeLane(syntax=finished(1))
+        mutate.evaluate(lane, dict(text="mutated source"),
+                        types.SimpleNamespace(quick_reject=True, build_timeout=1,
+                                              test_timeout=1))
+        self.assertEqual(lane.written, "mutated source")
+
+    def test_nothing_noticed_is_survived(self):
+        self.assertEqual(self.verdict(syntax=finished(0), build=finished(0),
+                                      tests=finished(0)), ("survived", []))
+
+    def test_a_failed_assertion_is_caught_and_names_the_test(self):
+        out = "TEST CASE:  erase_shifts_down\nf.cpp:1: ERROR: CHECK( x ) is NOT correct!\n"
+        self.assertEqual(self.verdict(syntax=finished(0), build=finished(0),
+                                      tests=finished(1, out)),
+                         ("caught", ["erase_shifts_down"]))
+
+    def test_a_mutant_the_prefilter_rejects_never_reaches_the_build(self):
+        self.assertEqual(self.verdict(syntax=finished(1), build=None, tests=None),
+                         ("compiler", []))
+
+    def test_a_build_that_failed_is_the_compiler(self):
+        self.assertEqual(self.verdict(syntax=finished(0), build=finished(1)),
+                         ("compiler", []))
+
+    def test_a_suite_that_never_returned_is_a_hang(self):
+        self.assertEqual(self.verdict(syntax=finished(0), build=finished(0), tests=None),
+                         ("hang", []))
+
+    def test_a_suite_stopped_at_the_cap_is_an_oom(self):
+        # The verdict this cap was added for: a mutated growth policy asking for
+        # more memory than the machine has.
+        self.assertEqual(self.verdict(syntax=finished(0), build=finished(0),
+                                      tests=finished(-9)), ("oom", []))
+
+    def test_a_build_stopped_at_the_cap_is_an_oom_and_not_the_compiler(self):
+        # A stopped ninja exits nonzero exactly as a refused one does. Reading it
+        # as `compiler` would report protection that is not there, and hide that
+        # the cap wants raising.
+        self.assertEqual(self.verdict(syntax=finished(0), build=finished(-9)),
+                         ("oom", []))
+
+    def test_a_prefilter_stopped_at_the_cap_is_an_oom_too(self):
+        # A mutated constant can send the compiler itself off allocating.
+        self.assertEqual(self.verdict(syntax=finished(-15)), ("oom", []))
+
+    def test_without_a_prefilter_the_build_is_what_decides(self):
+        args = types.SimpleNamespace(quick_reject=False, build_timeout=1, test_timeout=1)
+        lane = self.FakeLane(build=finished(0), tests=finished(0), has_syntax_cmd=False)
+        self.assertEqual(mutate.evaluate(lane, dict(text="x"), args), ("survived", []))
+
+
+class TestEstimate(unittest.TestCase):
+    def test_more_lanes_is_never_slower(self):
+        self.assertLessEqual(
+            mutate.estimate_seconds(500, lanes=32, cores=32),
+            mutate.estimate_seconds(500, lanes=1, cores=32))
+
+    def test_the_compiling_is_divided_by_the_machine_not_the_lanes(self):
+        # The distinction this whole tool is shaped around: every mutant
+        # rebuilds every TU, so lanes overlap the tail and nothing else.
+        many_cores = mutate.estimate_seconds(500, lanes=8, cores=64)
+        few_cores = mutate.estimate_seconds(500, lanes=8, cores=8)
+        self.assertLess(many_cores, few_cores / 2)
+
+    def test_it_reads_as_a_duration(self):
+        self.assertTrue(mutate.estimate(1, 1, 32).endswith("s"))
+        self.assertTrue(mutate.estimate(500, 32, 32).endswith("min"))
+        self.assertTrue(mutate.estimate(100000, 32, 32).endswith("h"))
+
+
+class TestCommandLine(unittest.TestCase):
+    """The argument rules, checked by running the script -- these are the paths a typo reaches."""
+
+    def run_script(self, *argv):
+        return subprocess.run([sys.executable, str(SCRIPT)] + list(argv),
+                              capture_output=True, text=True,
+                              cwd=str(SCRIPT.parent.parent.parent))
+
+    def test_the_three_bug_modes_are_exclusive(self):
+        r = self.run_script("--replace", "a", "b", "--reverse", "HEAD")
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("pick one", r.stderr)
+
+    def test_a_missing_file_is_refused(self):
+        r = self.run_script("--file", "include/nope.h", "--dry-run")
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("no such file", r.stderr)
+
+    def test_a_bug_that_does_not_apply_is_a_message_not_a_traceback(self):
+        r = self.run_script("--replace", "this text is not in the header", "x", "--dry-run")
+        self.assertEqual(r.returncode, 2)
+        self.assertNotIn("Traceback", r.stderr)
+        self.assertIn("do not apply", r.stderr)
+
+    def test_a_dry_run_of_the_whole_header_lists_mutants_and_costs_nothing(self):
+        r = self.run_script("--dry-run")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("mutants over", r.stdout)
+
+    def test_a_dry_run_says_what_each_lane_may_allocate(self):
+        # The number is worth seeing before an hour of lanes rather than after,
+        # and this is also where "no cgroup here" surfaces -- which is why the
+        # assertion is the word and not the phrasing: a machine that cannot cap
+        # anything has to say that instead of a size, and CI is such a machine.
+        r = self.run_script("--dry-run")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("memory", r.stdout)
+
+    def test_a_memory_limit_that_is_not_a_size_is_refused(self):
+        r = self.run_script("--memory-limit", "lots", "--dry-run")
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("not a size", r.stderr)
+
+    def test_a_sweep_of_lines_holding_no_code_says_so(self):
+        # A comment reflow or a version bump lands here, and "nothing to
+        # mutate" without a reason reads as a broken tool.
+        r = self.run_script("--lines", "1-3", "--dry-run")
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("nothing to mutate", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Coverage says a line ran. `scripts/mutate/mutate.py` says something would have gone red if it had misbehaved: it breaks the header in a throwaway copy of the tree, rebuilds, runs the suite, and reports what nothing noticed. The working tree is never touched.

## Two modes

Putting a **specific bug back** is the everyday one — the check that decides whether a new test earns its place. `scripts/mutate/bugs/erase-path.txt` is the first such file: six ways `erase()` can fail to put back what it owes.

```sh
scripts/mutate/mutate.py --bugs scripts/mutate/bugs/erase-path.txt
scripts/mutate/mutate.py --replace OLD NEW
scripts/mutate/mutate.py --reverse HEAD        # undo a fix, keep today's tests
```

**Sweeping** mutates one token at a time, for the holes nobody thought to ask about. The two compose, and a change is best asked both questions at once.

```sh
scripts/mutate/mutate.py --diff HEAD~1
scripts/mutate/mutate.py --lines 1278-1290 --dry-run
```

## What shapes it here

Every one of the ~90 translation units includes the header, so a mutant is a full rebuild that ccache cannot help with — ~100 CPU-seconds of compiling against 3 of running the suite. Hence lanes of one ninja job each, a single named bug getting the whole machine, and an `-fsyntax-only` pre-filter that rejects invalid C++ in half a second instead of a rebuild.

## Memory

Each lane runs inside a cgroup (`systemd-run --user --scope`) with a memory cap, and `oom` is a verdict of its own beside `hang`. A mutated growth policy turns an insert into a request for more memory than the machine has; capped, that mutant dies alone, uncapped the kernel picks the victim and it is as likely to be another lane, the ninja driving one, or the script itself — so one runaway would corrupt every verdict beside it.

The measurements the default is sized from: the green suite peaks at **14 MB** and one g++ -O0 translation unit at **185 MB**, so nothing honest is near the cap. Default per lane is the smaller of a lane's share of the machine and 1 GiB per ninja job; a build is never capped below what its jobs need, so an explicit `--memory-limit` tightens the mutant without breaking the compile. Where no user scope can be had — another init, no session bus, an undelegated container — the run says which piece is missing rather than pretending.

Two quieter costs of the same kind:

- Lanes are ~90 MB each in a workdir defaulting to `/tmp`, which is a tmpfs on most current distributions, so `--lanes` buys memory as much as parallelism. The run prints how much room it is taking and whether that room is RAM, and refuses before copying rather than part way through.
- Core dumps are turned off. A crashing mutant is an ordinary verdict, and each one was leaving ~30 MB in a lane about to be deleted.

## Tests

`scripts/test_mutate.py` (126 cases) covers the half of the tool that decides what a verdict *means*, and runs in CI beside `test_fuzz_afl.py`. It is hermetic: no compiler, no meson, no lanes, no cgroups. Every way that half can be wrong is silent — a bug block that substitutes nothing, a filter that matches no case, a lane still holding yesterday's binary all come back `survived` and read as a hole in the suite.

## Verified

- `bugs/erase-path.txt`: 6 bugs, 100% killed, 59 s
- 12-mutant sweep over 12 lanes: 100% killed, 71 s
- `initial_shifts = 64 - 2` → `64 - 36` asks for ~512 GB of buckets: `oom` in 21 s under a 2 GiB cap, nothing else on the machine touched
- `--reuse` across two consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
