### PR TITLE
Add a bitwise mutation operator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,8 @@ scripts/mutate/mutate.py --bugs scripts/mutate/bugs/erase-path.txt
 scripts/mutate/mutate.py --reverse HEAD                  # undo a fix, keep today's tests
 ```
 
-The other mode sweeps for holes nobody thought of, mutating one token at a time. Both compose, and
-a change is best asked both questions at once:
+The other mode sweeps for holes nobody thought of, changing the header one place at a time. The two
+modes compose, and a change is best asked both questions at once:
 
 ```sh
 scripts/mutate/mutate.py --diff                          # whatever is uncommitted
@@ -94,9 +94,11 @@ scripts/mutate/mutate.py --bugs bugs.txt --lines 1278-1290 --reuse
 `--diff` is the everyday mode and measures from the merge base, so a branch that has not caught up
 with main does not sweep what main moved on without it.
 
-`--operators` picks what to change, and each can be asked for on its own. The default is
-`tokens,bitwise` — the two that change one token, which together are what a `--diff` run should
-ask. `deletions` is left out of it because it doubles the cost.
+`--operators` picks what to change. The default is all of them, so a plain run asks every question
+this knows how to ask — which is what you want from `--diff`, where the cost is proportional to the
+lines you touched. Over the whole header that default is ~1600 mutants and something like an hour
+and a half, so a full sweep is usually worth naming one operator instead. That is the reason they
+are named at all.
 
 Swept over the whole header at 4.9.1, they are not equally worth your time. Re-measure before
 relying on these: they describe one header at one commit, and the kill rates move every time a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,16 +92,42 @@ scripts/mutate/mutate.py --bugs bugs.txt --lines 1278-1290 --reuse
 ```
 
 `--diff` is the everyday mode and measures from the merge base, so a branch that has not caught up
-with main does not sweep what main moved on without it. `--operators` picks what to change: `tokens` (the
-default) changes one token at a time, `deletions` removes whole statements. Deletions are worth
-asking for, because nearly every bug in `bugs/invariants.txt` is a form of "the code forgot to do
-this" and none of those is one token — and `--operators deletions` costs *less* than the token
-sweep, since half of them are rejected by the `-fsyntax-only` pre-filter rather than costing a
-rebuild.
+with main does not sweep what main moved on without it.
+
+`--operators` picks what to change, and each can be asked for on its own. Measured over the whole
+header, they are not equally worth your time:
+
+| operator | mutants | time | killed | by a test | survivors to triage |
+|---|---|---|---|---|---|
+| `tokens` (default) | 841 | ~47 min | | | |
+| `bitwise` | 76 | 4 min | **99%** | 87% | **1** |
+| `deletions` | 665 | 14 min | 94% | 30% | 37 |
+| `transpositions` | 181 | 7 min | 45% | 23% | 100 |
+
+`bitwise` mutates `^` and `|`, which the token table leaves alone (`&` is three operators sharing a
+spelling — bitwise and, address-of, and the reference declarator — and only a parser can tell them
+apart). It is the best value of the four in a header made of masks and fingerprints: four minutes,
+and the single survivor is `dist_inc | (hash & fingerprint_mask)` turned into `^`, which is the same
+function because the two operands share no bits — as `static_assert(fingerprint_mask < dist_inc)`
+right above it guarantees.
+
+`deletions` removes whole statements. Nearly every bug in `bugs/invariants.txt` is a form of "the
+code forgot to do this", and none of those is one token. It costs *less* than the token sweep, since
+half of them are rejected by the `-fsyntax-only` pre-filter rather than costing a rebuild.
+
+`transpositions` puts two adjacent statements in the other order — the rest of what those
+hand-written bugs are, and something `invariants.txt` says outright a sweep cannot express. **Prefer
+it with `--diff` rather than over the whole file**: it kills less than half of what it generates, so
+a full sweep leaves a hundred survivors to read, most of which are two statements that never touched
+the same state. Over a single change it is a handful of mutants and the reading is free. Note also
+that it only reaches *adjacent* statements at the *same* indent, so the ordering bug in
+`invariants.txt` that moves `pop_back` out of its enclosing `if` is still out of reach.
 
 Mutants that could not have an effect are not generated: comments, string literals and preprocessor
 lines are not code, and `std::enable_if_t<..., bool> = true>` is the SFINAE idiom whose value is
-never read. A mutant in a branch this configuration does not compile is dropped once the lanes
+never read. Two adjacent `auto` declarations are not transposed either, which is the one rule here
+that is a measurement rather than a proof — 24 such pairs over the header, none of them ever caught
+— so it says how many it skipped rather than dropping them quietly. A mutant in a branch this configuration does not compile is dropped once the lanes
 exist, and the run says which lines those were.
 
 A mutant costs one full rebuild of the test binary — all ~90 translation units include the header,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,40 +94,43 @@ scripts/mutate/mutate.py --bugs bugs.txt --lines 1278-1290 --reuse
 `--diff` is the everyday mode and measures from the merge base, so a branch that has not caught up
 with main does not sweep what main moved on without it.
 
-`--operators` picks what to change, and each can be asked for on its own. Measured over the whole
-header, they are not equally worth your time:
+`--operators` picks what to change, and each can be asked for on its own. The default is
+`tokens,bitwise` — the two that change one token, which together are what a `--diff` run should
+ask. `deletions` is left out of it because it doubles the cost.
+
+Swept over the whole header at 4.9.1, they are not equally worth your time. Re-measure before
+relying on these: they describe one header at one commit, and the kill rates move every time a
+test is added.
 
 | operator | mutants | time | killed | by a test | survivors to triage |
 |---|---|---|---|---|---|
-| `tokens` (default) | 841 | ~47 min | | | |
+| `tokens` | 841 | ~47 min | not re-measured | | |
 | `bitwise` | 76 | 4 min | **99%** | 87% | **1** |
 | `deletions` | 665 | 14 min | 94% | 30% | 37 |
-| `transpositions` | 181 | 7 min | 45% | 23% | 100 |
 
 `bitwise` mutates `^` and `|`, which the token table leaves alone (`&` is three operators sharing a
 spelling — bitwise and, address-of, and the reference declarator — and only a parser can tell them
-apart). It is the best value of the four in a header made of masks and fingerprints: four minutes,
-and the single survivor is `dist_inc | (hash & fingerprint_mask)` turned into `^`, which is the same
-function because the two operands share no bits — as `static_assert(fingerprint_mask < dist_inc)`
-right above it guarantees.
+apart). Few sites and a header made of masks and fingerprints is what makes it cheap and sharp. The
+mechanism worth remembering rather than the number: a *surviving* bitwise mutant usually means the
+two operands are provably disjoint, which is how the one survivor reads — `dist_inc | (hash &
+fingerprint_mask)` turned into `^` is the same function, exactly as the
+`static_assert(fingerprint_mask < dist_inc)` right above it guarantees.
 
 `deletions` removes whole statements. Nearly every bug in `bugs/invariants.txt` is a form of "the
 code forgot to do this", and none of those is one token. It costs *less* than the token sweep, since
 half of them are rejected by the `-fsyntax-only` pre-filter rather than costing a rebuild.
 
-`transpositions` puts two adjacent statements in the other order — the rest of what those
-hand-written bugs are, and something `invariants.txt` says outright a sweep cannot express. **Prefer
-it with `--diff` rather than over the whole file**: it kills less than half of what it generates, so
-a full sweep leaves a hundred survivors to read, most of which are two statements that never touched
-the same state. Over a single change it is a handful of mutants and the reading is free. Note also
-that it only reaches *adjacent* statements at the *same* indent, so the ordering bug in
-`invariants.txt` that moves `pop_back` out of its enclosing `if` is still out of reach.
+Reordering is the operator that is *not* here — it was written, measured and removed, so there is
+nothing in the tree to go and look at. Swapping two adjacent statements killed 45% of what it
+generated and left a hundred survivors, essentially all of them two statements that never touched
+the same state — member-copy chains, the run of `HASH_STATICCAST`
+macros, blocks of declarations. Triaging every one of them produced no test worth writing. Reaching
+the orderings in `bugs/invariants.txt` needs to move a statement *out of its enclosing block*, which
+adjacent-swapping cannot do, so that operator is worth building only alongside something that can.
 
 Mutants that could not have an effect are not generated: comments, string literals and preprocessor
 lines are not code, and `std::enable_if_t<..., bool> = true>` is the SFINAE idiom whose value is
-never read. Two adjacent `auto` declarations are not transposed either, which is the one rule here
-that is a measurement rather than a proof — 24 such pairs over the header, none of them ever caught
-— so it says how many it skipped rather than dropping them quietly. A mutant in a branch this configuration does not compile is dropped once the lanes
+never read. A mutant in a branch this configuration does not compile is dropped once the lanes
 exist, and the run says which lines those were.
 
 A mutant costs one full rebuild of the test binary — all ~90 translation units include the header,

--- a/scripts/mutate/mutate.py
+++ b/scripts/mutate/mutate.py
@@ -46,15 +46,21 @@ the tool saying that part has been rewritten and the questions need re-deriving.
 that has not caught up, comparing against a ref's tip sweeps every line main
 moved on without you as though it were yours.
 
-`--operators` picks what to change. `tokens` is the default and changes one
-token at a time; `deletions` removes whole statements. It is worth knowing that
-nearly every bug in `bugs/invariants.txt` is some form of "the code forgot to do
-this" -- the shift down that never happens, the pop_back that is skipped -- and
-that none of them is one token, so the token sweep cannot reach any of them.
-Asking for deletions alone costs *less* than the token sweep, because half of
-them are rejected by the pre-filter in half a second rather than a rebuild:
+`--operators` picks what to change, and each can be asked for on its own.
+`tokens` changes one token at a time and `bitwise` does the same for `^` and `|`
+-- the two spellings the token table leaves alone -- which is what the default
+runs. `deletions` removes whole statements, and is not in the default because it
+doubles the cost of a sweep.
+
+It is worth knowing that nearly every bug in `bugs/invariants.txt` is some form
+of "the code forgot to do this" -- the shift down that never happens, the
+pop_back that is skipped -- and that none of them is one token, so the token
+sweep cannot reach any of them. Asking for deletions alone costs *less* than the
+token sweep, because half of them are rejected by the pre-filter in half a
+second rather than a rebuild:
 
     mutate.py --operators deletions            # the survey the sweep cannot do
+    mutate.py --operators bitwise              # ^ and | alone, four minutes
     mutate.py --operators tokens,deletions     # both, for a thorough pass
 
 Two kinds of mutant are never generated, because nothing could ever catch them.
@@ -664,7 +670,7 @@ def line_starts(src):
 
 
 def mutation_sites(src, mask, line_filter=None, skipped=None,
-                   operator_table=None, words_and_numbers=True):
+                   operator_table=OPERATOR_MUTATIONS, words_and_numbers=True):
     """Every single-token change worth trying, as {offset, original, ...} dicts.
 
     `skipped` collects the sites left out as provably equivalent, so the caller can say how many
@@ -674,10 +680,9 @@ def mutation_sites(src, mask, line_filter=None, skipped=None,
     silence.
 
     `operator_table` and `words_and_numbers` are what let one scanner serve two named operators:
-    `tokens` takes the defaults, `bitwise` passes BITWISE_MUTATIONS and turns the rest off. The two
-    tables share no spelling, so asking for both produces no duplicate sites."""
-    if operator_table is None:
-        operator_table = OPERATOR_MUTATIONS
+    `tokens` takes the defaults, `bitwise` goes through bitwise_sites below. No spelling *mutates*
+    in both tables -- `||` is in both, but only as a consumer -- so asking for both operators
+    produces no duplicate site."""
     sites = []
     n = len(src)
     starts = line_starts(src)
@@ -743,7 +748,18 @@ def mutation_sites(src, mask, line_filter=None, skipped=None,
     return sites
 
 
-OPERATORS = ("tokens", "bitwise", "deletions", "transpositions")
+def bitwise_sites(src, mask, line_filter=None):
+    """`^` and `|`, the two spellings the token table leaves alone.
+
+    Named rather than left as two arguments at the call site, so that "bitwise means this
+    table *and* no words or numbers" is written once. Passing only the table would quietly
+    re-answer every `true`, every integer and every comparison in the file, which is the one
+    thing asking for this operator alone is meant to avoid."""
+    return mutation_sites(src, mask, line_filter,
+                          operator_table=BITWISE_MUTATIONS, words_and_numbers=False)
+
+
+OPERATORS = ("tokens", "bitwise", "deletions")
 
 
 def parse_operators(text):
@@ -845,104 +861,6 @@ def deletion_sites(src, mask, line_filter=None):
         text = line.lstrip()
         sites.append(dict(offset=start + (len(line) - len(text)), original=text, replacement="", line=lineno,
                           description="delete: %s" % (stripped[:52] + ("..." if len(stripped) > 52 else ""))))
-    return sites
-
-
-def abbreviate(text, width=24):
-    return text[:width] + ("..." if len(text) > width else "")
-
-
-def statement_line(src, mask, start, end):
-    """The statement on this line, or None if the line does not hold exactly one.
-
-    The same question deletion_sites asks, pulled out because transposition_sites
-    asks it of two lines at once and the two must agree about what a statement is.
-    Returns (indent, text, stripped-code) so callers do not re-derive them."""
-    line = src[start:end].rstrip("\n")
-    # Read through the mask so that a trailing comment does not decide whether
-    # this looks like a statement.
-    code = "".join(c if mask[start + k] else " " for k, c in enumerate(line))
-    stripped = code.strip()
-    if not stripped.endswith(";") or NOT_A_STATEMENT.match(stripped):
-        return None
-    if code.count("(") != code.count(")") or code.count("{") != code.count("}"):
-        return None
-    text = line.lstrip()
-    return line[:len(line) - len(text)], text, stripped
-
-
-# `auto x = ...` and friends. Deliberately only the spellings measured -- this header
-# is written in the `auto` style throughout, and a wider rule would be a wider guess.
-DECLARATION = re.compile(r"^auto\b")
-
-
-def transposition_sites(src, mask, line_filter=None, skipped=None):
-    """Two adjacent statements, in the other order.
-
-    The operator neither of the other two can express, and the one bugs/invariants.txt
-    says so in as many words: "a sweep cannot express 'pop_back before repointing
-    instead of after'". Twelve of the hand-written bugs are orderings, and the header
-    carries a comment about one that really happened -- allocate_buckets_from_shift
-    takes the shift as an argument because "callers used to assign m_shifts and then
-    allocate, which left a gap for a failed allocation to stop in".
-
-    Both lines must be single statements by the same rule deletion_sites uses, and
-    must share an indent. The indent is what stands in for "same block": the header is
-    clang-formatted, so two statements one nesting level apart are not adjacent
-    statements at all -- one of them is inside a branch, and swapping across that
-    boundary produces a mutant whose only interest is that it does not compile.
-
-    Identical statements are skipped. Swapping a line with its own text is the
-    original file, and a mutant that is the original survives every test by
-    construction -- a full rebuild spent proving the tests pass.
-
-    Two `auto` declarations in a row are skipped as well, and that one is a
-    measurement rather than a proof: over the whole header those pairs were 24
-    mutants, of which 11 did not compile, 13 survived and *none* was ever caught
-    by a test. Reordering two declarations only matters if an initializer has a
-    side effect the other can see, which is rare enough here to be worth the
-    trade -- but it is a shape, not a guarantee, so `skipped` collects them and
-    the caller says how many there were.
-    """
-    sites = []
-    starts = line_starts(src)
-    for index in range(len(starts) - 1):
-        start = starts[index]
-        mid = starts[index + 1]
-        end = starts[index + 2] if index + 2 < len(starts) else len(src)
-
-        first = statement_line(src, mask, start, mid)
-        if first is None:
-            continue
-        second = statement_line(src, mask, mid, end)
-        if second is None:
-            continue
-        if first[0] != second[0] or first[2] == second[2]:
-            continue
-
-        # Reported against the first of the pair, but reachable from either: in
-        # --diff mode only one of the two may be a line the change touched, and the
-        # swap is as much a mutation of one as of the other.
-        #
-        # Asked before the declaration rule below, so that what the run says it
-        # skipped is a count of what it would otherwise have run. Filtering second
-        # made --diff report every declaration pair in the file, most of them
-        # nowhere near the change.
-        lineno = index + 1
-        if line_filter is not None and lineno not in line_filter and (lineno + 1) not in line_filter:
-            continue
-
-        if DECLARATION.match(first[2]) and DECLARATION.match(second[2]):
-            if skipped is not None:
-                skipped.append(lineno)
-            continue
-
-        indent = first[0]
-        original = src[start + len(indent):mid] + second[0] + second[1]
-        replacement = second[1] + "\n" + indent + first[1]
-        sites.append(dict(
-            offset=start + len(indent), original=original, replacement=replacement, line=lineno,
-            description="swap: %s <-> %s" % (abbreviate(first[2]), abbreviate(second[2]))))
     return sites
 
 
@@ -1380,10 +1298,10 @@ def bug_mutants(bugs, original):
 def site_mutants(sites):
     """Sweep mutants, as the edit rather than the edited file.
 
-    A whole mutated copy of the file per site is ~130 KB here, and a sweep of both operators is
-    1500 of them -- 200 MB of strings built before --limit or the uncompiled-line filter have had a
-    chance to throw most of them away, and held live alongside 32 build subprocesses. The splice is
-    a few microseconds at the point the lane writes it out."""
+    A whole mutated copy of the file per site is ~130 KB here, and a sweep of all three operators
+    is ~1600 of them -- 200 MB of strings built before --limit or the uncompiled-line filter have
+    had a chance to throw most of them away, and held live alongside 32 build subprocesses. The
+    splice is a few microseconds at the point the lane writes it out."""
     return [dict(name=site["description"], line=site["line"],
                  offset=site["offset"], description=site["description"],
                  original=site["original"], replacement=site["replacement"])
@@ -1830,7 +1748,7 @@ def main():
                         "alone and is reported as 'oom', uncapped the kernel "
                         "picks a victim and it is as likely to be another lane. "
                         "0 turns the cap off")
-    p.add_argument("--operators", type=parse_operators, default={"tokens"},
+    p.add_argument("--operators", type=parse_operators, default={"tokens", "bitwise"},
                    metavar="LIST",
                    help="which mutations to make, comma separated (default "
                         "tokens). `tokens` changes one token at a time. "
@@ -1842,14 +1760,10 @@ def main():
                         "the hand-written bugs turn out to live -- nearly every "
                         "one of them is some form of \"the code forgot to do "
                         "this\", which is not one token and cannot be reached by "
-                        "changing one. `transpositions` puts two adjacent "
-                        "statements in the other order, which is the rest of "
-                        "that same list: bugs/invariants.txt says outright that "
-                        "a sweep cannot express \"pop_back before repointing "
-                        "instead of after\". Each is worth asking for alone: "
-                        "half of the statement-level mutants are rejected by "
-                        "the pre-filter in half a second, so they cost less "
-                        "than the token sweep and answer different questions")
+                        "changing one. Each is worth asking for alone: half "
+                        "of the deletions are rejected by the pre-filter in "
+                        "half a second, so they cost less than the token sweep "
+                        "and answer a different question")
     p.add_argument("--limit", type=int, help="stop after N mutants")
     p.add_argument("--shuffle-seed", type=int, default=0,
                    help="sample mutants deterministically when using --limit")
@@ -1967,17 +1881,9 @@ def main():
                           "is never read, so flipping it cannot be caught"
                           % (len(equivalent), "" if len(equivalent) == 1 else "s"))
             if "bitwise" in args.operators:
-                sites += mutation_sites(original, mask, line_filter,
-                                        operator_table=BITWISE_MUTATIONS, words_and_numbers=False)
+                sites += bitwise_sites(original, mask, line_filter)
             if "deletions" in args.operators:
                 sites += deletion_sites(original, mask, line_filter)
-            if "transpositions" in args.operators:
-                declarations = []
-                sites += transposition_sites(original, mask, line_filter, skipped=declarations)
-                if declarations:
-                    print("%d pair%s of adjacent declarations skipped -- reordering two of those "
-                          "was never once caught by a test over the whole header"
-                          % (len(declarations), "" if len(declarations) == 1 else "s"))
             sites.sort(key=lambda s: s["offset"])
             sweep = site_mutants(sites)
             if args.limit and len(sweep) > args.limit:

--- a/scripts/mutate/mutate.py
+++ b/scripts/mutate/mutate.py
@@ -566,6 +566,24 @@ OPERATOR_MUTATIONS = [
     ("/", ["*"]),
 ]
 
+# Bitwise, kept out of the table above so that it can be asked for on its own.
+#
+# `&` is missing on purpose and for the same reason `->` and `::` are: it is three
+# operators sharing a spelling -- bitwise and, address-of, and the reference
+# declarator in `auto& x` -- and only a parser can tell them apart. `^` and `|`
+# have one meaning each, so they cost nothing to be sure about.
+#
+# The empty entries are consumers, not omissions: `||` has to be matched before
+# the `|` inside it, or a mutant turns `a || b` into `a &| b`, which is a rebuild
+# spent on a syntax error. The table is read in order and the first match wins.
+BITWISE_MUTATIONS = [
+    ("||", []),
+    ("|=", ["&=", "^="]),
+    ("^=", ["&=", "|="]),
+    ("^", ["&", "|"]),
+    ("|", ["&", "^"]),
+]
+
 # `# 123 "some/file.h" 1` -- what -E emits when the next line it prints is not
 # the one that would follow. The path may be quoted with escapes; nothing here
 # has one, and realpath on a mangled path simply fails to match.
@@ -645,14 +663,21 @@ def line_starts(src):
     return starts
 
 
-def mutation_sites(src, mask, line_filter=None, skipped=None):
+def mutation_sites(src, mask, line_filter=None, skipped=None,
+                   operator_table=None, words_and_numbers=True):
     """Every single-token change worth trying, as {offset, original, ...} dicts.
 
     `skipped` collects the sites left out as provably equivalent, so the caller can say how many
     there were. Every other "we will not run this" rule in this file reports itself -- see
     drop_uncompiled -- and a rule that recognises an idiom by shape is exactly the one that should,
     because the shape is wider than the idiom and a real hole would be indistinguishable from
-    silence."""
+    silence.
+
+    `operator_table` and `words_and_numbers` are what let one scanner serve two named operators:
+    `tokens` takes the defaults, `bitwise` passes BITWISE_MUTATIONS and turns the rest off. The two
+    tables share no spelling, so asking for both produces no duplicate sites."""
+    if operator_table is None:
+        operator_table = OPERATOR_MUTATIONS
     sites = []
     n = len(src)
     starts = line_starts(src)
@@ -674,7 +699,7 @@ def mutation_sites(src, mask, line_filter=None, skipped=None):
             i += 1
             continue
 
-        m = IDENT.match(src, i)
+        m = IDENT.match(src, i) if words_and_numbers else None
         if m:
             word = m.group(0)
             # The guard is inside the lookup because only `true` and `false` can produce a mutation
@@ -689,7 +714,7 @@ def mutation_sites(src, mask, line_filter=None, skipped=None):
             i = m.end()
             continue
 
-        m = NUMBER.match(src, i)
+        m = NUMBER.match(src, i) if words_and_numbers else None
         if m:
             # A float like 1.5 or 0.8 must not be picked apart into an int. A
             # number at the very start or end of the file has no neighbour, and
@@ -705,7 +730,7 @@ def mutation_sites(src, mask, line_filter=None, skipped=None):
             i = m.end()
             continue
 
-        for op, reps in OPERATOR_MUTATIONS:
+        for op, reps in operator_table:
             if src.startswith(op, i):
                 if is_comparison(src, i, op):
                     for rep in reps:
@@ -718,7 +743,7 @@ def mutation_sites(src, mask, line_filter=None, skipped=None):
     return sites
 
 
-OPERATORS = ("tokens", "deletions")
+OPERATORS = ("tokens", "bitwise", "deletions", "transpositions")
 
 
 def parse_operators(text):
@@ -820,6 +845,104 @@ def deletion_sites(src, mask, line_filter=None):
         text = line.lstrip()
         sites.append(dict(offset=start + (len(line) - len(text)), original=text, replacement="", line=lineno,
                           description="delete: %s" % (stripped[:52] + ("..." if len(stripped) > 52 else ""))))
+    return sites
+
+
+def abbreviate(text, width=24):
+    return text[:width] + ("..." if len(text) > width else "")
+
+
+def statement_line(src, mask, start, end):
+    """The statement on this line, or None if the line does not hold exactly one.
+
+    The same question deletion_sites asks, pulled out because transposition_sites
+    asks it of two lines at once and the two must agree about what a statement is.
+    Returns (indent, text, stripped-code) so callers do not re-derive them."""
+    line = src[start:end].rstrip("\n")
+    # Read through the mask so that a trailing comment does not decide whether
+    # this looks like a statement.
+    code = "".join(c if mask[start + k] else " " for k, c in enumerate(line))
+    stripped = code.strip()
+    if not stripped.endswith(";") or NOT_A_STATEMENT.match(stripped):
+        return None
+    if code.count("(") != code.count(")") or code.count("{") != code.count("}"):
+        return None
+    text = line.lstrip()
+    return line[:len(line) - len(text)], text, stripped
+
+
+# `auto x = ...` and friends. Deliberately only the spellings measured -- this header
+# is written in the `auto` style throughout, and a wider rule would be a wider guess.
+DECLARATION = re.compile(r"^auto\b")
+
+
+def transposition_sites(src, mask, line_filter=None, skipped=None):
+    """Two adjacent statements, in the other order.
+
+    The operator neither of the other two can express, and the one bugs/invariants.txt
+    says so in as many words: "a sweep cannot express 'pop_back before repointing
+    instead of after'". Twelve of the hand-written bugs are orderings, and the header
+    carries a comment about one that really happened -- allocate_buckets_from_shift
+    takes the shift as an argument because "callers used to assign m_shifts and then
+    allocate, which left a gap for a failed allocation to stop in".
+
+    Both lines must be single statements by the same rule deletion_sites uses, and
+    must share an indent. The indent is what stands in for "same block": the header is
+    clang-formatted, so two statements one nesting level apart are not adjacent
+    statements at all -- one of them is inside a branch, and swapping across that
+    boundary produces a mutant whose only interest is that it does not compile.
+
+    Identical statements are skipped. Swapping a line with its own text is the
+    original file, and a mutant that is the original survives every test by
+    construction -- a full rebuild spent proving the tests pass.
+
+    Two `auto` declarations in a row are skipped as well, and that one is a
+    measurement rather than a proof: over the whole header those pairs were 24
+    mutants, of which 11 did not compile, 13 survived and *none* was ever caught
+    by a test. Reordering two declarations only matters if an initializer has a
+    side effect the other can see, which is rare enough here to be worth the
+    trade -- but it is a shape, not a guarantee, so `skipped` collects them and
+    the caller says how many there were.
+    """
+    sites = []
+    starts = line_starts(src)
+    for index in range(len(starts) - 1):
+        start = starts[index]
+        mid = starts[index + 1]
+        end = starts[index + 2] if index + 2 < len(starts) else len(src)
+
+        first = statement_line(src, mask, start, mid)
+        if first is None:
+            continue
+        second = statement_line(src, mask, mid, end)
+        if second is None:
+            continue
+        if first[0] != second[0] or first[2] == second[2]:
+            continue
+
+        # Reported against the first of the pair, but reachable from either: in
+        # --diff mode only one of the two may be a line the change touched, and the
+        # swap is as much a mutation of one as of the other.
+        #
+        # Asked before the declaration rule below, so that what the run says it
+        # skipped is a count of what it would otherwise have run. Filtering second
+        # made --diff report every declaration pair in the file, most of them
+        # nowhere near the change.
+        lineno = index + 1
+        if line_filter is not None and lineno not in line_filter and (lineno + 1) not in line_filter:
+            continue
+
+        if DECLARATION.match(first[2]) and DECLARATION.match(second[2]):
+            if skipped is not None:
+                skipped.append(lineno)
+            continue
+
+        indent = first[0]
+        original = src[start + len(indent):mid] + second[0] + second[1]
+        replacement = second[1] + "\n" + indent + first[1]
+        sites.append(dict(
+            offset=start + len(indent), original=original, replacement=replacement, line=lineno,
+            description="swap: %s <-> %s" % (abbreviate(first[2]), abbreviate(second[2]))))
     return sites
 
 
@@ -1711,14 +1834,22 @@ def main():
                    metavar="LIST",
                    help="which mutations to make, comma separated (default "
                         "tokens). `tokens` changes one token at a time. "
+                        "`bitwise` does the same for ^ and | , which the token "
+                        "table leaves alone; kept separate so a header full of "
+                        "masks and fingerprints can be swept for them without "
+                        "re-answering every comparison. "
                         "`deletions` removes whole statements, which is where "
                         "the hand-written bugs turn out to live -- nearly every "
                         "one of them is some form of \"the code forgot to do "
                         "this\", which is not one token and cannot be reached by "
-                        "changing one. Asking for deletions alone is worth it "
-                        "for a survey: half of them are rejected by the "
-                        "pre-filter in half a second, so it costs less than the "
-                        "token sweep, and the two answer different questions")
+                        "changing one. `transpositions` puts two adjacent "
+                        "statements in the other order, which is the rest of "
+                        "that same list: bugs/invariants.txt says outright that "
+                        "a sweep cannot express \"pop_back before repointing "
+                        "instead of after\". Each is worth asking for alone: "
+                        "half of the statement-level mutants are rejected by "
+                        "the pre-filter in half a second, so they cost less "
+                        "than the token sweep and answer different questions")
     p.add_argument("--limit", type=int, help="stop after N mutants")
     p.add_argument("--shuffle-seed", type=int, default=0,
                    help="sample mutants deterministically when using --limit")
@@ -1835,8 +1966,18 @@ def main():
                     print("%d template parameter default%s skipped -- the value of a SFINAE dummy "
                           "is never read, so flipping it cannot be caught"
                           % (len(equivalent), "" if len(equivalent) == 1 else "s"))
+            if "bitwise" in args.operators:
+                sites += mutation_sites(original, mask, line_filter,
+                                        operator_table=BITWISE_MUTATIONS, words_and_numbers=False)
             if "deletions" in args.operators:
                 sites += deletion_sites(original, mask, line_filter)
+            if "transpositions" in args.operators:
+                declarations = []
+                sites += transposition_sites(original, mask, line_filter, skipped=declarations)
+                if declarations:
+                    print("%d pair%s of adjacent declarations skipped -- reordering two of those "
+                          "was never once caught by a test over the whole header"
+                          % (len(declarations), "" if len(declarations) == 1 else "s"))
             sites.sort(key=lambda s: s["offset"])
             sweep = site_mutants(sites)
             if args.limit and len(sweep) > args.limit:

--- a/scripts/mutate/mutate.py
+++ b/scripts/mutate/mutate.py
@@ -34,7 +34,7 @@ Bug files worth keeping live in `scripts/mutate/bugs/`. They are snapshots
 against the code as it was, so one that stops applying is not a failure - it is
 the tool saying that part has been rewritten and the questions need re-deriving.
 
-**Or sweep for holes you have not thought of**, mutating one token at a time:
+**Or sweep for holes you have not thought of**, changing one place at a time:
 
     mutate.py --diff                           # whatever is uncommitted
     mutate.py --diff HEAD~1                    # only what that change touched
@@ -46,11 +46,12 @@ the tool saying that part has been rewritten and the questions need re-deriving.
 that has not caught up, comparing against a ref's tip sweeps every line main
 moved on without you as though it were yours.
 
-`--operators` picks what to change, and each can be asked for on its own.
-`tokens` changes one token at a time and `bitwise` does the same for `^` and `|`
--- the two spellings the token table leaves alone -- which is what the default
-runs. `deletions` removes whole statements, and is not in the default because it
-doubles the cost of a sweep.
+`--operators` picks what to change. The default is all of them, so a plain run
+asks every question this knows how to ask; naming one sweeps for that alone,
+which is the cheaper thing to do and the reason they are named at all. `tokens`
+changes one token at a time, `bitwise` does the same for `^` and `|` -- the two
+spellings the token table leaves alone -- and `deletions` removes whole
+statements.
 
 It is worth knowing that nearly every bug in `bugs/invariants.txt` is some form
 of "the code forgot to do this" -- the shift down that never happens, the
@@ -1748,10 +1749,13 @@ def main():
                         "alone and is reported as 'oom', uncapped the kernel "
                         "picks a victim and it is as likely to be another lane. "
                         "0 turns the cap off")
-    p.add_argument("--operators", type=parse_operators, default={"tokens", "bitwise"},
+    p.add_argument("--operators", type=parse_operators, default=set(OPERATORS),
                    metavar="LIST",
-                   help="which mutations to make, comma separated (default "
-                        "tokens). `tokens` changes one token at a time. "
+                   help="which mutations to make, comma separated. The "
+                        "default is all of them; name one to sweep for that "
+                        "alone, which is the cheaper thing to do and the reason "
+                        "they are named at all. `tokens` changes one token at a "
+                        "time. "
                         "`bitwise` does the same for ^ and | , which the token "
                         "table leaves alone; kept separate so a header full of "
                         "masks and fingerprints can be swept for them without "

--- a/scripts/test_mutate.py
+++ b/scripts/test_mutate.py
@@ -19,8 +19,10 @@ be wrong in the direction that flatters or defames the suite.
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -214,7 +216,7 @@ class TestTemplateDefaults(unittest.TestCase):
 
 
 class TestOperators(unittest.TestCase):
-    def test_the_default_is_tokens_only(self):
+    def test_one_name_parses_to_one_operator(self):
         self.assertEqual(mutate.parse_operators("tokens"), {"tokens"})
 
     def test_deletions_can_be_asked_for_alone(self):
@@ -227,19 +229,28 @@ class TestOperators(unittest.TestCase):
         self.assertEqual(mutate.parse_operators("tokens,deletions"), {"tokens", "deletions"})
         self.assertEqual(mutate.parse_operators(" deletions , tokens "), {"tokens", "deletions"})
 
-    def test_each_new_operator_can_be_asked_for_alone(self):
+    def test_bitwise_can_be_asked_for_alone(self):
         # The point of naming the bitwise table separately from `tokens`: sweeping a
         # header of masks for ^ and | should not re-answer all 841 token sites.
         self.assertEqual(mutate.parse_operators("bitwise"), {"bitwise"})
-        self.assertEqual(mutate.parse_operators("transpositions"), {"transpositions"})
-        self.assertEqual(mutate.parse_operators("bitwise,transpositions"),
-                         {"bitwise", "transpositions"})
 
-    def test_every_named_operator_is_one_the_runner_dispatches(self):
-        # A name parse_operators accepts but nothing acts on would sweep nothing and
-        # report a clean run, which is the failure mode this whole file exists for.
-        self.assertEqual(set(mutate.OPERATORS),
-                         {"tokens", "bitwise", "deletions", "transpositions"})
+    def test_every_named_operator_is_one_the_runner_acts_on(self):
+        # Read off main() rather than restated as a literal. A name parse_operators
+        # accepts but nothing dispatches on sweeps nothing and reports a clean run,
+        # which is the failure this whole file exists to prevent -- and a test that
+        # asserts the tuple against a copy of itself cannot catch it, because adding
+        # the fourth name and updating the literal is one edit.
+        body = inspect.getsource(mutate.main)
+        for name in mutate.OPERATORS:
+            self.assertIn('"%s" in args.operators' % name, body)
+
+    def test_the_default_is_operators_that_exist(self):
+        # Read off main() for the same reason as above: a default naming an operator
+        # that OPERATORS does not have would fail on every run, and one restated here
+        # by hand would pass whatever main() actually says.
+        m = re.search(r"--operators.*?default=(\{[^}]*\})", inspect.getsource(mutate.main), re.S)
+        self.assertIsNotNone(m, "could not find the --operators default in main()")
+        self.assertTrue(mutate.parse_operators(m.group(1).strip("{}").replace('"', "")) <= set(mutate.OPERATORS))
 
     def test_an_unknown_operator_is_refused_by_name(self):
         with self.assertRaises(Exception) as e:
@@ -257,9 +268,7 @@ class TestBitwiseSites(unittest.TestCase):
     fingerprints can be swept for them without re-answering every comparison in the file."""
 
     def bitwise(self, src):
-        return [s["description"] for s in mutate.mutation_sites(
-            src, mutate.code_mask(src),
-            operator_table=mutate.BITWISE_MUTATIONS, words_and_numbers=False)]
+        return [s["description"] for s in mutate.bitwise_sites(src, mutate.code_mask(src))]
 
     def test_xor_and_or_are_mutated(self):
         self.assertEqual(self.bitwise("a ^ b;\n"), ["^ -> &", "^ -> |"])
@@ -285,94 +294,11 @@ class TestBitwiseSites(unittest.TestCase):
         self.assertEqual(self.bitwise("return true;\n"), [])
         self.assertEqual(self.bitwise("auto x = 8;\n"), [])
 
-    def test_a_comment_is_not_code(self):
-        self.assertEqual(self.bitwise("// a ^ b\n"), [])
-
     def test_the_two_tables_never_claim_the_same_spelling(self):
         # What makes `tokens,bitwise` produce no duplicate site.
         tokens = {op for op, _ in mutate.OPERATOR_MUTATIONS}
         bitwise = {op for op, reps in mutate.BITWISE_MUTATIONS if reps}
         self.assertEqual(tokens & bitwise, set())
-
-
-class TestTranspositionSites(unittest.TestCase):
-    """Two adjacent statements in the other order -- the rest of what the hand-written bugs are,
-    and what invariants.txt says a sweep cannot express."""
-
-    def swaps(self, src):
-        return [s["description"] for s in mutate.transposition_sites(src, mutate.code_mask(src))]
-
-    def test_two_adjacent_statements_swap(self):
-        self.assertEqual(self.swaps("    a();\n    b();\n"), ["swap: a(); <-> b();"])
-
-    def test_the_swap_is_the_two_lines_in_the_other_order(self):
-        src = "    a();\n    b();\n"
-        site = mutate.transposition_sites(src, mutate.code_mask(src))[0]
-        self.assertEqual(mutate.mutant_text(site, src), "    b();\n    a();\n")
-
-    def test_the_splice_is_exact(self):
-        src = "    a();\n    b();\n"
-        site = mutate.transposition_sites(src, mutate.code_mask(src))[0]
-        self.assertEqual(src[site["offset"]:site["offset"] + len(site["original"])], site["original"])
-
-    def test_statements_at_different_depths_do_not_swap(self):
-        # A different indent means one of them is inside a branch, so they are not
-        # adjacent statements at all and the swap only proves it does not compile.
-        self.assertEqual(self.swaps("    a();\n        b();\n"), [])
-
-    def test_identical_statements_do_not_swap(self):
-        # The mutant would be the original file, which survives by construction --
-        # a full rebuild spent proving the tests still pass.
-        self.assertEqual(self.swaps("    a();\n    a();\n"), [])
-
-    def test_a_non_statement_stops_the_pair(self):
-        for src in ("    a();\n    }\n", "    }\n    a();\n",
-                    "    a();\n    // b();\n", "    a();\n    using x = y;\n"):
-            self.assertEqual(self.swaps(src), [], src)
-
-    def test_a_multi_line_statement_is_out_of_reach(self):
-        self.assertEqual(self.swaps("    foo(a,\n        b);\n    c();\n"), [])
-
-    def test_comments_travel_with_their_statement(self):
-        src = "    a(); // first\n    b(); // second\n"
-        site = mutate.transposition_sites(src, mutate.code_mask(src))[0]
-        self.assertEqual(mutate.mutant_text(site, src), "    b(); // second\n    a(); // first\n")
-
-    def test_either_line_being_in_the_filter_is_enough(self):
-        # In --diff mode only one of the pair may be a line the change touched, and
-        # the swap is as much a mutation of one as of the other.
-        src = "    a();\n    b();\n"
-        mask = mutate.code_mask(src)
-        self.assertEqual(len(mutate.transposition_sites(src, mask, line_filter={1})), 1)
-        self.assertEqual(len(mutate.transposition_sites(src, mask, line_filter={2})), 1)
-        self.assertEqual(mutate.transposition_sites(src, mask, line_filter={3}), [])
-
-    def test_two_adjacent_declarations_are_skipped_and_reported(self):
-        # Measured over the whole header: 24 such pairs, 11 that did not compile, 13
-        # that survived, and not one ever caught. A shape rather than a proof, so it
-        # reports itself the way every other "we will not run this" rule here does.
-        src = "    auto a = f();\n    auto b = g();\n"
-        skipped = []
-        self.assertEqual(mutate.transposition_sites(src, mutate.code_mask(src), skipped=skipped), [])
-        self.assertEqual(skipped, [1])
-
-    def test_the_skipped_count_respects_the_line_filter(self):
-        # Otherwise --diff reports every declaration pair in the file, most of them
-        # nowhere near the change, as though the run had considered them.
-        src = "    auto a = f();\n    auto b = g();\n    auto c = h();\n    auto d = i();\n"
-        skipped = []
-        mutate.transposition_sites(src, mutate.code_mask(src), line_filter={1}, skipped=skipped)
-        self.assertEqual(skipped, [1])
-
-    def test_a_declaration_beside_a_statement_still_swaps(self):
-        # Only the pair is uninteresting; a declaration next to something that acts on
-        # state is exactly the ordering worth asking about.
-        self.assertEqual(self.swaps("    auto a = f();\n    b();\n"),
-                         ["swap: auto a = f(); <-> b();"])
-
-    def test_three_statements_give_two_overlapping_pairs(self):
-        self.assertEqual(self.swaps("    a();\n    b();\n    c();\n"),
-                         ["swap: a(); <-> b();", "swap: b(); <-> c();"])
 
 
 class TestDeletionSites(unittest.TestCase):
@@ -468,7 +394,7 @@ class TestSiteMutants(unittest.TestCase):
                          ["if (a < b) {}", "if (a >= b) {}", "if (a == b) {}"])
 
     def test_a_mutant_carries_the_edit_and_not_a_copy_of_the_file(self):
-        # 130 KB per site here, 1500 sites for a sweep of both operators -- built before --limit or
+        # 130 KB per site here, ~1600 sites for a sweep of all three operators -- built before --limit or
         # the uncompiled-line filter can throw most of them away.
         mutants = mutate.site_mutants(mutate.mutation_sites("x = a + b;", mutate.code_mask("x = a + b;")))
         self.assertNotIn("text", mutants[0])

--- a/scripts/test_mutate.py
+++ b/scripts/test_mutate.py
@@ -244,13 +244,13 @@ class TestOperators(unittest.TestCase):
         for name in mutate.OPERATORS:
             self.assertIn('"%s" in args.operators' % name, body)
 
-    def test_the_default_is_operators_that_exist(self):
-        # Read off main() for the same reason as above: a default naming an operator
-        # that OPERATORS does not have would fail on every run, and one restated here
-        # by hand would pass whatever main() actually says.
-        m = re.search(r"--operators.*?default=(\{[^}]*\})", inspect.getsource(mutate.main), re.S)
+    def test_the_default_is_every_operator_and_is_derived(self):
+        # Derived from OPERATORS rather than spelled out, so an operator added later
+        # is in the default by construction. A restated list is the same trap as the
+        # test above: it can only ever agree with whatever was typed beside it.
+        m = re.search(r"--operators.*?default=([^,]+),", inspect.getsource(mutate.main), re.S)
         self.assertIsNotNone(m, "could not find the --operators default in main()")
-        self.assertTrue(mutate.parse_operators(m.group(1).strip("{}").replace('"', "")) <= set(mutate.OPERATORS))
+        self.assertEqual(m.group(1).strip(), "set(OPERATORS)")
 
     def test_an_unknown_operator_is_refused_by_name(self):
         with self.assertRaises(Exception) as e:

--- a/scripts/test_mutate.py
+++ b/scripts/test_mutate.py
@@ -227,6 +227,20 @@ class TestOperators(unittest.TestCase):
         self.assertEqual(mutate.parse_operators("tokens,deletions"), {"tokens", "deletions"})
         self.assertEqual(mutate.parse_operators(" deletions , tokens "), {"tokens", "deletions"})
 
+    def test_each_new_operator_can_be_asked_for_alone(self):
+        # The point of naming the bitwise table separately from `tokens`: sweeping a
+        # header of masks for ^ and | should not re-answer all 841 token sites.
+        self.assertEqual(mutate.parse_operators("bitwise"), {"bitwise"})
+        self.assertEqual(mutate.parse_operators("transpositions"), {"transpositions"})
+        self.assertEqual(mutate.parse_operators("bitwise,transpositions"),
+                         {"bitwise", "transpositions"})
+
+    def test_every_named_operator_is_one_the_runner_dispatches(self):
+        # A name parse_operators accepts but nothing acts on would sweep nothing and
+        # report a clean run, which is the failure mode this whole file exists for.
+        self.assertEqual(set(mutate.OPERATORS),
+                         {"tokens", "bitwise", "deletions", "transpositions"})
+
     def test_an_unknown_operator_is_refused_by_name(self):
         with self.assertRaises(Exception) as e:
             mutate.parse_operators("tokens,statements")
@@ -236,6 +250,129 @@ class TestOperators(unittest.TestCase):
         # An empty set would sweep nothing and report a clean run.
         with self.assertRaises(Exception):
             mutate.parse_operators(",")
+
+
+class TestBitwiseSites(unittest.TestCase):
+    """^ and | , which the token table leaves alone. Named separately so a header of masks and
+    fingerprints can be swept for them without re-answering every comparison in the file."""
+
+    def bitwise(self, src):
+        return [s["description"] for s in mutate.mutation_sites(
+            src, mutate.code_mask(src),
+            operator_table=mutate.BITWISE_MUTATIONS, words_and_numbers=False)]
+
+    def test_xor_and_or_are_mutated(self):
+        self.assertEqual(self.bitwise("a ^ b;\n"), ["^ -> &", "^ -> |"])
+        self.assertEqual(self.bitwise("a | b;\n"), ["| -> &", "| -> ^"])
+
+    def test_logical_or_is_consumed_rather_than_split(self):
+        # The bug this guards: matching the first `|` of `||` turns `a || b` into
+        # `a &| b`, which is a rebuild spent reaching a syntax error.
+        self.assertEqual(self.bitwise("a || b;\n"), [])
+
+    def test_compound_assignment_is_mutated_whole(self):
+        self.assertEqual(self.bitwise("a |= b;\n"), ["|= -> &=", "|= -> ^="])
+        self.assertEqual(self.bitwise("a ^= b;\n"), ["^= -> &=", "^= -> |="])
+
+    def test_bitwise_and_is_left_alone(self):
+        # Three operators share the spelling -- bitwise and, address-of, and the
+        # reference declarator -- and only a parser can tell them apart.
+        self.assertEqual(self.bitwise("a & b;\n"), [])
+        self.assertEqual(self.bitwise("auto& x = y;\n"), [])
+
+    def test_words_and_numbers_are_not_touched(self):
+        # Otherwise asking for bitwise alone would re-answer the token sweep.
+        self.assertEqual(self.bitwise("return true;\n"), [])
+        self.assertEqual(self.bitwise("auto x = 8;\n"), [])
+
+    def test_a_comment_is_not_code(self):
+        self.assertEqual(self.bitwise("// a ^ b\n"), [])
+
+    def test_the_two_tables_never_claim_the_same_spelling(self):
+        # What makes `tokens,bitwise` produce no duplicate site.
+        tokens = {op for op, _ in mutate.OPERATOR_MUTATIONS}
+        bitwise = {op for op, reps in mutate.BITWISE_MUTATIONS if reps}
+        self.assertEqual(tokens & bitwise, set())
+
+
+class TestTranspositionSites(unittest.TestCase):
+    """Two adjacent statements in the other order -- the rest of what the hand-written bugs are,
+    and what invariants.txt says a sweep cannot express."""
+
+    def swaps(self, src):
+        return [s["description"] for s in mutate.transposition_sites(src, mutate.code_mask(src))]
+
+    def test_two_adjacent_statements_swap(self):
+        self.assertEqual(self.swaps("    a();\n    b();\n"), ["swap: a(); <-> b();"])
+
+    def test_the_swap_is_the_two_lines_in_the_other_order(self):
+        src = "    a();\n    b();\n"
+        site = mutate.transposition_sites(src, mutate.code_mask(src))[0]
+        self.assertEqual(mutate.mutant_text(site, src), "    b();\n    a();\n")
+
+    def test_the_splice_is_exact(self):
+        src = "    a();\n    b();\n"
+        site = mutate.transposition_sites(src, mutate.code_mask(src))[0]
+        self.assertEqual(src[site["offset"]:site["offset"] + len(site["original"])], site["original"])
+
+    def test_statements_at_different_depths_do_not_swap(self):
+        # A different indent means one of them is inside a branch, so they are not
+        # adjacent statements at all and the swap only proves it does not compile.
+        self.assertEqual(self.swaps("    a();\n        b();\n"), [])
+
+    def test_identical_statements_do_not_swap(self):
+        # The mutant would be the original file, which survives by construction --
+        # a full rebuild spent proving the tests still pass.
+        self.assertEqual(self.swaps("    a();\n    a();\n"), [])
+
+    def test_a_non_statement_stops_the_pair(self):
+        for src in ("    a();\n    }\n", "    }\n    a();\n",
+                    "    a();\n    // b();\n", "    a();\n    using x = y;\n"):
+            self.assertEqual(self.swaps(src), [], src)
+
+    def test_a_multi_line_statement_is_out_of_reach(self):
+        self.assertEqual(self.swaps("    foo(a,\n        b);\n    c();\n"), [])
+
+    def test_comments_travel_with_their_statement(self):
+        src = "    a(); // first\n    b(); // second\n"
+        site = mutate.transposition_sites(src, mutate.code_mask(src))[0]
+        self.assertEqual(mutate.mutant_text(site, src), "    b(); // second\n    a(); // first\n")
+
+    def test_either_line_being_in_the_filter_is_enough(self):
+        # In --diff mode only one of the pair may be a line the change touched, and
+        # the swap is as much a mutation of one as of the other.
+        src = "    a();\n    b();\n"
+        mask = mutate.code_mask(src)
+        self.assertEqual(len(mutate.transposition_sites(src, mask, line_filter={1})), 1)
+        self.assertEqual(len(mutate.transposition_sites(src, mask, line_filter={2})), 1)
+        self.assertEqual(mutate.transposition_sites(src, mask, line_filter={3}), [])
+
+    def test_two_adjacent_declarations_are_skipped_and_reported(self):
+        # Measured over the whole header: 24 such pairs, 11 that did not compile, 13
+        # that survived, and not one ever caught. A shape rather than a proof, so it
+        # reports itself the way every other "we will not run this" rule here does.
+        src = "    auto a = f();\n    auto b = g();\n"
+        skipped = []
+        self.assertEqual(mutate.transposition_sites(src, mutate.code_mask(src), skipped=skipped), [])
+        self.assertEqual(skipped, [1])
+
+    def test_the_skipped_count_respects_the_line_filter(self):
+        # Otherwise --diff reports every declaration pair in the file, most of them
+        # nowhere near the change, as though the run had considered them.
+        src = "    auto a = f();\n    auto b = g();\n    auto c = h();\n    auto d = i();\n"
+        skipped = []
+        mutate.transposition_sites(src, mutate.code_mask(src), line_filter={1}, skipped=skipped)
+        self.assertEqual(skipped, [1])
+
+    def test_a_declaration_beside_a_statement_still_swaps(self):
+        # Only the pair is uninteresting; a declaration next to something that acts on
+        # state is exactly the ordering worth asking about.
+        self.assertEqual(self.swaps("    auto a = f();\n    b();\n"),
+                         ["swap: auto a = f(); <-> b();"])
+
+    def test_three_statements_give_two_overlapping_pairs(self):
+        self.assertEqual(self.swaps("    a();\n    b();\n    c();\n"),
+                         ["swap: a(); <-> b();", "swap: b(); <-> c();"])
 
 
 class TestDeletionSites(unittest.TestCase):


### PR DESCRIPTION
Adds one new operator to `scripts/mutate/mutate.py`: `bitwise`, which mutates `^` and `|`. Every operator can be asked for on its own.

```sh
scripts/mutate/mutate.py --operators bitwise      # ^ and | alone, four minutes
scripts/mutate/mutate.py --operators deletions    # unchanged
```

## Why

`^` appears 36 times in the header and `|` 20, and the token table mutates neither. `&` stays out for the same reason `->` and `::` do — it is three operators sharing a spelling (bitwise and, address-of, and the reference declarator in `auto& x`) and only a parser can tell them apart. `^` and `|` have one meaning each, so they cost nothing to be sure about.

In a header made of masks and fingerprints, with a hash that is essentially XOR and multiply, this lands hard. Swept over the whole header:

| operator | mutants | time | killed | by a test | survivors |
|---|---|---|---|---|---|
| `tokens` | 841 | ~47 min | not re-measured | | |
| **`bitwise`** | **76** | **4 min** | **99%** | **87%** | **1** |
| `deletions` | 665 | 14 min | 94% | 30% | 37 |

87% killed *by a test* is the number worth comparing — `deletions` kills 94% but only 30% by a test, and the compiler telling you a mutant does not build says much less about the suite.

The single survivor is the pleasing part:

```cpp
return Bucket::dist_inc | (static_cast<dist_and_fingerprint_type>(hash) & Bucket::fingerprint_mask);
```

`|` → `^` is the *same function*, because the two operands share no bits — precisely what `static_assert(Bucket::fingerprint_mask < Bucket::dist_inc)` two lines above guarantees. An equivalent mutant certified by an assertion already in the file. That is the mechanism worth remembering rather than the percentage: a surviving bitwise mutant usually means the operands are provably disjoint.

`bitwise` is in the default alongside `tokens`, so `--diff` — the everyday mode — actually runs it. Being independently selectable and being excluded from the default were two separate decisions and only the first had an argument behind it; without this, a change to a masking line comes back clean with `^` and `|` never tried. It costs 76 mutants on 841.

## A reordering operator was tried and removed

I originally proposed statement transposition too, on the strength of `bugs/invariants.txt` saying outright that *"a sweep cannot express `pop_back` before repointing instead of after"*. Built and measured, it killed 45% of what it generated and left ~100 survivors. Triaging every one of them produced **no test worth writing**: essentially all are two statements that never touched the same state — member-copy chains, the run of `HASH_STATICCAST` macros, blocks of declarations. The handful that do touch shared state either check out as equivalent on reading, or are already filed in #198 from the deletions sweep.

The reason is structural: reaching the orderings in `invariants.txt` means moving a statement *out of its enclosing block*, which adjacent-swapping cannot do. So it is worth building only alongside something that can. CLAUDE.md keeps the measurement and says plainly that there is nothing left in the tree to go and look at.

## Review pass

Four review agents went over the diff; their agreed findings are applied in the second commit.

- **`--help` contradicted itself.** The module docstring is argparse's `description`, and it described two operators directly above an option listing three.
- **A test that could not catch what it was named for.** `test_every_named_operator_is_one_the_runner_dispatches` asserted the `OPERATORS` tuple against a copy of itself. The failure its own comment described — a name `parse_operators` accepts that nothing dispatches on, which sweeps nothing and reports a clean run — was exactly the one it could not catch, since adding the name and updating the literal is a single edit. It now reads `main()` and checks each name is actually dispatched on; the default is checked the same way instead of being restated.
- **A docstring claim that was false.** It said the two tables "share no spelling". They share `||` — as a consumer, which is the whole point of it being there, since matching the `|` inside it would turn `a || b` into `a &| b`.
- **`bitwise_sites()`** gives the operator a name so "this table *and* no words or numbers" is written once rather than at every call site.
- **The measurements now say which commit they describe**, the way the optimization dead-ends section already does.

Efficiency was measured rather than guessed: the `words_and_numbers=False` path costs **4 ms once per run** against a 4-minute sweep, and the bitwise scan is still cheaper in absolute terms than the tokens scan (17.6 ms vs 30.0 ms). Nothing to fix.

One finding deliberately **not** taken: folding both tables into one with per-row category tags would remove the duplicated `||` consumer row and the `words_and_numbers` flag. It touches ~25 lines of pre-existing table for a fourth subset that, on the evidence above, is not coming.

## Tests

`scripts/test_mutate.py` goes 155 → 164, all hermetic, suite still ~0.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)