### PR TITLE
Test the deletion survivors that turned out to be testable

### DIFF
--- a/test/unit/assignment_exception_safety.cpp
+++ b/test/unit/assignment_exception_safety.cpp
@@ -145,8 +145,8 @@ struct throws_on_move {
 };
 
 using throwing_move_alloc = test::pmr_like_allocator<std::pair<int, throws_on_move>>;
-using throwing_move_map =
-    ankerl::unordered_dense::map<int, throws_on_move, ankerl::unordered_dense::hash<int>, std::equal_to<int>, throwing_move_alloc>;
+using throwing_move_map = ankerl::unordered_dense::
+    map<int, throws_on_move, ankerl::unordered_dense::hash<int>, std::equal_to<int>, throwing_move_alloc>;
 
 // The whole point of the allocator choice, asserted rather than assumed: with a nothrow move
 // assignment the recovery below is not instantiated and the test would pass vacuously.

--- a/test/unit/assignment_exception_safety.cpp
+++ b/test/unit/assignment_exception_safety.cpp
@@ -1,9 +1,12 @@
 #include <ankerl/unordered_dense.h>
 
+#include <app/bombing_allocator.h>
 #include <app/doctest.h>
+#include <app/id_allocator.h>
 #include <app/map_fixtures.h>
 
 #include <cstddef>
+#include <new>
 #include <stdexcept>
 #include <utility>
 
@@ -96,3 +99,166 @@ TEST_CASE("copy_assignment_that_throws_leaves_a_usable_table") {
         check_throwing_copy_assignment<map_t>(200, 0, 100);
     }
 }
+
+// Move assignment has the identical window and its own recovery, and nothing was reaching it: both
+// the reset_to_empty() that puts the table back and the bare `throw;` that re-raises could be
+// deleted with the suite green.
+//
+// It takes more setting up than the copy above, because a move only reaches the recovery when it
+// can fail at all. With std::allocator the whole operation is noexcept -- the containers simply
+// take the other's memory -- so `move_assign_is_nothrow` is true, the try/catch is not even
+// instantiated, and there is nothing to test. An allocator that neither propagates on move
+// assignment nor compares equal is what makes the table move the elements one at a time into
+// memory of its own, which is a loop with a throwing move in it.
+namespace {
+
+// Throws on the nth move. The mirror of throws_on_copy above, and it has to be copyable without
+// throwing for the same reason that one has to be movable.
+struct throws_on_move {
+    static inline int moves_until_throw = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    int m_value = 0;
+
+    throws_on_move() = default;
+
+    explicit throws_on_move(int value)
+        : m_value(value) {}
+
+    throws_on_move(throws_on_move const&) = default;
+    auto operator=(throws_on_move const&) -> throws_on_move& = default;
+    ~throws_on_move() = default;
+
+    throws_on_move(throws_on_move&& other)
+        : m_value(other.m_value) {
+        if (0 < moves_until_throw && 0 == --moves_until_throw) {
+            throw std::runtime_error("move");
+        }
+    }
+
+    auto operator=(throws_on_move&& other) -> throws_on_move& {
+        m_value = other.m_value;
+        if (0 < moves_until_throw && 0 == --moves_until_throw) {
+            throw std::runtime_error("move");
+        }
+        return *this;
+    }
+};
+
+using unequal_alloc = test::pmr_like_allocator<std::pair<int, throws_on_move>>;
+using unequal_alloc_map =
+    ankerl::unordered_dense::map<int, throws_on_move, ankerl::unordered_dense::hash<int>, std::equal_to<int>, unequal_alloc>;
+
+// The whole point of the allocator choice, asserted rather than assumed: with a nothrow move
+// assignment the recovery below is not instantiated and the test would pass vacuously.
+static_assert(!std::is_nothrow_move_assignable_v<unequal_alloc_map>,
+              "the recovery this file tests only exists when move assignment can throw");
+
+struct move_countdown_guard {
+    explicit move_countdown_guard(int n) {
+        throws_on_move::moves_until_throw = n;
+    }
+    move_countdown_guard(move_countdown_guard const&) = delete;
+    move_countdown_guard(move_countdown_guard&&) = delete;
+    auto operator=(move_countdown_guard const&) -> move_countdown_guard& = delete;
+    auto operator=(move_countdown_guard&&) -> move_countdown_guard& = delete;
+    ~move_countdown_guard() {
+        throws_on_move::moves_until_throw = 0;
+    }
+};
+
+auto filled_with(int count, int allocator_id) -> unequal_alloc_map {
+    auto map = unequal_alloc_map(0, unequal_alloc(allocator_id));
+    for (int i = 0; i < count; ++i) {
+        map.try_emplace(i, throws_on_move(i));
+    }
+    return map;
+}
+
+} // namespace
+
+TEST_CASE("move_assignment_that_throws_leaves_a_usable_table") {
+    auto source = filled_with(200, 1);
+    auto target = filled_with(50, 2);
+
+    // Unequal allocators are what stop the move being a pointer swap.
+    REQUIRE(!(source.get_allocator() == target.get_allocator()));
+
+    {
+        auto const guard = move_countdown_guard(100);
+        REQUIRE_THROWS_AS(target = std::move(source), std::runtime_error);
+    }
+
+    test::require_empty_table_answers(target);
+}
+
+// The recovery has one more corner, and it is the only one where the *bucket* array is what the
+// table is left holding. copy_everything_from() copies the values first and builds the buckets
+// last, so every test above throws while m_buckets is still empty from the deallocate_buckets()
+// that ran before the try -- which makes reset_to_empty()'s m_buckets.clear() a no-op and leaves
+// it untested.
+//
+// A failure inside the bucket build is what reaches it, and only for a segmented table: the
+// default container builds a fresh array beside the old one and swaps it in, so a throw there
+// leaves m_buckets exactly as it was, while the segmented one grows in place and a throw part way
+// through leaves a partly grown array behind.
+//
+// Rather than guess which allocation that is -- it moves with the code, and MSVC's debug iterators
+// take one through the allocator for every container constructed -- this walks the budget upward
+// until the assignment completes, so every allocation it makes has had its turn at failing.
+namespace {
+
+template <typename Alloc>
+using assign_map_of = ankerl::unordered_dense::map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+template <typename Alloc>
+using assign_segmented_map_of =
+    ankerl::unordered_dense::segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+using assign_pair_t = std::pair<int, int>;
+using assign_bombing_map = assign_map_of<test::bombing_allocator<assign_pair_t>>;
+using assign_bombing_segmented_map = assign_segmented_map_of<test::bombing_allocator<assign_pair_t>>;
+
+#if ANKERL_TEST_CAN_BOMB_ALLOCATIONS()
+template <typename Map>
+void require_assignment_survives_every_allocation_failure() {
+    auto failures = 0;
+    auto completed = false;
+    for (int budget = 0; budget < 1000 && !completed; ++budget) {
+        auto const source = test::filled<Map>(200);
+        auto target = test::filled<Map>(50);
+
+        try {
+            auto const bomb = test::bomb_after(budget);
+            target = source;
+            completed = true;
+        } catch (std::bad_alloc const&) {
+            ++failures;
+            // Whichever allocation failed, the table is back to what a default constructed one
+            // looks like -- including holding no bucket array, which is the part that a throw
+            // during the bucket build is the only way to reach.
+            test::require_empty_table_answers(target);
+        }
+    }
+    // Both halves matter: with no failure the loop proved nothing, and with no completion it never
+    // reached the end and the later allocations went untested.
+    REQUIRE(failures > 0);
+    REQUIRE(completed);
+}
+#endif
+
+} // namespace
+
+#if ANKERL_TEST_CAN_BOMB_ALLOCATIONS()
+
+TEST_CASE("copy_assignment_that_cannot_allocate_leaves_a_usable_table") {
+    SUBCASE("map") {
+        require_assignment_survives_every_allocation_failure<assign_bombing_map>();
+    }
+
+    // The one that can throw with a partly built bucket array behind it.
+    SUBCASE("segmented map") {
+        require_assignment_survives_every_allocation_failure<assign_bombing_segmented_map>();
+    }
+}
+
+#endif

--- a/test/unit/assignment_exception_safety.cpp
+++ b/test/unit/assignment_exception_safety.cpp
@@ -144,13 +144,13 @@ struct throws_on_move {
     }
 };
 
-using unequal_alloc = test::pmr_like_allocator<std::pair<int, throws_on_move>>;
-using unequal_alloc_map =
-    ankerl::unordered_dense::map<int, throws_on_move, ankerl::unordered_dense::hash<int>, std::equal_to<int>, unequal_alloc>;
+using throwing_move_alloc = test::pmr_like_allocator<std::pair<int, throws_on_move>>;
+using throwing_move_map =
+    ankerl::unordered_dense::map<int, throws_on_move, ankerl::unordered_dense::hash<int>, std::equal_to<int>, throwing_move_alloc>;
 
 // The whole point of the allocator choice, asserted rather than assumed: with a nothrow move
 // assignment the recovery below is not instantiated and the test would pass vacuously.
-static_assert(!std::is_nothrow_move_assignable_v<unequal_alloc_map>,
+static_assert(!std::is_nothrow_move_assignable_v<throwing_move_map>,
               "the recovery this file tests only exists when move assignment can throw");
 
 struct move_countdown_guard {
@@ -166,8 +166,8 @@ struct move_countdown_guard {
     }
 };
 
-auto filled_with(int count, int allocator_id) -> unequal_alloc_map {
-    auto map = unequal_alloc_map(0, unequal_alloc(allocator_id));
+auto filled_with(int count, int allocator_id) -> throwing_move_map {
+    auto map = throwing_move_map(0, throwing_move_alloc(allocator_id));
     for (int i = 0; i < count; ++i) {
         map.try_emplace(i, throws_on_move(i));
     }

--- a/test/unit/bucket.cpp
+++ b/test/unit/bucket.cpp
@@ -184,3 +184,48 @@ TEST_CASE("a_count_above_the_bucket_limit_does_not_collapse_the_array") {
         }
     }
 }
+
+// reserve() clamps what it is asked for to max_size() before handing it to the value container.
+// Without that, a caller asking for more than the table could ever index reaches
+// std::vector::reserve() with the raw number and gets a std::length_error out of a call that
+// should simply have given them everything there is.
+//
+// bucket_micro is what makes this askable. On a default map max_size() is 2^32, so the clamped
+// call still reserves 2^32 pairs -- tens of gigabytes -- and the test would be indistinguishable
+// from the bug. Here the clamp lands on 256.
+TEST_CASE("reserve_clamps_to_max_size_instead_of_failing") {
+    auto map = micro_map_t();
+    map.reserve((std::numeric_limits<size_t>::max)());
+
+    REQUIRE(map.bucket_count() <= micro_map_t::max_bucket_count());
+    REQUIRE(map.values().capacity() <= micro_map_t::max_size());
+
+    // ... and it is a working table afterwards, not merely one that did not throw
+    map[1] = 10;
+    REQUIRE(map.at(1) == 10U);
+    REQUIRE(map.size() == 1U);
+}
+
+// The same clamp in rehash() is *not* tested, and deliberately: calc_shifts_for_size() saturates
+// at max_bucket_count(), so it answers the same for count and for min(count, max_size()) and the
+// clamp cannot change anything. It is the reserve() one that reaches a container.
+
+// rehash() hands the values container back whatever it is holding beyond its size. Nothing was
+// checking that, because every other rehash test asks about buckets -- and the value container is
+// the larger of the two allocations.
+TEST_CASE("rehash_shrinks_the_value_container") {
+    auto map = ankerl::unordered_dense::map<size_t, size_t>();
+    map.reserve(1000);
+    for (size_t i = 0; i < 10; ++i) {
+        map[i] = i;
+    }
+    REQUIRE(map.values().capacity() >= 1000);
+
+    map.rehash(0);
+
+    REQUIRE(map.values().capacity() < 1000);
+    REQUIRE(map.size() == 10U);
+    for (size_t i = 0; i < 10; ++i) {
+        REQUIRE(map.at(i) == i);
+    }
+}

--- a/test/unit/carried_state.cpp
+++ b/test/unit/carried_state.cpp
@@ -179,14 +179,14 @@ TEST_CASE_MAP("move_assignment_takes_the_growth_threshold", int, int, test::tagg
 // -- which is why it needs an allocator whose instances differ.
 namespace {
 
-using unequal_alloc = test::pmr_like_allocator<std::pair<int, int>>;
-using unequal_alloc_map = ankerl::unordered_dense::map<int, int, test::tagged_hash, test::tagged_equal, unequal_alloc>;
+using carried_state_alloc = test::pmr_like_allocator<std::pair<int, int>>;
+using carried_state_map = ankerl::unordered_dense::map<int, int, test::tagged_hash, test::tagged_equal, carried_state_alloc>;
 
 } // namespace
 
 TEST_CASE("move_assignment_between_unequal_allocators_takes_the_carried_state") {
-    auto a = unequal_alloc_map(0, test::tagged_hash{tag_a}, test::tagged_equal{tag_a}, unequal_alloc(1));
-    auto b = unequal_alloc_map(0, test::tagged_hash{tag_b}, test::tagged_equal{tag_b}, unequal_alloc(2));
+    auto a = carried_state_map(0, test::tagged_hash{tag_a}, test::tagged_equal{tag_a}, carried_state_alloc(1));
+    auto b = carried_state_map(0, test::tagged_hash{tag_b}, test::tagged_equal{tag_b}, carried_state_alloc(2));
     a.max_load_factor(load_a);
     b.max_load_factor(load_b);
     for (int i = 0; i < 20; ++i) {

--- a/test/unit/segmented_vector_allocators.cpp
+++ b/test/unit/segmented_vector_allocators.cpp
@@ -150,3 +150,55 @@ TEST_CASE("segmented_vector_move_construction_takes_the_source_allocator") {
     REQUIRE(moved.get_allocator().m_id == 4);
     require_vector_holds(moved, 10);
 }
+
+// Self assignment has a second door. The copy above goes through operator=(segmented_vector const&);
+// this is the move, which guards itself separately and has to, because the body it guards would
+// clear the vector and then move its own blocks into itself. Nothing was reaching that guard: the
+// table's own operator= checks `&other != this` first, so a self-move through a segmented_map never
+// gets here, and only a segmented_vector used directly can.
+TEST_CASE("segmented_vector_self_move_assignment_keeps_the_contents") {
+    auto vec = filled<sticky_vec>(3, 10);
+
+    // Through a pointer so that this is a self-move the compiler cannot see and warn about, which
+    // is also the only way it happens in real code -- two references that turn out to be one.
+    auto* alias = &vec;
+    vec = std::move(*alias);
+
+    require_vector_holds(vec, 10);
+    REQUIRE(vec.get_allocator().m_id == 3);
+}
+
+// Taking over another vector's blocks means giving back the ones already held. Nothing checked
+// that: every move-assignment test above asks what the target ended up holding, and a target that
+// took the source's blocks without freeing its own answers all of those correctly while leaking
+// every block it had.
+//
+// Counting rather than asserting a number of blocks, so this does not have to know how many
+// elements fit in one.
+namespace {
+
+template <typename Vec>
+auto filled_counting(int allocator_id, test::alloc_counts* counts, int count) -> Vec {
+    auto vec = Vec(typename Vec::allocator_type(allocator_id, counts));
+    for (int i = 0; i < count; ++i) {
+        vec.emplace_back(i);
+    }
+    return vec;
+}
+
+} // namespace
+
+TEST_CASE("segmented_vector_move_assign_frees_the_blocks_it_replaces") {
+    auto counts = test::alloc_counts{};
+    {
+        // The same id, so the two compare equal and the blocks can be taken over -- which is the
+        // branch that has something to give back first.
+        auto source = filled_counting<sticky_vec>(7, &counts, 10);
+        auto target = filled_counting<sticky_vec>(7, &counts, 12);
+        REQUIRE(counts.allocations > 0);
+
+        target = std::move(source);
+        require_vector_holds(target, 10);
+    }
+    REQUIRE(counts.allocations == counts.deallocations);
+}

--- a/test/unit/transparent.cpp
+++ b/test/unit/transparent.cpp
@@ -8,6 +8,7 @@
 #include <array>         // for array
 #include <cstddef>       // for size_t
 #include <functional>    // for equal_to
+#include <optional>      // for optional
 #include <string>        // for basic_string, string, operator""s
 #include <string_view>   // for basic_string_view, operator""sv
 #include <type_traits>   // for add_const_t
@@ -213,6 +214,31 @@ TEST_CASE_MAP("transparent_erase", std::string, size_t, string_hash, std::equal_
     check(__LINE__, map, 5, 2, 1);
     REQUIRE(1 == map.erase("hello"s));
     check(__LINE__, map, 5, 2, 2);
+}
+
+// extract(key) has a transparent overload of its own -- the one that hands the whole value back in
+// an optional rather than counting what it removed -- and nothing was calling it. Its body could be
+// deleted in full with the suite still green, which is only possible for a template nothing
+// instantiates: erase() above is a different function, and the non-transparent extract() is reached
+// only with a key of the map's own type.
+TEST_CASE_MAP("transparent_extract", std::string, size_t, string_hash, string_eq) {
+    auto map = map_t();
+    map.try_emplace("hello", 1);
+    map.try_emplace("world", 2);
+
+    auto got = map.extract("hello"sv);
+    REQUIRE(got.has_value());
+    REQUIRE(got->first == "hello");
+    REQUIRE(got->second == 1U);
+    REQUIRE(map.size() == 1U);
+    REQUIRE(!map.contains("hello"sv));
+
+    // a miss gives an empty optional and leaves the table alone, which is what tells this apart
+    // from a version that always returns whatever it last saw
+    auto missing = map.extract("nope"sv);
+    REQUIRE(!missing.has_value());
+    REQUIRE(map.size() == 1U);
+    REQUIRE(map.at("world"sv) == 2U);
 }
 
 TEST_CASE_MAP("transparent_equal_range", std::string, size_t, string_hash, std::equal_to<>) {


### PR DESCRIPTION
Works through #198. Seven tests, each verified against the mutant it targets.

| | before this PR | after |
|---|---|---|
| `survived` | 37 | **29** |
| `caught` | 199 | 205 |
| score | 94% killed | **96% killed** |

Across the whole deletions effort: **75 → 37 → 29**.

Every one of the 29 that remain now has an evidence-backed reason, so the residue is closed rather than merely smaller.

## Tests added

**`reserve()` clamps to `max_size()`** (2736). Without it a caller asking for more than the table could ever index reaches `std::vector::reserve()` with the raw number and gets a `std::length_error` out of a call that should simply have handed them everything there is. `bucket_micro` is what makes this askable at all — on a default map `max_size()` is 2^32, so the *clamped* call still reserves 2^32 pairs and the test would be indistinguishable from the bug. Here the clamp lands on 256.

**Move assignment's recovery** (1961, 1962) — `reset_to_empty()` and the bare `throw;`. The copy-assignment twin was already tested; the move needed more setting up, because a move only reaches the recovery when it can fail at all. With `std::allocator` the whole operation is noexcept, `move_assign_is_nothrow` is true, the `try`/`catch` is not instantiated, and there is nothing to test. It takes a throwing move **and** an allocator that neither propagates on move assignment nor compares equal. That precondition is a `static_assert` in the test rather than an assumption, so it cannot go quietly vacuous.

**The transparent `extract()` overload** (2436, 2438) — nothing was calling it, so its body could be deleted whole. Now returns `compiler` rather than `survived`, which is the proof it is genuinely instantiated.

**`rehash()` shrinks the value container** (2730). Every other rehash test asks about buckets, and the value container is the larger of the two allocations.

**`segmented_vector` self-*move*-assignment** (959). The self-*copy* was tested; the move guards itself separately and has to, since the body it guards would clear the vector and then move its own blocks into itself. Nothing reached it: the table's own `&other != this` means a self-move through a `segmented_map` never gets there, and only a vector used directly can.

**A move assignment frees the blocks it replaces** (966). Every existing move-assign test asks what the target ended up holding — and a target that took the source's blocks without freeing its own answers all of them correctly while leaking every block it had. Counted rather than asserted as a number of blocks, so it does not have to know how many elements fit in one.

## Three things that are not tests

**`rehash`'s clamp cannot be caught by anything** (2726). `calc_shifts_for_size()` saturates at `max_bucket_count()`, so it answers identically with and without `count = min(count, max_size())`. The fix in #192 made it redundant. #198 listed it as the priority item; it is an equivalent mutant.

**Two survivors are already covered — by the sanitizer legs, not by an assertion.** Verified by re-running each under `--meson-arg=-Db_sanitize=address,undefined`:

- `clear_buckets()`'s early `return` (1531) → UBSan: *"null pointer passed as argument 1, which is declared to never be null"* — exactly the UB its comment describes.
- `segmented_vector`'s block-growth `reserve` (855) → ASan: *"12288 byte(s) leaked in 3 allocation(s)"* — exactly the leak its comment describes.

Both are load-bearing and both are tested; the tool simply cannot see it without a sanitizer, which is the caveat #198 ends with.

**#198 got a premise wrong, and it is corrected in the issue.** It says `bucket_count()` derives from `m_bucket_mask`; it returns `m_buckets.size()`. The whole bucket-lifecycle group was triaged on that.

## What is left, and why

All 29 remaining survivors, accounted for:

- **6 unkillable by construction** — `~table() = default`, the two `PREFETCH` hints, `operator==`'s self-comparison fast path, the `static_assert` error branch, and `char8_t` (verified `compiler` under C++20).
- **6 performance statements** — `reserve` before an append loop, `shrink_to_fit`. Deleting one is correct but slower; no assertion can catch that.
- **6 bucket-field resets** (1434–1436, 1450–1451, 1521) — every path that reaches them either already holds that value or overwrites it before anything reads it. These survive **ASan+UBSan** too, which is what moves them from "untested" to "unobservable".
- **4 defensive clears after a move** (1398, 1902, 1903, 2080) — every container this library ships leaves a moved-from source empty, so these guard a conforming container that does not. Not dead, not reachable.
- **3 `if constexpr` branches nothing instantiates** (1578, 1939, and 1625). The first two are the `else` of `HAS_EXCEPTIONS()`, and the suite cannot be built `-fno-exceptions` — doctest itself needs them, which I checked rather than assumed. 1625's `else` only ever runs with a callback that does nothing, for every one of its six call sites.
- **2 provably equivalent** — `rehash`'s clamp, and the `break` at 2126 whose `bucket_idx` and `dist_and_fingerprint` are unread on that path.

599 test cases pass, clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)