### PR TITLE
Add a valgrind CI leg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,18 +284,41 @@ jobs:
           # in a deliberate order -- see allocate_buckets_from_shift -- so "has that field been
           # written yet" is a real question to be able to ask.
           #
-          # debugoptimized is what makes it cheap, and is the whole reason this needs no sharding:
-          # the same suite takes 20 seconds under valgrind optimised against just over two minutes
-          # at -O0. The timeout multiplier is because meson's default is 30 seconds per test and
-          # this is one test containing all of them.
-          - name: Linux Valgrind (gcc, C++17, 64bit)
-            id: linux-valgrind
+          # debugoptimized is what makes it affordable at all: the suite takes 20 seconds under
+          # valgrind optimised against just over two minutes at -O0. The timeout multiplier is
+          # because meson's default is 30 seconds per test and this project has one test()
+          # containing all 599 cases -- which is also why `meson test --slice` cannot split it and
+          # the split below is a doctest filter instead.
+          #
+          # Split in two because unsharded this was the slowest job in the whole matrix, 145s
+          # against 99s for the next one, so it set the wall clock for all of CI on its own.
+          # Replaying the fuzz corpora is 73% of the run and fuzz_api alone is half of that, so
+          # one shard is that single case and the other is everything else: 9s and 12s rather
+          # than 20s. It is the best two-way split available, because a test case cannot be
+          # divided and fuzz_api is the floor for any number of shards.
+          #
+          # Written as one name and its complement so it stays correct without being maintained:
+          # a fuzz target added later lands in the second shard rather than in neither.
+          - name: Linux Valgrind (gcc, fuzz_api)
+            id: linux-valgrind-fuzz-api
             os: ubuntu-latest
             cxx: g++
             apt: libboost-dev valgrind
             setup_args: --buildtype=debugoptimized
             test_args: >-
               --timeout-multiplier 20
+              --test-args=-tc=fuzz_api
+              --wrap='valgrind --error-exitcode=1 --leak-check=full
+              --errors-for-leak-kinds=definite -q'
+          - name: Linux Valgrind (gcc, everything else)
+            id: linux-valgrind-rest
+            os: ubuntu-latest
+            cxx: g++
+            apt: libboost-dev valgrind
+            setup_args: --buildtype=debugoptimized
+            test_args: >-
+              --timeout-multiplier 20
+              --test-args=-tce=fuzz_api
               --wrap='valgrind --error-exitcode=1 --leak-check=full
               --errors-for-leak-kinds=definite -q'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,41 +284,25 @@ jobs:
           # in a deliberate order -- see allocate_buckets_from_shift -- so "has that field been
           # written yet" is a real question to be able to ask.
           #
-          # debugoptimized is what makes it affordable at all: the suite takes 20 seconds under
-          # valgrind optimised against just over two minutes at -O0. The timeout multiplier is
-          # because meson's default is 30 seconds per test and this project has one test()
-          # containing all 599 cases -- which is also why `meson test --slice` cannot split it and
-          # the split below is a doctest filter instead.
+          # debugoptimized is what makes it affordable: the suite takes 20 seconds under valgrind
+          # optimised against just over two minutes at -O0. The timeout multiplier is because
+          # meson's default is 30 seconds per test and this project has one test() containing all
+          # 599 cases.
           #
-          # Split in two because unsharded this was the slowest job in the whole matrix, 145s
-          # against 99s for the next one, so it set the wall clock for all of CI on its own.
-          # Replaying the fuzz corpora is 73% of the run and fuzz_api alone is half of that, so
-          # one shard is that single case and the other is everything else: 9s and 12s rather
-          # than 20s. It is the best two-way split available, because a test case cannot be
-          # divided and fuzz_api is the floor for any number of shards.
-          #
-          # Written as one name and its complement so it stays correct without being maintained:
-          # a fuzz target added later lands in the second shard rather than in neither.
-          - name: Linux Valgrind (gcc, fuzz_api)
-            id: linux-valgrind-fuzz-api
+          # Deliberately not sharded, and worth writing down because the job's total time invites
+          # it. `meson test` builds before it tests, so the single step below is compile plus run,
+          # and on the cold ccache any new leg starts with, the compile is the large majority of
+          # it. Measured by actually splitting it: the shard running one test case took 127s and
+          # the shard running the other 598 took 128s. Sharding a job whose cost is the build buys
+          # nothing and pays for a second cold cache.
+          - name: Linux Valgrind (gcc, C++17, 64bit)
+            id: linux-valgrind
             os: ubuntu-latest
             cxx: g++
             apt: libboost-dev valgrind
             setup_args: --buildtype=debugoptimized
             test_args: >-
               --timeout-multiplier 20
-              --test-args=-tc=fuzz_api
-              --wrap='valgrind --error-exitcode=1 --leak-check=full
-              --errors-for-leak-kinds=definite -q'
-          - name: Linux Valgrind (gcc, everything else)
-            id: linux-valgrind-rest
-            os: ubuntu-latest
-            cxx: g++
-            apt: libboost-dev valgrind
-            setup_args: --buildtype=debugoptimized
-            test_args: >-
-              --timeout-multiplier 20
-              --test-args=-tce=fuzz_api
               --wrap='valgrind --error-exitcode=1 --leak-check=full
               --errors-for-leak-kinds=definite -q'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -272,6 +272,32 @@ jobs:
               -fstack-protector-strong -fstack-clash-protection -fcf-protection=full
               -Wformat -Wformat-security -Werror=format-security"
               -Dcpp_link_args="-Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack"
+
+          # The one class of bug the sanitizer legs cannot see: a read of memory that was never
+          # written. ASan reports out-of-bounds and use-after-free, UBSan reports the language-level
+          # UB, and neither says a word about an uninitialised read -- that is MemorySanitizer,
+          # which needs the whole standard library rebuilt instrumented to be usable at all, which
+          # is why nobody runs it. Valgrind gets it for free.
+          #
+          # Worth having for this container in particular: the buckets are memset rather than
+          # constructed, and m_shifts, m_bucket_mask and m_max_bucket_capacity are written by hand
+          # in a deliberate order -- see allocate_buckets_from_shift -- so "has that field been
+          # written yet" is a real question to be able to ask.
+          #
+          # debugoptimized is what makes it cheap, and is the whole reason this needs no sharding:
+          # the same suite takes 20 seconds under valgrind optimised against just over two minutes
+          # at -O0. The timeout multiplier is because meson's default is 30 seconds per test and
+          # this is one test containing all of them.
+          - name: Linux Valgrind (gcc, C++17, 64bit)
+            id: linux-valgrind
+            os: ubuntu-latest
+            cxx: g++
+            apt: libboost-dev valgrind
+            setup_args: --buildtype=debugoptimized
+            test_args: >-
+              --timeout-multiplier 20
+              --wrap='valgrind --error-exitcode=1 --leak-check=full
+              --errors-for-leak-kinds=definite -q'
     steps:
       - uses: actions/checkout@v7
       - uses: hendrikmuhs/ccache-action@v1.2
@@ -302,7 +328,7 @@ jobs:
       - run: meson setup builddir --force-fallback-for=fmt -Dcpp_std=c++${{ matrix.cpp_std || '17' }} ${{ matrix.setup_args }}
         env:
           CXX: ${{ matrix.ccache_variant || 'ccache' }} ${{ matrix.cxx }}
-      - run: meson test -C builddir --print-errorlogs
+      - run: meson test -C builddir --print-errorlogs ${{ matrix.test_args }}
         env:
           ASAN_OPTIONS: ${{ matrix.asan_options }}
           UBSAN_OPTIONS: ${{ matrix.ubsan_options }}


### PR DESCRIPTION
Adds one matrix entry: `Linux Valgrind (gcc, C++17, 64bit)`.

## What it buys that the existing legs do not

A read of memory that was **never written**. The sanitizer legs do not cover this and cannot:

| tool | finds | already here |
|---|---|---|
| ASan | out-of-bounds, use-after-free, leaks | yes |
| UBSan | language-level UB — it is what catches the `memset(nullptr)` guard in `clear_buckets()` | yes |
| MSan | **uninitialised reads** | no, and impractical: it needs the whole standard library rebuilt instrumented |
| **valgrind** | **uninitialised reads**, plus leaks | **this PR** |

That gap is worth closing for this container in particular. Buckets are `memset` rather than constructed, and `m_shifts` / `m_bucket_mask` / `m_max_bucket_capacity` are written by hand in an order chosen so nothing describing the bucket array is published before the array exists — see the comment in `allocate_buckets_from_shift`. "Has that field been written yet" is a real question to be able to ask.

## It finds nothing today, and that is the expected result

Running it against the current tree, with flags stricter than the leg uses:

```
in use at exit: 0 bytes in 0 blocks
ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

The code already passes ASan, UBSan, TSan and four fuzzers, so anything in the overlapping categories was gone before this leg existed. The only category where valgrind could have found something new is uninitialised reads, and there are none. **The value is prospective** — it is a ratchet, not a discovery, and it can only go red on a *new* uninitialised read or leak.

## Verified in both directions

A leg that cannot fail is worth nothing:

- **Passes clean** — 599 cases, 5.38M assertions, running the exact command the workflow runs.
- **Goes red on a real fault** — with an uninitialised read planted behind a `[[gnu::noinline]]` call, valgrind reports `Conditional jump or move depends on uninitialised value(s)` and meson reports `Fail: 1`.

Worth noting from the second check: the *obvious* spelling of an uninitialised read is rejected at compile time by `-Werror=uninitialized`, so the plant had to be opaque enough to get past the compiler. That is itself a small argument for the leg — the easy cases are already caught, so what is left for a runtime tool is exactly what the compiler cannot see.

## Not sharded, and that was measured rather than assumed

The job's total time invites sharding, and the history here is worth keeping because the obvious reading is wrong.

`meson test` builds before it tests, so the single step is compile **plus** run — and a brand-new leg starts with an empty ccache, because the key is the matrix id. So the first run's 145s was mostly a cold compile of ~90 translation units, not valgrind.

I shipped a two-way split to find out, and the result settles it:

| shard | test cases | step time |
|---|---|---|
| `fuzz_api` | **1** | 127s |
| everything else | **598** | 128s |

One second apart. The run is the small remainder; the build is the job. Sharding it buys nothing and pays for a second cold cache — the two shards came to 161s and 156s against 145s for the single leg they replaced. Reverted, with the measurement left in the workflow comment so the next person to think "shard it" finds out it was already tried.

## Risk

The one thing I could not test locally was the runner's valgrind against the runner's glibc, where a mismatch sometimes produces false positives in optimised libc string routines. CI has now run it — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)