### PR TITLE
bump version to 4.9.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 cmake_minimum_required(VERSION ${CMAKEVER})
 project("unordered_dense"
-    VERSION 4.9.1
+    VERSION 4.9.2
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense"
     LANGUAGES CXX)

--- a/include/ankerl/stl.h
+++ b/include/ankerl/stl.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 4.9.1
+// Version 4.9.2
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 4.9.1
+// Version 4.9.2
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
@@ -32,7 +32,7 @@
 // see https://semver.org/spec/v2.0.0.html
 #define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 4 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
 #define ANKERL_UNORDERED_DENSE_VERSION_MINOR 9 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
-#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 1 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
+#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 2 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
 
 // API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '4.9.1',
+    version: '4.9.2',
     license: 'MIT',
     default_options : [
         'cpp_std=c++17', 

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -1,7 +1,7 @@
 #include <ankerl/unordered_dense.h>
 #include <app/doctest.h>
 
-namespace versioned_namespace = ankerl::unordered_dense::v4_9_1;
+namespace versioned_namespace = ankerl::unordered_dense::v4_9_2;
 
 static_assert(std::is_same_v<versioned_namespace::map<int, int>, ankerl::unordered_dense::map<int, int>>);
 static_assert(std::is_same_v<versioned_namespace::hash<int>, ankerl::unordered_dense::hash<int>>);


### PR DESCRIPTION
Patch release. Two bug fixes in the header since v4.9.1, no API changes.

## What is in it

**A size at the limit produced an unusable table** (#192, `52f64e9`) — two independent faults, both at `max_size()`:

- `calc_shifts_for_size()` walked the shift down past the point where the bucket array can still grow. `calc_num_buckets()` saturates at `max_bucket_count()`, so above `max_bucket_count() * max_load_factor()` the capacity being compared stopped growing while the loop kept decrementing — all the way to a shift of zero, where `calc_num_buckets()` asks for `1 << 64`. That is undefined and in practice one: a table sized for billions of elements came back with a **single bucket and a mask of zero**, and the next probe read past the end of it. Reachable from `rehash()`, which does not allocate the values and so has nothing to fail first — `map<uint32_t, uint32_t>::rehash(3865470566)` reproduced it.
- `replace()` and `clear_and_fill_buckets_from_values()` counted in `value_idx_type`. `max_size()` is exactly what that type can hold, so a container of precisely that many has a size that is not representable in it: the cast wrapped to zero, the loop never ran, and the table came back reporting `size()` elements with **no bucket pointing at any of them**.

**Two static_asserts on the bucket type.** The fingerprint must fit strictly below `dist_inc`, and `dist_inc` must be a power of two. Both were always required — the probe arithmetic adds `dist_inc` expecting it to touch only the distance — but nothing said so, and a custom `Bucket` violating either failed at run time in ways that looked like a hashing bug. Only affects code supplying its own bucket type, and only where it was already broken.

Everything else since v4.9.1 is tests, tooling and CI, which does not reach anyone consuming the header.

## Version

Patch rather than minor: no API is added or changed. The static_asserts can newly reject a user-provided `Bucket`, but only one that never worked.

Bumped in all five places `scripts/lint/lint-version.py` checks — the header's `VERSION_PATCH` macro and its comment, `stl.h`, `CMakeLists.txt`, `meson.build`, and the versioned inline namespace asserted by `test/unit/namespace.cpp`. `lint-version.py --expect 4.9.2` passes, which is the same check `release.yml` runs against the tag.

Tag goes on this commit once it is on main.