### PR TITLE
Probe four buckets at once with SSE2, and stop replaying lookups in the quick bench

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,39 +41,18 @@ Benchmarking practices:
 
 - Always benchmark a `--buildtype release` build (never debug).
 - Record a baseline score on the unmodified code first, then compare after each change. Run each measurement 2–3 times; treat differences within run-to-run noise (~1–2%) as no change.
-- Don't compare runs made at different times — even a desktop drifts by a few percent over minutes. `scripts/ab/run.sh` (see below) runs baseline and candidate interleaved in one process and reports a confidence interval for the ratio; believe a change when the interval excludes 100%.
+- Don't compare runs made at different times — even a desktop drifts by a few percent over minutes. `scripts/ab/run.sh` runs baseline (any git revision) and candidate (the working tree) interleaved in one process, on the benchmark's own workloads, and reports a confidence interval for the ratio; believe a change when the interval excludes 100%.
 - Beware code-layout luck: any edit (even to never-executed code) can shift alignment and move individual sub-benchmarks by ±3%. Judge micro-optimizations by mechanism plus a focused microbenchmark, and confirm on the paired geomean, not on a single sub-benchmark delta.
 - nanobench prints per-benchmark `err%`; rerun if it's high (> ~3%). A warning about CPU governor/turbo is normal on non-tuned machines — it just means more noise.
 - Other useful benchmarks in `test/bench/` (e.g. `bench_copy`, `bench_game_of_life`, find variants) can be run the same way via `-tc=<name>`; run all with `-ns -ts=bench`. List all test cases with `-ltc`.
 
-## Where the time goes (measured 2026-09 on a Ryzen 9 7950X, clang 22, default `-march`)
+## Where the time goes
 
-The cost model that predicted every experiment within a cycle or two: **cycles per operation ≈
-16 × branch mispredictions + instructions / ~3.5**. The hot loops are front-end bound between
-mispredictions, so both terms matter and nothing else does -- the whole working set of the
-benchmark sits in L2.
-
-- **u64 lookups are bounded by branch mispredictions.** The scalar probe branched once per
-  bucket, so the *position* of a hit leaked into the branch pattern. The SSE2 probe (four
-  buckets per step, lowest deciding lane via `ctz`) makes the outcome one data-dependent branch
-  regardless of position. On lookups whose hit/miss sequence is random that is worth 35-80% on
-  u64 keys. The old, replayed find of `bench_quick_overall_udm` showed only ~6% (see below).
-- **String workloads are latency bound.** At ~250 instructions per lookup -- ~150 of them the
-  200 byte wyhash -- the reorder buffer holds barely one lookup, so anything on the dependency
-  chain shows directly. The vector decision (`movmskps` → `tzcnt` → index load) adds ~10 cycles
-  before the value load can issue where the scalar path's predicted branch let it issue at
-  once. That is the -4% of `findstr` under clang; gcc shows +7% instead. Random string lookups
-  win 5-12% either way.
-- **Hashing is 42-45% of the string workloads**, at ~40 cycles per 200 byte key: 0.5 uops per
-  byte, nothing to do with multiply count. With a trivial 8 byte hash, insert/erase time equals
-  boost's exactly -- the rest of the gap there is that a robin hood erase hashes the moved last
-  element too.
-
-Paired measurements: `scripts/ab/run.sh` builds the working-tree header against any revision of
-itself (renamed into a second namespace) and optionally `boost::unordered_flat_map`, and runs
-the vendored nanobench's `compare()` (4.6, `test/third-party/nanobench.h`) -- interleaved, with a confidence interval on the *ratio*, which is what
-makes a 2% change believable on a desktop that drifts by more than that. It also has all-hits
-and no-hits lookup workloads (`rhit64`, `rmiss64`, and the `str` variants).
+The u64 workloads are bound by branch mispredictions, the string workloads by the latency of a
+~250 instruction lookup of which the 200 byte hash is ~150, and a model of 16 cycles per
+misprediction plus instructions at ~3.5 per cycle predicts changes within a cycle or two. The
+measurements behind that, and the per-workload numbers, are in `scripts/ab/README.md` with the
+paired A/B harness that produced them.
 
 **Lookup benchmarks must not replay.** Until 2026-09 the find workload of
 `bench_quick_overall_udm` reset its search rng to the insertion rng's seed, so its sequence of hits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,19 +41,68 @@ Benchmarking practices:
 
 - Always benchmark a `--buildtype release` build (never debug).
 - Record a baseline score on the unmodified code first, then compare after each change. Run each measurement 2–3 times; treat differences within run-to-run noise (~1–2%) as no change.
-- On noisy/shared machines, don't compare runs made at different times — the machine can drift by >10% over minutes. Instead keep a baseline binary around (copy `udm-test` elsewhere before rebuilding) and run baseline and candidate **interleaved** (A B A B A B), then compare paired runs. A change is real when it wins in (almost) every pair.
+- Don't compare runs made at different times — even a desktop drifts by a few percent over minutes. `scripts/ab/run.sh` (see below) runs baseline and candidate interleaved in one process and reports a confidence interval for the ratio; believe a change when the interval excludes 100%.
 - Beware code-layout luck: any edit (even to never-executed code) can shift alignment and move individual sub-benchmarks by ±3%. Judge micro-optimizations by mechanism plus a focused microbenchmark, and confirm on the paired geomean, not on a single sub-benchmark delta.
 - nanobench prints per-benchmark `err%`; rerun if it's high (> ~3%). A warning about CPU governor/turbo is normal on non-tuned machines — it just means more noise.
 - Other useful benchmarks in `test/bench/` (e.g. `bench_copy`, `bench_game_of_life`, find variants) can be run the same way via `-tc=<name>`; run all with `-ns -ts=bench`. List all test cases with `-ltc`.
 
-## Optimization dead ends (verified with interleaved A/B runs; re-test before assuming they still hold)
+## Where the time goes (measured 2026-09 on a Ryzen 9 7950X, clang 22, default `-march`)
 
-Measured on a shared x86-64 VM with clang 18, default `-march` (baseline x86-64, so no BMI2/AVX2 in generated code). The `bench_quick_overall_udm` hot paths are close to machine limits: a lookup is hash + two dependent cache accesses (~10 ns map-side), and hashing the 200-byte string keys (~42 cycles each) is ~45% of the wall time of the string sub-benchmarks. Ideas that consistently **regressed** and were reverted:
+The cost model that predicted every experiment within a cycle or two: **cycles per operation ≈
+16 × branch mispredictions + instructions / ~3.5**. The hot loops are front-end bound between
+mispredictions, so both terms matter and nothing else does -- the whole working set of the
+benchmark sits in L2.
+
+- **u64 lookups are bounded by branch mispredictions.** The scalar probe branched once per
+  bucket, so the *position* of a hit leaked into the branch pattern. The SSE2 probe (four
+  buckets per step, lowest deciding lane via `ctz`) makes the outcome one data-dependent branch
+  regardless of position. On lookups whose hit/miss sequence is random that is worth 35-80% on
+  u64 keys. The old, replayed find of `bench_quick_overall_udm` showed only ~6% (see below).
+- **String workloads are latency bound.** At ~250 instructions per lookup -- ~150 of them the
+  200 byte wyhash -- the reorder buffer holds barely one lookup, so anything on the dependency
+  chain shows directly. The vector decision (`movmskps` → `tzcnt` → index load) adds ~10 cycles
+  before the value load can issue where the scalar path's predicted branch let it issue at
+  once. That is the -4% of `findstr` under clang; gcc shows +7% instead. Random string lookups
+  win 5-12% either way.
+- **Hashing is 42-45% of the string workloads**, at ~40 cycles per 200 byte key: 0.5 uops per
+  byte, nothing to do with multiply count. With a trivial 8 byte hash, insert/erase time equals
+  boost's exactly -- the rest of the gap there is that a robin hood erase hashes the moved last
+  element too.
+
+Paired measurements: `scripts/ab/run.sh` builds the working-tree header against any revision of
+itself (renamed into a second namespace) and optionally `boost::unordered_flat_map`, and runs
+nanobench's `compare()` -- interleaved, with a confidence interval on the *ratio*, which is what
+makes a 2% change believable on a desktop that drifts by more than that. It also has all-hits
+and no-hits lookup workloads (`rhit64`, `rmiss64`, and the `str` variants).
+
+**Lookup benchmarks must not replay.** Until 2026-09 the find workload of
+`bench_quick_overall_udm` reset its search rng to the insertion rng's seed, so its sequence of hits
+and misses repeated and a TAGE-style predictor learned much of it: 0.6 mispredictions per lookup
+where a random sequence costs the scalar probe 1.35. That under-reported the cost of branchy
+probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The workload now
+decides every lookup with an rng of its own. `find_random.cpp` still replays.
+
+## Optimization dead ends (verified with paired A/B runs; re-test before assuming they still hold)
+
+The `bench_quick_overall_udm` hot paths are close to machine limits. Ideas that consistently
+**regressed** and were reverted:
 
 - Force-inlining `wyhash::hash` into the map (icache/register pressure outweighs saved call overhead).
 - A branchless `do_find` fast path for scalar keys (unconditional key compare + conditional-move result): the speculative value load doubles cache misses on the ~50% miss lookups.
 - Explicit `__builtin_prefetch` of `m_values[bucket->m_value_idx]` in `do_find`, and computing the moved element's hash early + prefetching its home bucket in `do_erase`: out-of-order execution already hides these latencies.
 - Replacing wyhash with rapidhash (v3, 2025): the wyhash implementation here is *faster* for inputs ≥ 24 bytes in both latency and throughput; rapidhash only won at ≤ 16 bytes, and that trick (two plain 8-byte reads instead of building `a`/`b` from four 4-byte reads) has been adopted.
+- An AES-NI hash (a port of gxhash, compiled with `-maes`, no dispatch): 30% *slower* than this
+  wyhash on 200 byte keys and 27-55% slower in the map. Its serial `aesenc` chain has worse latency,
+  and latency is what the string loop pays for. Fewer uops do not help a chain.
+- SIMD probe variants: an *aligned* group of four (1-4 lanes visible from home) left the "nothing
+  decided, next group" branch random and won nothing; deciding hit-vs-miss with two branches
+  (scalar home probe, then the vector for the rest) mispredicted *more* than one vector decision
+  (0.90 vs 0.70 per lookup) although each branch is more biased; keeping the key comparison inside
+  the vector loop made the compiler spill the xmm state around `bcmp` on every string hit.
+- Storing the top 32 hash bits per value so an erase never re-hashes the moved element: only the
+  successful half of the erases move one, so the bound is ~7% of `iestr`, and it measured 1.4%
+  for 4 bytes per element and a second container to keep consistent.
+- Caching the bucket data pointer in the shift loops (the compiler already hoists it).
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ benchmark sits in L2.
 
 Paired measurements: `scripts/ab/run.sh` builds the working-tree header against any revision of
 itself (renamed into a second namespace) and optionally `boost::unordered_flat_map`, and runs
-nanobench's `compare()` -- interleaved, with a confidence interval on the *ratio*, which is what
+the vendored nanobench's `compare()` (4.6, `test/third-party/nanobench.h`) -- interleaved, with a confidence interval on the *ratio*, which is what
 makes a 2% change believable on a desktop that drifts by more than that. It also has all-hits
 and no-hits lookup workloads (`rhit64`, `rmiss64`, and the `str` variants).
 

--- a/handoff/2026-09-02_1200-simd-probe.md
+++ b/handoff/2026-09-02_1200-simd-probe.md
@@ -1,0 +1,79 @@
+# Session Handoff — 2026-09-02 12:00
+
+## Resume prompt
+Paste this into a fresh session:
+> Read `handoff/2026-09-02_1200-simd-probe.md`. The SSE2 probe is on a branch with a PR; decide with
+> the user whether to merge as is, and continue with the "untried" list if there is appetite.
+
+## Goal
+Deep analysis of where `ankerl::unordered_dense::map` still loses to `boost::unordered_flat_map`, and
+whether SIMD-style probing can close it. Measured on the user's desktop (Ryzen 9 7950X, clang 22,
+gcc 16, boost 1.90, `perf` available) with nanobench 4.6's paired `compare()` from the sibling
+checkout `/home/martinus/gra/nanobench/calmcake`.
+
+## State
+- Branch: `claude/simd-probe` (see the PR). Working tree = the branch.
+- Changes: `include/ankerl/unordered_dense.h` (the SSE2 probe, padded bucket array, shared
+  `probe()` for find/insert/erase, vector erase-fixup scan), `test/unit/probe_wrap.cpp` (forces
+  the wrap-around paths; found by the mutation sweep), `scripts/ab/` (paired A/B harness),
+  `test/bench/quick_overall_map.cpp` (the find workload no longer replays), `CLAUDE.md`
+  (cost model, dead ends, benchmark caveat).
+- Verified: 599/599 unit tests under clang and gcc, ASan+UBSan build green, gcc `-Werror` clean,
+  lint clean on the touched lines (this machine's clang-tidy 22 also flags pre-existing code that
+  the pinned clang-tidy 18 in CI does not). Mutation sweep of the diff: 179 mutants; the wrap
+  paths survived until `probe_wrap.cpp`, after which a targeted run over them left only
+  equivalent mutants (advance-by-fewer variants and the guard for distances beyond 2^23).
+
+## What was found (the numbers that matter)
+
+**`bench_quick_overall_udm`'s find workload was a replay** (search rng reset to the insertion
+seed), and a TAGE-style predictor learned half of its hit/miss outcomes: 0.60 mispredicts per
+lookup for the scalar probe where a random sequence costs 1.35. At the user's request the workload
+now decides every lookup with an rng of its own (random existing key or a key that cannot exist),
+still against a map growing to ~50k. Scores before this change are not comparable with scores
+after it. `find_random.cpp` still replays; not touched.
+
+Paired A/B (nanobench compare(), clang, ms; base = main, same workloads):
+
+| workload | base | cand | boost | note |
+|---|---|---|---|---|
+| find64 (new, non-replayed) | 78.6 | 48.0 | 40.1 | **+64%** |
+| findstr (new) | 218 | 210 | 182 | +4% |
+| find64 (old, replayed) | 61.4 | 57.9 | 51.6 | +6%; -4.5% on the old findstr |
+| ie64 | 62.0 | 65.3 | 57.1 | -5%: ~20 more instructions per op |
+| iestr | 226 | 212 | 188 | +6% |
+| rhit64 / rmiss64 (all hits / no hits) | 145 / 48 | 80 / 35 | 50 / 28 | +82% / +35% |
+
+gcc (old find): find64 +6.5%, findstr +7%, ie64 -6%, iestr +19%, rhit64 +57%.
+Official `bench_quick_overall_udm` with the new find, clang: main 0.0416, branch 0.0378-0.0380 (9% better).
+
+The cost model that fit every experiment: cycles/op ≈ 16 × mispredicts + instructions / 3.5.
+The u64 loops are mispredict bound; the string loops are *latency* bound (250 instructions per
+lookup, 150 of them the hash, so the ROB holds ~1 lookup).
+
+## Rejected this session (all in CLAUDE.md's dead-end list with the reason)
+Aligned 4-groups; hybrid scalar-home-then-vector (more mispredicts, 0.90 vs 0.70); key compare inside
+the vector loop (xmm spills around bcmp); gxhash/AES-NI (30% slower: latency); storing top 32 hash
+bits per value to skip the erase re-hash (bound 7%, measured 1.4%); caching the bucket pointer in the
+shift loops (no effect).
+
+## Untried ideas
+1. **ie64's -5%** is ~20 extra instructions per op. The vector probe's irreducible core is ~16
+   instructions; the scalar probe's first bucket is 3. An 8-lane AVX2 window would not help (same
+   tax). What might: vectorising `place_and_shift_up` / `erase_and_shift_down` (they still carry
+   ~0.15 mispredicts per op from their data-dependent trip counts; boost has no shifting at all).
+2. **findstr's -4.5% under clang** is the ~10 cycle vector decision on the hit path of a
+   latency-bound loop. Only a shorter hash chain buys that back: the 6-lane wyhash is ~25 cycles
+   latency for 200 bytes; 12 independent lanes with a tree fold would be ~15 but needs register
+   pressure care and SMHasher validation.
+3. A boost-style layout (1 byte metadata per slot, 15-slot groups, overflow byte, no robin hood):
+   the only way to boost's 0.42 mispredicts *and* 52 instructions per lookup. A rewrite of the
+   table's core; expect find64 -15%, ie64 -10%, strings unchanged.
+4. Runtime AVX2 dispatch is not worth it for the probe (same instruction tax); for the hash, AES was
+   a dead end and a pmuludq/VPMULUDQ design would need its own SMHasher run.
+
+## Tools
+- `scripts/ab/run.sh -b <workload|all> [epochs]` with `NANOBENCH_INCLUDE=/home/martinus/gra/nanobench/calmcake/src/include`.
+- `perf stat -e cycles,instructions,branch-misses` on a single-workload runner is what separated
+  "more instructions" from "more mispredicts"; `perf record -e cycles:pp` for annotate. The scratch
+  harness with more variants is in `/tmp/udm-ab/` (not preserved).

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1930,11 +1930,15 @@ private:
     template <typename K>
     auto probe(K const& key, std::uint64_t mh) const -> probe_result {
 #    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+        // An else, so that the scalar call is not merely never reached but not there at all: MSVC
+        // warns about code it can prove unreachable, and this build treats warnings as errors.
         if constexpr (has_simd_scan) {
             return probe_simd(key, mh);
-        }
+        } else
 #    endif
-        return probe_scalar(key, dist_and_fingerprint_from_hash(mh), bucket_idx_from_hash(mh));
+        {
+            return probe_scalar(key, dist_and_fingerprint_from_hash(mh), bucket_idx_from_hash(mh));
+        }
     }
 
     // Same lookup with the hashing already done. Requires the bucket array to be allocated, which

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -77,16 +77,15 @@
 #    define ANKERL_UNORDERED_DENSE_PREFETCH(addr) static_cast<void>(addr) // NOLINT(cppcoreguidelines-macro-usage)
 #endif
 
-// SSE2 is part of the x86-64 baseline, so the four-buckets-at-a-time probe below is available on
-// every x86-64 build without asking for it. Elsewhere the scalar probe is used.
-#if defined(__SSE2__) || (defined(_MSC_VER) && (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)))
-#    define ANKERL_UNORDERED_DENSE_HAS_SSE2 1 // NOLINT(cppcoreguidelines-macro-usage)
-#    include <emmintrin.h>
-#    if defined(_MSC_VER)
-#        include <intrin.h>
+// SSE2 is part of the x86-64 baseline, so the four-buckets-at-a-time probe is available on every
+// x86-64 build without asking for it. Elsewhere, and in a build that defines this to 0, the scalar
+// probe is used.
+#if !defined(ANKERL_UNORDERED_DENSE_HAS_SSE2)
+#    if defined(__SSE2__) || (defined(_MSC_VER) && (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)))
+#        define ANKERL_UNORDERED_DENSE_HAS_SSE2 1 // NOLINT(cppcoreguidelines-macro-usage)
+#    else
+#        define ANKERL_UNORDERED_DENSE_HAS_SSE2 0 // NOLINT(cppcoreguidelines-macro-usage)
 #    endif
-#else
-#    define ANKERL_UNORDERED_DENSE_HAS_SSE2 0 // NOLINT(cppcoreguidelines-macro-usage)
 #endif
 
 #if defined(__clang__) && defined(__has_attribute)
@@ -111,6 +110,12 @@
 
 #    if !ANKERL_UNORDERED_DENSE_STD_MODULE
 #        include "stl.h"
+#    endif
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+#        include <emmintrin.h> // for _mm_loadu_si128, _mm_cmpeq_epi32, ...
+#        if defined(_MSC_VER)
+#            include <intrin.h> // for _BitScanForward
+#        endif
 #    endif
 
 #    if __has_cpp_attribute(likely) && __has_cpp_attribute(unlikely) && ANKERL_UNORDERED_DENSE_CPP_VERSION >= 202002L
@@ -165,24 +170,22 @@ namespace detail {
 
 #    endif
 
-} // namespace detail
-
-// hash ///////////////////////////////////////////////////////////////////////
-
-namespace detail {
-
-// Index of the lowest set bit. x must not be zero.
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+// Index of the lowest set bit, for the lane masks of the vector probe. x must not be zero.
 [[nodiscard]] inline auto countr_zero(std::uint32_t x) -> unsigned {
-#    if defined(_MSC_VER)
+#        if defined(_MSC_VER)
     unsigned long idx{};
     _BitScanForward(&idx, x);
     return static_cast<unsigned>(idx);
-#    else
+#        else
     return static_cast<unsigned>(__builtin_ctz(x));
-#    endif
+#        endif
 }
+#    endif
 
 } // namespace detail
+
+// hash ///////////////////////////////////////////////////////////////////////
 
 // This is a stripped-down implementation of wyhash: https://github.com/wangyi-fudan/wyhash
 // No big-endian support (because different values on different machines don't matter),
@@ -1176,19 +1179,22 @@ private:
     static constexpr std::uint8_t initial_shifts = 64 - 2; // 2^(64-m_shift) number of buckets
     static constexpr float default_max_load_factor = 0.8F;
 
-    // The probe can read four buckets at once where the bucket array is contiguous -- the default
-    // container, a std::vector -- and the bucket is the standard 8 byte one, on a platform with SSE2.
-    static constexpr bool has_simd_scan = ANKERL_UNORDERED_DENSE_HAS_SSE2 && !IsSegmented &&
-                                          std::is_same_v<BucketContainer, detail::default_container_t> &&
+    // The default bucket container is a std::vector: one allocation, reached through data().
+    static constexpr bool has_contiguous_buckets =
+        !IsSegmented && std::is_same_v<BucketContainer, detail::default_container_t>;
+
+    // The probe can read four buckets at once where the bucket array is contiguous and the bucket
+    // is the standard 8 byte one, on a platform with SSE2.
+    static constexpr bool has_simd_scan = ANKERL_UNORDERED_DENSE_HAS_SSE2 && has_contiguous_buckets &&
                                           std::is_same_v<Bucket, ankerl::unordered_dense::bucket_type::standard>;
 
     // Four buckets read from any bucket index reach up to three past the end of the array, so the
-    // array carries that many extra. They hold a dist_and_fingerprint no key can expect and no
-    // bucket can hold less than, and the value index of an empty bucket, so a scan passes over
-    // them as it would over occupied buckets that are not the answer -- and the wrap to bucket
-    // zero is taken only where a scan moves on, which is rare. bucket_count() does not count them.
+    // array carries that many extra, written by allocate_buckets_from_shift() and copied along
+    // with the rest. They hold a dist_and_fingerprint no key can expect and no bucket can hold
+    // less than, and a value index no value has, so a scan passes over them as it would over
+    // occupied buckets that are not the answer -- and the wrap to bucket zero is taken only where a
+    // scan moves on, which is rare. bucket_count() does not count them.
     static constexpr std::size_t bucket_padding = has_simd_scan ? 3 : 0;
-    static constexpr std::uint32_t sentinel_dist_and_fingerprint = 0x7FFFFFFFU;
 
     // Named, and covering both containers, so that the promise and the recovery that exists for
     // when the promise cannot be made are spelled the same way and cannot drift apart -- the same
@@ -1223,6 +1229,10 @@ public:
 private:
     using value_idx_type = decltype(Bucket::m_value_idx);
     using dist_and_fingerprint_type = decltype(Bucket::m_dist_and_fingerprint);
+
+    // what the padding buckets hold, see bucket_padding
+    static constexpr auto sentinel_dist_and_fingerprint = static_cast<dist_and_fingerprint_type>(0x7FFFFFFFU);
+    static constexpr auto sentinel_value_idx = (std::numeric_limits<value_idx_type>::max)();
 
     static_assert(std::is_trivially_destructible_v<Bucket>, "assert there's no need to call destructor / std::destroy");
     static_assert(std::is_trivially_copyable_v<Bucket>, "assert we can just memset / memcpy");
@@ -1375,7 +1385,7 @@ private:
             // first insert allocate. Copying an empty table therefore allocates nothing either.
             m_shifts = initial_shifts;
         } else {
-            if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
+            if constexpr (!has_contiguous_buckets) {
                 allocate_buckets_from_shift(other.m_shifts);
                 for (auto i = 0UL; i < bucket_count(); ++i) {
                     at(m_buckets, i) = at(other.m_buckets, i);
@@ -1392,7 +1402,7 @@ private:
                 // exactly wrong.
                 m_buckets.assign(other.m_buckets.begin(), other.m_buckets.end());
                 m_shifts = other.m_shifts;
-                describe_buckets(bucket_count());
+                describe_buckets(other.bucket_count());
             }
         }
     }
@@ -1497,7 +1507,7 @@ private:
     // allocate, which left a gap for a failed allocation to stop in.
     void allocate_buckets_from_shift(std::uint8_t shifts) {
         auto num_buckets = calc_num_buckets(shifts);
-        if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
+        if constexpr (!has_contiguous_buckets) {
             if (num_buckets < m_buckets.size()) {
                 // Shrinking, which rehash does. This used to work because the caller emptied the
                 // array first and the loop below then grew it from nothing; without that it would
@@ -1525,8 +1535,7 @@ private:
             auto fresh = bucket_container_type(m_buckets.get_allocator());
             fresh.resize(num_buckets + bucket_padding);
             for (std::size_t i = 0; i < bucket_padding; ++i) {
-                fresh[num_buckets + i].m_dist_and_fingerprint =
-                    static_cast<dist_and_fingerprint_type>(sentinel_dist_and_fingerprint);
+                fresh[num_buckets + i] = {sentinel_dist_and_fingerprint, sentinel_value_idx};
             }
             m_buckets = std::move(fresh);
         }
@@ -1560,7 +1569,7 @@ private:
     // is the three insert entry points, the only ones that reach the buckets without a prior
     // emptiness check.
     void allocate_buckets_if_none() {
-        if (ANKERL_UNORDERED_DENSE_UNLIKELY(0 == bucket_count()))
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(m_buckets.empty()))
             ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
                 allocate_buckets_from_shift(m_shifts);
                 clear_buckets();
@@ -1572,14 +1581,15 @@ private:
         // out whether or not there are any. data() is null in that state, and memset's pointer has
         // to be valid even for a zero length. Neither sanitizer in CI objects, so this is on the
         // language rule rather than on a diagnostic.
-        if (0 == bucket_count()) {
+        if (m_buckets.empty()) {
             return;
         }
-        if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
+        if constexpr (!has_contiguous_buckets) {
             for (auto&& e : m_buckets) {
                 std::memset(&e, 0, sizeof(e));
             }
         } else {
+            // bucket_count() and not the array size: the sentinels behind it stay
             std::memset(m_buckets.data(), 0, sizeof(Bucket) * bucket_count());
         }
     }
@@ -1635,48 +1645,16 @@ private:
             auto& val = m_values[value_idx_to_remove];
             val = std::move(m_values.back());
 
-            // update the values_idx of the moved entry. No need to play the info game, just look until we find the values_idx
-            auto bucket_idx = bucket_idx_from_hash(mixed_hash(get_key(val)));
+            // update the value index of the moved entry
             auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
-#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
-            // NOLINTBEGIN(portability-simd-intrinsics)
-            if constexpr (has_simd_scan) {
-                // four buckets at a time, matching the value index this time: only one bucket in the
-                // table holds it, so its lane is the answer
-                auto const mask = m_bucket_mask;
-                auto* data = m_buckets.data();
-                auto const wanted = _mm_set1_epi32(static_cast<int>(values_idx_back));
-                while (true) {
-                    auto* gp = data + bucket_idx;
-                    auto lo = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp));     // NOLINT
-                    auto hi = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 2)); // NOLINT
-                    auto v =
-                        _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(3, 1, 3, 1)));
-                    auto eq = static_cast<unsigned>(_mm_movemask_ps(_mm_castsi128_ps(_mm_cmpeq_epi32(v, wanted))));
-                    if (ANKERL_UNORDERED_DENSE_LIKELY(eq != 0)) {
-                        gp[detail::countr_zero(eq)].m_value_idx = value_idx_to_remove;
-                        break;
-                    }
-                    auto lanes = (std::min)(std::size_t{4}, std::size_t{mask} + 1 - bucket_idx);
-                    bucket_idx = static_cast<value_idx_type>((bucket_idx + lanes) & mask);
-                }
-            } else
-            // NOLINTEND(portability-simd-intrinsics)
-#    endif
-            {
-                while (values_idx_back != at(m_buckets, bucket_idx).m_value_idx) {
-                    bucket_idx = next(bucket_idx);
-                }
-                at(m_buckets, bucket_idx).m_value_idx = value_idx_to_remove;
-            }
+            auto const home = bucket_idx_from_hash(mixed_hash(get_key(val)));
+            at(m_buckets, bucket_idx_of_value(home, values_idx_back)).m_value_idx = value_idx_to_remove;
         }
         m_values.pop_back();
     }
 
     template <typename Op>
-    void do_erase(value_idx_type bucket_idx, Op handle_erased_value) {
-        auto const value_idx_to_remove = at(m_buckets, bucket_idx).m_value_idx;
-
+    void do_erase(value_idx_type bucket_idx, value_idx_type value_idx_to_remove, Op handle_erased_value) {
         // both values are needed after the shift down; start fetching them now to overlap the latencies
         ANKERL_UNORDERED_DENSE_PREFETCH(&m_values[value_idx_to_remove]);
         ANKERL_UNORDERED_DENSE_PREFETCH(&m_values.back());
@@ -1710,7 +1688,7 @@ private:
         if (!r.found) {
             return 0;
         }
-        do_erase(r.bucket_idx, handle_erased_value);
+        do_erase(r.bucket_idx, r.value_idx, handle_erased_value);
         return 1;
     }
 
@@ -1767,9 +1745,59 @@ private:
         return do_find_hashed(key, mixed_hash(key));
     }
 
-    // Same lookup with the hashing already done. Requires the bucket array to be allocated, which
-    // !empty() implies; the callers test empty() rather than this function so that a lookup in an
-    // empty table returns without hashing anything.
+    // Where a window of four buckets decided nothing, the next window: four buckets on, or fewer
+    // where the padding was among them -- which is also where the index wraps to zero. Returns how
+    // many buckets were real.
+    auto next_window(value_idx_type& bucket_idx) const -> std::size_t {
+        auto lanes = (std::min)(std::size_t{4}, std::size_t{m_bucket_mask} + 1 - bucket_idx);
+        bucket_idx = static_cast<value_idx_type>((bucket_idx + lanes) & m_bucket_mask);
+        return lanes;
+    }
+
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+    // NOLINTBEGIN(portability-simd-intrinsics) -- this is the x86 path, on purpose
+    // One field of each of the four buckets at gp, in four lanes: field 0 is
+    // m_dist_and_fingerprint, field 1 is m_value_idx.
+    template <int Field>
+    [[nodiscard]] static auto gather(Bucket const* gp) -> __m128i {
+        auto lo = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp));     // NOLINT
+        auto hi = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 2)); // NOLINT
+        return _mm_castps_si128(
+            _mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(2 + Field, Field, 2 + Field, Field)));
+    }
+    // NOLINTEND(portability-simd-intrinsics)
+#    endif
+
+    // The bucket that points at a value, searched from the value's home bucket. Every value has
+    // one, so there is no other stopping condition.
+    [[nodiscard]] auto bucket_idx_of_value(value_idx_type bucket_idx, value_idx_type value_idx) const -> value_idx_type {
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+        // NOLINTBEGIN(portability-simd-intrinsics)
+        if constexpr (has_simd_scan) {
+            // Four at a time, matching the value index: only one bucket in the table holds it, so
+            // its lane is the answer. The sentinels hold the one index a value can have only in a
+            // table at max_size(), which is what the scalar walk below is left with.
+            if (ANKERL_UNORDERED_DENSE_LIKELY(value_idx != sentinel_value_idx)) {
+                auto const* data = m_buckets.data();
+                auto const wanted = _mm_set1_epi32(static_cast<int>(value_idx));
+                while (true) {
+                    auto eq = static_cast<unsigned>(
+                        _mm_movemask_ps(_mm_castsi128_ps(_mm_cmpeq_epi32(gather<1>(data + bucket_idx), wanted))));
+                    if (ANKERL_UNORDERED_DENSE_LIKELY(eq != 0)) {
+                        return static_cast<value_idx_type>(bucket_idx + detail::countr_zero(eq));
+                    }
+                    next_window(bucket_idx);
+                }
+            }
+        }
+        // NOLINTEND(portability-simd-intrinsics)
+#    endif
+        while (value_idx != at(m_buckets, bucket_idx).m_value_idx) {
+            bucket_idx = next(bucket_idx);
+        }
+        return bucket_idx;
+    }
+
     // Where a probe for a key stopped. Found: the bucket holding it, and the value it points to.
     // Not found: the bucket the key would be placed in, and the dist_and_fingerprint it would carry
     // there -- exactly what an insert needs next. dist_and_fingerprint is meaningful only then.
@@ -1811,7 +1839,6 @@ private:
     auto probe_simd(K const& key, std::uint64_t mh) const -> probe_result {
         auto dist_and_fingerprint = dist_and_fingerprint_from_hash(mh);
         auto bucket_idx = bucket_idx_from_hash(mh);
-        auto const mask = m_bucket_mask;
         auto const* data = m_buckets.data();
 
         auto expected = _mm_add_epi32(_mm_set1_epi32(static_cast<int>(dist_and_fingerprint)),
@@ -1823,9 +1850,7 @@ private:
 
         while (true) {
             auto const* gp = data + bucket_idx;
-            auto lo = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp));     // NOLINT
-            auto hi = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 2)); // NOLINT
-            auto d = _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(2, 0, 2, 0)));
+            auto d = gather<0>(gp);
 
             // Two lane masks from the sign bits: bucket - expected is negative where the bucket
             // holds less (both are far below 2^31, so the difference cannot wrap), and a compare
@@ -1854,10 +1879,8 @@ private:
                     static_cast<dist_and_fingerprint_type>(dist_and_fingerprint + ((j + 1) * Bucket::dist_inc)),
                     next(idx));
             }
-            // Nothing decided in these four. Move on by as many buckets as were real -- fewer than
-            // four only where the padding was among them, which is also where the index wraps.
-            auto lanes = (std::min)(std::size_t{4}, std::size_t{mask} + 1 - bucket_idx);
-            bucket_idx = static_cast<value_idx_type>((bucket_idx + lanes) & mask);
+            // nothing decided in these four
+            auto lanes = next_window(bucket_idx);
             dist_and_fingerprint = static_cast<dist_and_fingerprint_type>(dist_and_fingerprint + (lanes * Bucket::dist_inc));
             if (ANKERL_UNORDERED_DENSE_UNLIKELY(lanes != 4 || dist_and_fingerprint >=
                                                                   sentinel_dist_and_fingerprint - (4 * Bucket::dist_inc))) {
@@ -1914,6 +1937,9 @@ private:
         return probe_scalar(key, dist_and_fingerprint_from_hash(mh), bucket_idx_from_hash(mh));
     }
 
+    // Same lookup with the hashing already done. Requires the bucket array to be allocated, which
+    // !empty() implies; the callers test empty() rather than this function so that a lookup in an
+    // empty table returns without hashing anything.
     template <typename K>
     auto do_find_hashed(K const& key, std::uint64_t mh) -> iterator {
         if constexpr (has_simd_scan) {
@@ -2282,33 +2308,14 @@ public:
         // loop until we reach the end of the container. duplicated entries will be replaced with back().
         while (value_idx != m_values.size()) {
             auto const& key = get_key(m_values[value_idx]);
-
-            auto hash = mixed_hash(key);
-            auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
-            auto bucket_idx = bucket_idx_from_hash(hash);
-
-            bool key_found = false;
-            while (true) {
-                auto const& bucket = at(m_buckets, bucket_idx);
-                if (dist_and_fingerprint > bucket.m_dist_and_fingerprint) {
-                    break;
-                }
-                if (dist_and_fingerprint == bucket.m_dist_and_fingerprint &&
-                    m_equal(key, get_key(m_values[bucket.m_value_idx]))) {
-                    key_found = true;
-                    break;
-                }
-                dist_and_fingerprint = dist_inc(dist_and_fingerprint);
-                bucket_idx = next(bucket_idx);
-            }
-
-            if (key_found) {
+            auto r = probe(key, mixed_hash(key));
+            if (r.found) {
                 if (value_idx != m_values.size() - 1) {
                     m_values[value_idx] = std::move(m_values.back());
                 }
                 m_values.pop_back();
             } else {
-                place_and_shift_up({dist_and_fingerprint, static_cast<value_idx_type>(value_idx)}, bucket_idx);
+                place_and_shift_up({r.dist_and_fingerprint, static_cast<value_idx_type>(value_idx)}, r.bucket_idx);
                 ++value_idx;
             }
         }
@@ -2362,22 +2369,14 @@ public:
               std::enable_if_t<!is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
     auto emplace(K&& key) -> std::pair<iterator, bool> {
         allocate_buckets_if_none();
-        auto hash = mixed_hash(key);
-        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
-        auto bucket_idx = bucket_idx_from_hash(hash);
-
-        while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
-            if (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
-                m_equal(key, m_values[at(m_buckets, bucket_idx).m_value_idx])) {
-                // found it, return without ever actually creating anything
-                return {begin() + static_cast<difference_type>(at(m_buckets, bucket_idx).m_value_idx), false};
-            }
-            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
-            bucket_idx = next(bucket_idx);
+        auto r = probe(key, mixed_hash(key));
+        if (r.found) {
+            // found it, return without ever actually creating anything
+            return {begin() + static_cast<difference_type>(r.value_idx), false};
         }
 
         // value is new, insert element first, so when exception happens we are in a valid state
-        return do_place_element(dist_and_fingerprint, bucket_idx, std::forward<K>(key));
+        return do_place_element(r.dist_and_fingerprint, r.bucket_idx, std::forward<K>(key));
     }
 
     template <class... Args>
@@ -2387,18 +2386,10 @@ public:
         // we have to instantiate the value_type to be able to access the key.
         // 1. emplace_back the object so it is constructed. 2. If the key is already there, pop it later in the loop.
         auto& key = get_key(m_values.emplace_back(std::forward<Args>(args)...));
-        auto hash = mixed_hash(key);
-        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
-        auto bucket_idx = bucket_idx_from_hash(hash);
-
-        while (dist_and_fingerprint <= at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
-            if (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
-                m_equal(key, get_key(m_values[at(m_buckets, bucket_idx).m_value_idx]))) {
-                m_values.pop_back(); // value was already there, so get rid of it
-                return {begin() + static_cast<difference_type>(at(m_buckets, bucket_idx).m_value_idx), false};
-            }
-            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
-            bucket_idx = next(bucket_idx);
+        auto r = probe(key, mixed_hash(key));
+        if (r.found) {
+            m_values.pop_back(); // value was already there, so get rid of it
+            return {begin() + static_cast<difference_type>(r.value_idx), false};
         }
 
         // value is new, place the bucket and shift up until we find an empty spot
@@ -2410,7 +2401,7 @@ public:
             }
         else {
             // place element and shift up until we find an empty spot
-            place_and_shift_up({dist_and_fingerprint, value_idx}, bucket_idx);
+            place_and_shift_up({r.dist_and_fingerprint, value_idx}, r.bucket_idx);
         }
         return {begin() + static_cast<difference_type>(value_idx), true};
     }
@@ -2498,12 +2489,7 @@ public:
 
         auto const value_idx = static_cast<value_idx_type>(it - begin());
 
-        // Find the bucket containing our value_idx. It's guaranteed we find it, so no other stopping condition needed.
-        bucket_idx = old_key_bucket_idx;
-        while (value_idx != at(m_buckets, bucket_idx).m_value_idx) {
-            bucket_idx = next(bucket_idx);
-        }
-        erase_and_shift_down(bucket_idx);
+        erase_and_shift_down(bucket_idx_of_value(old_key_bucket_idx, value_idx));
 
         // place the new bucket
         dist_and_fingerprint = dist_and_fingerprint_from_hash(new_key_hash);
@@ -2518,32 +2504,22 @@ public:
     }
 
     auto erase(iterator it) -> iterator {
-        auto hash = mixed_hash(get_key(*it));
-        auto bucket_idx = bucket_idx_from_hash(hash);
-
         auto const value_idx_to_remove = static_cast<value_idx_type>(it - cbegin());
-        while (at(m_buckets, bucket_idx).m_value_idx != value_idx_to_remove) {
-            bucket_idx = next(bucket_idx);
-        }
+        auto const bucket_idx = bucket_idx_of_value(bucket_idx_from_hash(mixed_hash(get_key(*it))), value_idx_to_remove);
 
         // The noexcept here and on the other two erase callbacks is what keeps erase() out of do_erase()'s exception
         // guard: a call expression is noexcept only if the callee says so, an empty body is not enough.
-        do_erase(bucket_idx, [](value_type const& /*unused*/) noexcept -> void {
+        do_erase(bucket_idx, value_idx_to_remove, [](value_type const& /*unused*/) noexcept -> void {
         });
         return begin() + static_cast<difference_type>(value_idx_to_remove);
     }
 
     auto extract(iterator it) -> value_type {
-        auto hash = mixed_hash(get_key(*it));
-        auto bucket_idx = bucket_idx_from_hash(hash);
-
         auto const value_idx_to_remove = static_cast<value_idx_type>(it - cbegin());
-        while (at(m_buckets, bucket_idx).m_value_idx != value_idx_to_remove) {
-            bucket_idx = next(bucket_idx);
-        }
+        auto const bucket_idx = bucket_idx_of_value(bucket_idx_from_hash(mixed_hash(get_key(*it))), value_idx_to_remove);
 
         auto tmp = std::optional<value_type>{};
-        do_erase(bucket_idx, [&tmp](value_type&& val) -> void {
+        do_erase(bucket_idx, value_idx_to_remove, [&tmp](value_type&& val) -> void {
             tmp = std::move(val);
         });
         return std::move(tmp).value();
@@ -2867,7 +2843,8 @@ public:
     // bucket interface ///////////////////////////////////////////////////////
 
     auto bucket_count() const noexcept -> std::size_t { // NOLINT(modernize-use-nodiscard)
-        return m_buckets.empty() ? 0 : m_buckets.size() - bucket_padding;
+        // from the mask rather than the array, which is bucket_padding longer than it counts
+        return m_buckets.empty() ? 0 : std::size_t{m_bucket_mask} + 1;
     }
 
     static constexpr auto max_bucket_count() noexcept -> std::size_t { // NOLINT(modernize-use-nodiscard)

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -77,6 +77,18 @@
 #    define ANKERL_UNORDERED_DENSE_PREFETCH(addr) static_cast<void>(addr) // NOLINT(cppcoreguidelines-macro-usage)
 #endif
 
+// SSE2 is part of the x86-64 baseline, so the four-buckets-at-a-time probe below is available on
+// every x86-64 build without asking for it. Elsewhere the scalar probe is used.
+#if defined(__SSE2__) || (defined(_MSC_VER) && (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)))
+#    define ANKERL_UNORDERED_DENSE_HAS_SSE2 1 // NOLINT(cppcoreguidelines-macro-usage)
+#    include <emmintrin.h>
+#    if defined(_MSC_VER)
+#        include <intrin.h>
+#    endif
+#else
+#    define ANKERL_UNORDERED_DENSE_HAS_SSE2 0 // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+
 #if defined(__clang__) && defined(__has_attribute)
 #    if __has_attribute(__no_sanitize__)
 #        define ANKERL_UNORDERED_DENSE_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK \
@@ -156,6 +168,21 @@ namespace detail {
 } // namespace detail
 
 // hash ///////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+// Index of the lowest set bit. x must not be zero.
+[[nodiscard]] inline auto countr_zero(std::uint32_t x) -> unsigned {
+#    if defined(_MSC_VER)
+    unsigned long idx{};
+    _BitScanForward(&idx, x);
+    return static_cast<unsigned>(idx);
+#    else
+    return static_cast<unsigned>(__builtin_ctz(x));
+#    endif
+}
+
+} // namespace detail
 
 // This is a stripped-down implementation of wyhash: https://github.com/wangyi-fudan/wyhash
 // No big-endian support (because different values on different machines don't matter),
@@ -1149,6 +1176,20 @@ private:
     static constexpr std::uint8_t initial_shifts = 64 - 2; // 2^(64-m_shift) number of buckets
     static constexpr float default_max_load_factor = 0.8F;
 
+    // The probe can read four buckets at once where the bucket array is contiguous -- the default
+    // container, a std::vector -- and the bucket is the standard 8 byte one, on a platform with SSE2.
+    static constexpr bool has_simd_scan = ANKERL_UNORDERED_DENSE_HAS_SSE2 && !IsSegmented &&
+                                          std::is_same_v<BucketContainer, detail::default_container_t> &&
+                                          std::is_same_v<Bucket, ankerl::unordered_dense::bucket_type::standard>;
+
+    // Four buckets read from any bucket index reach up to three past the end of the array, so the
+    // array carries that many extra. They hold a dist_and_fingerprint no key can expect and no
+    // bucket can hold less than, and the value index of an empty bucket, so a scan passes over
+    // them as it would over occupied buckets that are not the answer -- and the wrap to bucket
+    // zero is taken only where a scan moves on, which is rare. bucket_count() does not count them.
+    static constexpr std::size_t bucket_padding = has_simd_scan ? 3 : 0;
+    static constexpr std::uint32_t sentinel_dist_and_fingerprint = 0x7FFFFFFFU;
+
     // Named, and covering both containers, so that the promise and the recovery that exists for
     // when the promise cannot be made are spelled the same way and cannot drift apart -- the same
     // reason segmented_vector names its propagation traits. Covering only m_values would be wrong
@@ -1351,7 +1392,7 @@ private:
                 // exactly wrong.
                 m_buckets.assign(other.m_buckets.begin(), other.m_buckets.end());
                 m_shifts = other.m_shifts;
-                describe_buckets(m_buckets.size());
+                describe_buckets(bucket_count());
             }
         }
     }
@@ -1482,7 +1523,11 @@ private:
             // no buckets to find them by, which is not a state anything can recover from without
             // allocating again.
             auto fresh = bucket_container_type(m_buckets.get_allocator());
-            fresh.resize(num_buckets);
+            fresh.resize(num_buckets + bucket_padding);
+            for (std::size_t i = 0; i < bucket_padding; ++i) {
+                fresh[num_buckets + i].m_dist_and_fingerprint =
+                    static_cast<dist_and_fingerprint_type>(sentinel_dist_and_fingerprint);
+            }
             m_buckets = std::move(fresh);
         }
         // All three commit here, together, and only once the array they describe exists. They have
@@ -1593,10 +1638,37 @@ private:
             // update the values_idx of the moved entry. No need to play the info game, just look until we find the values_idx
             auto bucket_idx = bucket_idx_from_hash(mixed_hash(get_key(val)));
             auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
-            while (values_idx_back != at(m_buckets, bucket_idx).m_value_idx) {
-                bucket_idx = next(bucket_idx);
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+            // NOLINTBEGIN(portability-simd-intrinsics)
+            if constexpr (has_simd_scan) {
+                // four buckets at a time, matching the value index this time: only one bucket in the
+                // table holds it, so its lane is the answer
+                auto const mask = m_bucket_mask;
+                auto* data = m_buckets.data();
+                auto const wanted = _mm_set1_epi32(static_cast<int>(values_idx_back));
+                while (true) {
+                    auto* gp = data + bucket_idx;
+                    auto lo = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp));     // NOLINT
+                    auto hi = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 2)); // NOLINT
+                    auto v =
+                        _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(3, 1, 3, 1)));
+                    auto eq = static_cast<unsigned>(_mm_movemask_ps(_mm_castsi128_ps(_mm_cmpeq_epi32(v, wanted))));
+                    if (ANKERL_UNORDERED_DENSE_LIKELY(eq != 0)) {
+                        gp[detail::countr_zero(eq)].m_value_idx = value_idx_to_remove;
+                        break;
+                    }
+                    auto lanes = (std::min)(std::size_t{4}, std::size_t{mask} + 1 - bucket_idx);
+                    bucket_idx = static_cast<value_idx_type>((bucket_idx + lanes) & mask);
+                }
+            } else
+            // NOLINTEND(portability-simd-intrinsics)
+#    endif
+            {
+                while (values_idx_back != at(m_buckets, bucket_idx).m_value_idx) {
+                    bucket_idx = next(bucket_idx);
+                }
+                at(m_buckets, bucket_idx).m_value_idx = value_idx_to_remove;
             }
-            at(m_buckets, bucket_idx).m_value_idx = value_idx_to_remove;
         }
         m_values.pop_back();
     }
@@ -1634,18 +1706,11 @@ private:
             return 0;
         }
 
-        auto [dist_and_fingerprint, bucket_idx] = next_while_less(key);
-
-        while (dist_and_fingerprint == at(m_buckets, bucket_idx).m_dist_and_fingerprint &&
-               !m_equal(key, get_key(m_values[at(m_buckets, bucket_idx).m_value_idx]))) {
-            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
-            bucket_idx = next(bucket_idx);
-        }
-
-        if (dist_and_fingerprint != at(m_buckets, bucket_idx).m_dist_and_fingerprint) {
+        auto r = probe(key, mixed_hash(key));
+        if (!r.found) {
             return 0;
         }
-        do_erase(bucket_idx, handle_erased_value);
+        do_erase(r.bucket_idx, handle_erased_value);
         return 1;
     }
 
@@ -1681,26 +1746,15 @@ private:
     template <typename K, typename... Args>
     auto do_try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
         allocate_buckets_if_none();
-        auto hash = mixed_hash(key);
-        auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
-        auto bucket_idx = bucket_idx_from_hash(hash);
-
-        while (true) {
-            auto* bucket = &at(m_buckets, bucket_idx);
-            if (dist_and_fingerprint == bucket->m_dist_and_fingerprint) {
-                if (m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
-                    return {begin() + static_cast<difference_type>(bucket->m_value_idx), false};
-                }
-            } else if (dist_and_fingerprint > bucket->m_dist_and_fingerprint) {
-                return do_place_element(dist_and_fingerprint,
-                                        bucket_idx,
-                                        std::piecewise_construct,
-                                        std::forward_as_tuple(std::forward<K>(key)),
-                                        std::forward_as_tuple(std::forward<Args>(args)...));
-            }
-            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
-            bucket_idx = next(bucket_idx);
+        auto r = probe(key, mixed_hash(key));
+        if (r.found) {
+            return {begin() + static_cast<difference_type>(r.value_idx), false};
         }
+        return do_place_element(r.dist_and_fingerprint,
+                                r.bucket_idx,
+                                std::piecewise_construct,
+                                std::forward_as_tuple(std::forward<K>(key)),
+                                std::forward_as_tuple(std::forward<Args>(args)...));
     }
 
     template <typename K>
@@ -1716,13 +1770,112 @@ private:
     // Same lookup with the hashing already done. Requires the bucket array to be allocated, which
     // !empty() implies; the callers test empty() rather than this function so that a lookup in an
     // empty table returns without hashing anything.
+    // Where a probe for a key stopped. Found: the bucket holding it, and the value it points to.
+    // Not found: the bucket the key would be placed in, and the dist_and_fingerprint it would carry
+    // there -- exactly what an insert needs next. dist_and_fingerprint is meaningful only then.
+    struct probe_result {
+        dist_and_fingerprint_type dist_and_fingerprint;
+        value_idx_type bucket_idx;
+        value_idx_type value_idx;
+        bool found;
+    };
+
+    // One bucket at a time, from any point of a probe sequence.
     template <typename K>
-    auto do_find_hashed(K const& key, std::uint64_t mh) -> iterator {
+    auto probe_scalar(K const& key, dist_and_fingerprint_type dist_and_fingerprint, value_idx_type bucket_idx) const
+        -> probe_result {
+        while (true) {
+            auto const* bucket = &at(m_buckets, bucket_idx);
+            if (dist_and_fingerprint == bucket->m_dist_and_fingerprint) {
+                if (m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
+                    return {dist_and_fingerprint, bucket_idx, bucket->m_value_idx, true};
+                }
+            } else if (dist_and_fingerprint > bucket->m_dist_and_fingerprint) {
+                return {dist_and_fingerprint, bucket_idx, 0, false};
+            }
+            dist_and_fingerprint = dist_inc(dist_and_fingerprint);
+            bucket_idx = next(bucket_idx);
+        }
+    }
+
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+    // NOLINTBEGIN(portability-simd-intrinsics) -- this is the x86 path, on purpose
+    // Four consecutive buckets per step, starting at the home bucket. For each lane the
+    // dist_and_fingerprint this key would have there is compared: equal is a fingerprint match
+    // worth a key comparison, less is the robin hood proof that the key is absent -- and where it
+    // would go. The lowest lane that is either decides, which makes the outcome independent of
+    // *where* in the probe sequence it happened: one data dependent branch per probe instead of one
+    // per bucket. The last three buckets of the array have no four buckets after them, and hand
+    // over to the scalar probe.
+    template <typename K>
+    auto probe_simd(K const& key, std::uint64_t mh) const -> probe_result {
         auto dist_and_fingerprint = dist_and_fingerprint_from_hash(mh);
         auto bucket_idx = bucket_idx_from_hash(mh);
+        auto const mask = m_bucket_mask;
+        auto const* data = m_buckets.data();
+
+        auto expected = _mm_add_epi32(_mm_set1_epi32(static_cast<int>(dist_and_fingerprint)),
+                                      _mm_setr_epi32(0,
+                                                     static_cast<int>(Bucket::dist_inc),
+                                                     static_cast<int>(2 * Bucket::dist_inc),
+                                                     static_cast<int>(3 * Bucket::dist_inc)));
+        auto const step = _mm_set1_epi32(static_cast<int>(4 * Bucket::dist_inc));
+
+        while (true) {
+            auto const* gp = data + bucket_idx;
+            auto lo = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp));     // NOLINT
+            auto hi = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 2)); // NOLINT
+            auto d = _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(2, 0, 2, 0)));
+
+            // Two lane masks from the sign bits: bucket - expected is negative where the bucket
+            // holds less (both are far below 2^31, so the difference cannot wrap), and a compare
+            // for equality is all ones where they are equal. Their or has a sign bit set in every
+            // lane that is either.
+            auto eqv = _mm_cmpeq_epi32(d, expected);
+            auto lessv = _mm_sub_epi32(d, expected);
+            auto candidates = static_cast<unsigned>(_mm_movemask_ps(_mm_castsi128_ps(_mm_or_si128(eqv, lessv))));
+            auto less = static_cast<unsigned>(_mm_movemask_ps(_mm_castsi128_ps(lessv)));
+            if (ANKERL_UNORDERED_DENSE_LIKELY(candidates != 0)) {
+                auto j = detail::countr_zero(candidates);
+                auto idx = static_cast<value_idx_type>(bucket_idx + j);
+                if (0 != ((less >> j) & 1U)) {
+                    return {
+                        static_cast<dist_and_fingerprint_type>(dist_and_fingerprint + (j * Bucket::dist_inc)), idx, 0, false};
+                }
+                auto value_idx = gp[j].m_value_idx;
+                if (ANKERL_UNORDERED_DENSE_LIKELY(m_equal(key, get_key(m_values[value_idx])))) {
+                    return {dist_and_fingerprint, idx, value_idx, true};
+                }
+                // A fingerprint collision. Rare enough that the scalar probe can take it from the
+                // next bucket on, which also keeps the vector state from having to survive the
+                // key comparison above.
+                return probe_scalar(
+                    key,
+                    static_cast<dist_and_fingerprint_type>(dist_and_fingerprint + ((j + 1) * Bucket::dist_inc)),
+                    next(idx));
+            }
+            // Nothing decided in these four. Move on by as many buckets as were real -- fewer than
+            // four only where the padding was among them, which is also where the index wraps.
+            auto lanes = (std::min)(std::size_t{4}, std::size_t{mask} + 1 - bucket_idx);
+            bucket_idx = static_cast<value_idx_type>((bucket_idx + lanes) & mask);
+            dist_and_fingerprint = static_cast<dist_and_fingerprint_type>(dist_and_fingerprint + (lanes * Bucket::dist_inc));
+            if (ANKERL_UNORDERED_DENSE_UNLIKELY(lanes != 4 || dist_and_fingerprint >=
+                                                                  sentinel_dist_and_fingerprint - (4 * Bucket::dist_inc))) {
+                // a wrap, or a distance the lane arithmetic could not hold: the scalar probe takes it
+                return probe_scalar(key, dist_and_fingerprint, bucket_idx);
+            }
+            expected = _mm_add_epi32(expected, step);
+        }
+    }
+    // NOLINTEND(portability-simd-intrinsics)
+#    endif
+
+    // The find of a configuration without the vector probe: one bucket at a time, the first two
+    // unrolled. *Always* checking a few directly before entering the loop measured faster.
+    template <typename K>
+    auto do_find_scalar(K const& key, dist_and_fingerprint_type dist_and_fingerprint, value_idx_type bucket_idx) -> iterator {
         auto* bucket = &at(m_buckets, bucket_idx);
 
-        // unrolled loop. *Always* check a few directly, then enter the loop. This is faster.
         if (dist_and_fingerprint == bucket->m_dist_and_fingerprint && m_equal(key, get_key(m_values[bucket->m_value_idx]))) {
             return begin() + static_cast<difference_type>(bucket->m_value_idx);
         }
@@ -1748,6 +1901,26 @@ private:
             dist_and_fingerprint = dist_inc(dist_and_fingerprint);
             bucket_idx = next(bucket_idx);
             bucket = &at(m_buckets, bucket_idx);
+        }
+    }
+
+    template <typename K>
+    auto probe(K const& key, std::uint64_t mh) const -> probe_result {
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+        if constexpr (has_simd_scan) {
+            return probe_simd(key, mh);
+        }
+#    endif
+        return probe_scalar(key, dist_and_fingerprint_from_hash(mh), bucket_idx_from_hash(mh));
+    }
+
+    template <typename K>
+    auto do_find_hashed(K const& key, std::uint64_t mh) -> iterator {
+        if constexpr (has_simd_scan) {
+            auto r = probe(key, mh);
+            return r.found ? begin() + static_cast<difference_type>(r.value_idx) : end();
+        } else {
+            return do_find_scalar(key, dist_and_fingerprint_from_hash(mh), bucket_idx_from_hash(mh));
         }
     }
 
@@ -2694,7 +2867,7 @@ public:
     // bucket interface ///////////////////////////////////////////////////////
 
     auto bucket_count() const noexcept -> std::size_t { // NOLINT(modernize-use-nodiscard)
-        return m_buckets.size();
+        return m_buckets.empty() ? 0 : m_buckets.size() - bucket_padding;
     }
 
     static constexpr auto max_bucket_count() noexcept -> std::size_t { // NOLINT(modernize-use-nodiscard)

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -1,0 +1,44 @@
+# Paired A/B measurements
+
+    scripts/ab/run.sh [-r REV] [-b] [-c COMPILER] <workload|all> [epochs]
+
+Builds the working-tree header against `REV`'s (default `HEAD`) in one binary -- the baseline is
+renamed into a second namespace -- and runs nanobench's `compare()`: the alternatives run
+interleaved in the same slice of time, so drift cancels out of the ratios, and the interval it
+prints is about the ratio. `-b` adds `boost::unordered_flat_map` (needs its headers). The
+workloads are `test/bench/workloads.h`, the ones `bench_quick_overall_udm` scores, plus all-hits
+and no-hits lookups. Believe a change when the interval excludes 100%.
+
+## What the hot paths are bound by (Ryzen 9 7950X, clang 22, default `-march`, 2026-09)
+
+A cost model that predicted every experiment of the SSE2-probe work within a cycle or two:
+**cycles per operation ≈ 16 × branch mispredictions + instructions / ~3.5**. The loops are
+front-end bound between mispredictions, so both terms matter and nothing else does -- the whole
+working set of the benchmark sits in L2.
+
+- **u64 lookups are bounded by branch mispredictions.** The scalar probe branched once per bucket,
+  so the *position* of a hit leaked into the branch pattern; on random lookups that was 1.35
+  mispredictions per lookup, against 0.42 for boost's grouped scan. The SSE2 probe makes the
+  outcome one data-dependent branch regardless of position: 0.70, and 35-80% faster.
+- **String workloads are latency bound.** At ~250 instructions per lookup -- ~150 of them the
+  200 byte wyhash -- the reorder buffer holds barely one lookup, so anything on the dependency
+  chain shows directly. The vector decision (`movmskps` → `tzcnt` → index load) adds ~10 cycles
+  before the value load can issue where the scalar path's predicted branch let it issue at once.
+- **Hashing is 42-45% of the string workloads**, at ~40 cycles per 200 byte key: 0.5 uops per
+  byte, nothing to do with multiply count. With a trivial 8 byte hash, insert/erase time equals
+  boost's exactly -- the rest of the gap there is that a robin hood erase hashes the moved last
+  element too (only the successful half of the erases, so at most ~7% of that workload).
+
+Numbers from that session, paired against main (ms; boost for scale):
+
+| workload | main | SSE2 probe | boost |
+|---|---|---|---|
+| find64 | 78.6 | 48.0 | 40.1 |
+| findstr | 218 | 210 | 182 |
+| ie64 | 62.0 | 65.3 | 57.1 |
+| iestr | 226 | 212 | 188 |
+| rhit64 | 145 | 80 | 50 |
+| rmiss64 | 48 | 35 | 28 |
+
+`perf stat -e cycles,instructions,branch-misses` on a single-workload runner is what separates
+"more instructions" from "more mispredictions"; `perf record -e cycles:pp` for annotate.

--- a/scripts/ab/ab.cpp
+++ b/scripts/ab/ab.cpp
@@ -1,0 +1,246 @@
+// Paired A/B of the working-tree header against another revision of it, and optionally against
+// boost::unordered_flat_map, using nanobench's compare(): the alternatives run interleaved in the
+// same slice of time, so machine drift cancels out and the reported interval is about the ratio.
+//
+// The two headers coexist in one binary because run.sh renames the baseline's namespace and macro
+// prefix (ankerl -> udmbase) into base.h. The workloads replicate bench_quick_overall_udm exactly,
+// plus all-hits and no-hits lookups, which bound what a workload's hit rate can do to the probe.
+#include "base.h"
+
+#include <ankerl/unordered_dense.h>
+#include <nanobench.h>
+#ifdef UDM_AB_HAVE_BOOST
+#    include <boost/unordered/unordered_flat_map.hpp>
+#endif
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+template <typename K>
+auto init_key() -> K {
+    return {};
+}
+
+template <>
+auto init_key<std::string>() -> std::string {
+    return std::string(200, '\0');
+}
+
+template <typename T>
+void randomize_key(ankerl::nanobench::Rng* rng, int n, T* key) {
+    auto limited = (((*rng)() >> 32U) * static_cast<uint64_t>(n)) >> 32U;
+    *key = static_cast<T>(limited);
+}
+
+void randomize_key(ankerl::nanobench::Rng* rng, int n, std::string* key) {
+    uint64_t k{};
+    randomize_key(rng, n, &k);
+    std::memcpy(key->data(), &k, sizeof(k));
+}
+
+template <typename K>
+void set_key(uint64_t v, K* key) {
+    *key = static_cast<K>(v);
+}
+
+void set_key(uint64_t v, std::string* key) {
+    std::memcpy(key->data(), &v, sizeof(v));
+}
+
+// the three quick_overall workloads, verbatim
+template <typename Map>
+auto insert_erase() -> uint64_t {
+    ankerl::nanobench::Rng rng(123);
+    size_t verifier{};
+    Map map;
+    auto key = init_key<typename Map::key_type>();
+    for (int n = 1; n < 20000; ++n) {
+        for (int i = 0; i < 200; ++i) {
+            randomize_key(&rng, n, &key);
+            map[key];
+            randomize_key(&rng, n, &key);
+            verifier += map.erase(key);
+        }
+    }
+    return verifier + map.size();
+}
+
+template <typename Map>
+auto find_50() -> uint64_t {
+    ankerl::nanobench::Rng insert_rng(123123);
+    ankerl::nanobench::Rng search_rng(987654321);
+    constexpr auto never_inserted = uint64_t{1} << 63U;
+    std::vector<uint64_t> inserted;
+    size_t checksum = 0;
+    Map map;
+    auto key = init_key<typename Map::key_type>();
+    for (size_t i = 0; i < 100000; ++i) {
+        auto candidate = insert_rng() & ~never_inserted;
+        if (inserted.empty() || (insert_rng() & 1U) != 0) {
+            set_key(candidate, &key);
+            if (map.emplace(key, i).second) {
+                inserted.push_back(candidate);
+            }
+        }
+        for (size_t search = 0; search < 100; ++search) {
+            auto r = search_rng();
+            if ((r & 1U) != 0) {
+                set_key(inserted[((r >> 32U) * inserted.size()) >> 32U], &key);
+            } else {
+                set_key(r | never_inserted, &key);
+            }
+            auto it = map.find(key);
+            if (it != map.end()) {
+                checksum += it->second;
+            }
+        }
+    }
+    return checksum;
+}
+
+template <typename Map>
+auto iterate() -> uint64_t {
+    auto key = init_key<typename Map::key_type>();
+    ankerl::nanobench::Rng rng(555);
+    Map map;
+    size_t result = 0;
+    for (size_t n = 0; n < 5000; ++n) {
+        randomize_key(&rng, 1000000, &key);
+        map[key] = n;
+        for (auto const& kv : map) {
+            result += kv.second;
+        }
+    }
+    rng = ankerl::nanobench::Rng(555);
+    do {
+        randomize_key(&rng, 1000000, &key);
+        map.erase(key);
+        for (auto const& kv : map) {
+            result += kv.second;
+        }
+    } while (!map.empty());
+    return result;
+}
+
+// 50k entries, then 10M lookups whose outcome is decided by an independent rng: HitPct of them
+// find a key that is there, the rest look for one that cannot be.
+template <typename Map, int HitPct>
+auto random_find() -> uint64_t {
+    ankerl::nanobench::Rng rng(999);
+    Map map;
+    std::vector<uint64_t> keys;
+    auto key = init_key<typename Map::key_type>();
+    while (map.size() < 50000) {
+        auto v = rng() & ((uint64_t{1} << 30U) - 1);
+        set_key(v, &key);
+        if (map.emplace(key, keys.size()).second) {
+            keys.push_back(v);
+        }
+    }
+    size_t checksum = 0;
+    for (size_t i = 0; i < 10000000; ++i) {
+        auto r = rng();
+        bool hit = HitPct == 100 || (HitPct != 0 && (r & 1U));
+        set_key(hit ? keys[(r >> 1U) % keys.size()] : ((uint64_t{1} << 30U) | (r >> 1U)), &key);
+        auto it = map.find(key);
+        if (it != map.end()) {
+            checksum += it->second;
+        }
+    }
+    return checksum;
+}
+
+template <typename Base, typename Cand, typename Boost, typename Fn>
+void compare(char const* name, size_t epochs, bool with_boost, Fn fn) {
+    auto bench = ankerl::nanobench::Bench().title(name).epochs(epochs).performanceCounters(false);
+    auto base = [&] {
+        ankerl::nanobench::doNotOptimizeAway(fn(static_cast<Base*>(nullptr)));
+    };
+    auto cand = [&] {
+        ankerl::nanobench::doNotOptimizeAway(fn(static_cast<Cand*>(nullptr)));
+    };
+    auto boost = [&] {
+        ankerl::nanobench::doNotOptimizeAway(fn(static_cast<Boost*>(nullptr)));
+    };
+    if (with_boost) {
+        bench.compare("base", base, "cand", cand, "boost", boost);
+    } else {
+        bench.compare("base", base, "cand", cand);
+    }
+}
+
+#define UDM_AB_WORKLOAD(fn)                              \
+    [](auto* m) {                                        \
+        return fn<std::remove_pointer_t<decltype(m)>>(); \
+    }
+
+using base_u64 = udmbase::unordered_dense::map<uint64_t, size_t>;
+using cand_u64 = ankerl::unordered_dense::map<uint64_t, size_t>;
+using base_str = udmbase::unordered_dense::map<std::string, size_t>;
+using cand_str = ankerl::unordered_dense::map<std::string, size_t>;
+#ifdef UDM_AB_HAVE_BOOST
+using boost_u64 = boost::unordered_flat_map<uint64_t, size_t, ankerl::unordered_dense::hash<uint64_t>>;
+using boost_str = boost::unordered_flat_map<std::string, size_t, ankerl::unordered_dense::hash<std::string>>;
+#else
+using boost_u64 = cand_u64;
+using boost_str = cand_str;
+#endif
+
+} // namespace
+
+auto main(int argc, char** argv) -> int {
+    if (argc < 2) {
+        std::printf("usage: %s <workload|all> [epochs=12] [boost=0]\n"
+                    "workloads: it64 ie64 find64 itstr iestr findstr (bench_quick_overall_udm)\n"
+                    "           rhit64 rmiss64 rhitstr rmissstr (all hits / no hits)\n",
+                    argv[0]);
+        return 1;
+    }
+    std::string w = argv[1];
+    auto epochs = static_cast<size_t>(argc > 2 ? std::atoi(argv[2]) : 12);
+    bool boost = argc > 3 && std::atoi(argv[3]) != 0;
+#ifndef UDM_AB_HAVE_BOOST
+    if (boost) {
+        std::printf("built without boost, see run.sh\n");
+        return 1;
+    }
+#endif
+    auto want = [&](char const* n) {
+        return w == "all" || w == n;
+    };
+#define U64(name, fn) \
+    if (want(name))   \
+    compare<base_u64, cand_u64, boost_u64>(name, epochs, boost, UDM_AB_WORKLOAD(fn))
+#define STR(name, fn) \
+    if (want(name))   \
+    compare<base_str, cand_str, boost_str>(name, epochs, boost, UDM_AB_WORKLOAD(fn))
+    U64("it64", iterate);
+    U64("ie64", insert_erase);
+    U64("find64", find_50);
+    STR("itstr", iterate);
+    STR("iestr", insert_erase);
+    STR("findstr", find_50);
+    if (want("rhit64"))
+        compare<base_u64, cand_u64, boost_u64>("rhit64", epochs, boost, [](auto* m) {
+            return random_find<std::remove_pointer_t<decltype(m)>, 100>();
+        });
+    if (want("rmiss64"))
+        compare<base_u64, cand_u64, boost_u64>("rmiss64", epochs, boost, [](auto* m) {
+            return random_find<std::remove_pointer_t<decltype(m)>, 0>();
+        });
+    if (want("rhitstr"))
+        compare<base_str, cand_str, boost_str>("rhitstr", epochs, boost, [](auto* m) {
+            return random_find<std::remove_pointer_t<decltype(m)>, 100>();
+        });
+    if (want("rmissstr"))
+        compare<base_str, cand_str, boost_str>("rmissstr", epochs, boost, [](auto* m) {
+            return random_find<std::remove_pointer_t<decltype(m)>, 0>();
+        });
+    return 0;
+}

--- a/scripts/ab/ab.cpp
+++ b/scripts/ab/ab.cpp
@@ -3,12 +3,13 @@
 // same slice of time, so machine drift cancels out and the reported interval is about the ratio.
 //
 // The two headers coexist in one binary because run.sh renames the baseline's namespace and macro
-// prefix (ankerl -> udmbase) into base.h. The workloads replicate bench_quick_overall_udm exactly,
-// plus all-hits and no-hits lookups, which bound what a workload's hit rate can do to the probe.
+// prefix (ankerl -> udmbase) into base.h. The workloads are those of bench_quick_overall_udm, from
+// the header the benchmark itself uses, plus its all-hits and no-hits lookups.
 #include "base.h"
 
 #include <ankerl/unordered_dense.h>
-#include <nanobench.h>
+#include <bench/workloads.h>
+#include <third-party/nanobench.h>
 #ifdef UDM_AB_HAVE_BOOST
 #    include <boost/unordered/unordered_flat_map.hpp>
 #endif
@@ -16,169 +17,9 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <string>
-#include <vector>
 
 namespace {
-
-template <typename K>
-auto init_key() -> K {
-    return {};
-}
-
-template <>
-auto init_key<std::string>() -> std::string {
-    return std::string(200, '\0');
-}
-
-template <typename T>
-void randomize_key(ankerl::nanobench::Rng* rng, int n, T* key) {
-    auto limited = (((*rng)() >> 32U) * static_cast<uint64_t>(n)) >> 32U;
-    *key = static_cast<T>(limited);
-}
-
-void randomize_key(ankerl::nanobench::Rng* rng, int n, std::string* key) {
-    uint64_t k{};
-    randomize_key(rng, n, &k);
-    std::memcpy(key->data(), &k, sizeof(k));
-}
-
-template <typename K>
-void set_key(uint64_t v, K* key) {
-    *key = static_cast<K>(v);
-}
-
-void set_key(uint64_t v, std::string* key) {
-    std::memcpy(key->data(), &v, sizeof(v));
-}
-
-// the three quick_overall workloads, verbatim
-template <typename Map>
-auto insert_erase() -> uint64_t {
-    ankerl::nanobench::Rng rng(123);
-    size_t verifier{};
-    Map map;
-    auto key = init_key<typename Map::key_type>();
-    for (int n = 1; n < 20000; ++n) {
-        for (int i = 0; i < 200; ++i) {
-            randomize_key(&rng, n, &key);
-            map[key];
-            randomize_key(&rng, n, &key);
-            verifier += map.erase(key);
-        }
-    }
-    return verifier + map.size();
-}
-
-template <typename Map>
-auto find_50() -> uint64_t {
-    ankerl::nanobench::Rng insert_rng(123123);
-    ankerl::nanobench::Rng search_rng(987654321);
-    constexpr auto never_inserted = uint64_t{1} << 63U;
-    std::vector<uint64_t> inserted;
-    size_t checksum = 0;
-    Map map;
-    auto key = init_key<typename Map::key_type>();
-    for (size_t i = 0; i < 100000; ++i) {
-        auto candidate = insert_rng() & ~never_inserted;
-        if (inserted.empty() || (insert_rng() & 1U) != 0) {
-            set_key(candidate, &key);
-            if (map.emplace(key, i).second) {
-                inserted.push_back(candidate);
-            }
-        }
-        for (size_t search = 0; search < 100; ++search) {
-            auto r = search_rng();
-            if ((r & 1U) != 0) {
-                set_key(inserted[((r >> 32U) * inserted.size()) >> 32U], &key);
-            } else {
-                set_key(r | never_inserted, &key);
-            }
-            auto it = map.find(key);
-            if (it != map.end()) {
-                checksum += it->second;
-            }
-        }
-    }
-    return checksum;
-}
-
-template <typename Map>
-auto iterate() -> uint64_t {
-    auto key = init_key<typename Map::key_type>();
-    ankerl::nanobench::Rng rng(555);
-    Map map;
-    size_t result = 0;
-    for (size_t n = 0; n < 5000; ++n) {
-        randomize_key(&rng, 1000000, &key);
-        map[key] = n;
-        for (auto const& kv : map) {
-            result += kv.second;
-        }
-    }
-    rng = ankerl::nanobench::Rng(555);
-    do {
-        randomize_key(&rng, 1000000, &key);
-        map.erase(key);
-        for (auto const& kv : map) {
-            result += kv.second;
-        }
-    } while (!map.empty());
-    return result;
-}
-
-// 50k entries, then 10M lookups whose outcome is decided by an independent rng: HitPct of them
-// find a key that is there, the rest look for one that cannot be.
-template <typename Map, int HitPct>
-auto random_find() -> uint64_t {
-    ankerl::nanobench::Rng rng(999);
-    Map map;
-    std::vector<uint64_t> keys;
-    auto key = init_key<typename Map::key_type>();
-    while (map.size() < 50000) {
-        auto v = rng() & ((uint64_t{1} << 30U) - 1);
-        set_key(v, &key);
-        if (map.emplace(key, keys.size()).second) {
-            keys.push_back(v);
-        }
-    }
-    size_t checksum = 0;
-    for (size_t i = 0; i < 10000000; ++i) {
-        auto r = rng();
-        bool hit = HitPct == 100 || (HitPct != 0 && (r & 1U));
-        set_key(hit ? keys[(r >> 1U) % keys.size()] : ((uint64_t{1} << 30U) | (r >> 1U)), &key);
-        auto it = map.find(key);
-        if (it != map.end()) {
-            checksum += it->second;
-        }
-    }
-    return checksum;
-}
-
-template <typename Base, typename Cand, typename Boost, typename Fn>
-void compare(char const* name, size_t epochs, bool with_boost, Fn fn) {
-    auto bench = ankerl::nanobench::Bench().title(name).epochs(epochs).performanceCounters(false);
-    auto base = [&] {
-        ankerl::nanobench::doNotOptimizeAway(fn(static_cast<Base*>(nullptr)));
-    };
-    auto cand = [&] {
-        ankerl::nanobench::doNotOptimizeAway(fn(static_cast<Cand*>(nullptr)));
-    };
-    auto boost = [&] {
-        ankerl::nanobench::doNotOptimizeAway(fn(static_cast<Boost*>(nullptr)));
-    };
-    if (with_boost) {
-        bench.compare("base", base, "cand", cand, "boost", boost);
-    } else {
-        bench.compare("base", base, "cand", cand);
-    }
-}
-
-#define UDM_AB_WORKLOAD(fn)                              \
-    [](auto* m) {                                        \
-        return fn<std::remove_pointer_t<decltype(m)>>(); \
-    }
 
 using base_u64 = udmbase::unordered_dense::map<uint64_t, size_t>;
 using cand_u64 = ankerl::unordered_dense::map<uint64_t, size_t>;
@@ -191,6 +32,68 @@ using boost_str = boost::unordered_flat_map<std::string, size_t, ankerl::unorder
 using boost_u64 = cand_u64;
 using boost_str = cand_str;
 #endif
+
+// Workload is a template with one type parameter, the map. The result is whatever it returns;
+// doNotOptimizeAway needs it to be a scalar, which is why insert_erase's pair is summed.
+template <typename T>
+auto scalar(T v) -> T {
+    return v;
+}
+
+auto scalar(workloads::insert_erase_result r) -> size_t {
+    return r.erased + r.size;
+}
+
+template <template <typename> class Workload, typename Base, typename Cand, typename Boost>
+void compare(char const* name, size_t epochs, bool with_boost) {
+    auto bench = ankerl::nanobench::Bench().title(name).epochs(epochs).performanceCounters(false);
+    auto base = [] {
+        ankerl::nanobench::doNotOptimizeAway(scalar(Workload<Base>::run()));
+    };
+    auto cand = [] {
+        ankerl::nanobench::doNotOptimizeAway(scalar(Workload<Cand>::run()));
+    };
+    auto boost = [] {
+        ankerl::nanobench::doNotOptimizeAway(scalar(Workload<Boost>::run()));
+    };
+    if (with_boost) {
+        bench.compare("base", base, "cand", cand, "boost", boost);
+    } else {
+        bench.compare("base", base, "cand", cand);
+    }
+}
+
+// the workloads as templates with one parameter, so that compare() can name them
+template <typename Map>
+struct iterate {
+    static auto run() {
+        return workloads::iterate<Map>();
+    }
+};
+template <typename Map>
+struct insert_erase {
+    static auto run() {
+        return workloads::insert_erase<Map>();
+    }
+};
+template <typename Map>
+struct find_50 {
+    static auto run() {
+        return workloads::find_50<Map>();
+    }
+};
+template <typename Map>
+struct find_hits {
+    static auto run() {
+        return workloads::find_all<Map, true>();
+    }
+};
+template <typename Map>
+struct find_misses {
+    static auto run() {
+        return workloads::find_all<Map, false>();
+    }
+};
 
 } // namespace
 
@@ -214,33 +117,21 @@ auto main(int argc, char** argv) -> int {
     auto want = [&](char const* n) {
         return w == "all" || w == n;
     };
-#define U64(name, fn) \
-    if (want(name))   \
-    compare<base_u64, cand_u64, boost_u64>(name, epochs, boost, UDM_AB_WORKLOAD(fn))
-#define STR(name, fn) \
-    if (want(name))   \
-    compare<base_str, cand_str, boost_str>(name, epochs, boost, UDM_AB_WORKLOAD(fn))
+#define U64(name, workload) \
+    if (want(name))         \
+    compare<workload, base_u64, cand_u64, boost_u64>(name, epochs, boost)
+#define STR(name, workload) \
+    if (want(name))         \
+    compare<workload, base_str, cand_str, boost_str>(name, epochs, boost)
     U64("it64", iterate);
     U64("ie64", insert_erase);
     U64("find64", find_50);
     STR("itstr", iterate);
     STR("iestr", insert_erase);
     STR("findstr", find_50);
-    if (want("rhit64"))
-        compare<base_u64, cand_u64, boost_u64>("rhit64", epochs, boost, [](auto* m) {
-            return random_find<std::remove_pointer_t<decltype(m)>, 100>();
-        });
-    if (want("rmiss64"))
-        compare<base_u64, cand_u64, boost_u64>("rmiss64", epochs, boost, [](auto* m) {
-            return random_find<std::remove_pointer_t<decltype(m)>, 0>();
-        });
-    if (want("rhitstr"))
-        compare<base_str, cand_str, boost_str>("rhitstr", epochs, boost, [](auto* m) {
-            return random_find<std::remove_pointer_t<decltype(m)>, 100>();
-        });
-    if (want("rmissstr"))
-        compare<base_str, cand_str, boost_str>("rmissstr", epochs, boost, [](auto* m) {
-            return random_find<std::remove_pointer_t<decltype(m)>, 0>();
-        });
+    U64("rhit64", find_hits);
+    U64("rmiss64", find_misses);
+    STR("rhitstr", find_hits);
+    STR("rmissstr", find_misses);
     return 0;
 }

--- a/scripts/ab/run.sh
+++ b/scripts/ab/run.sh
@@ -8,7 +8,7 @@
 #   -c COMPILER  default clang++
 #
 # Uses the vendored nanobench (test/third-party, >= 4.6 for Bench::compare()); NANOBENCH_INCLUDE
-# overrides it. Everything is built in $AB_BUILD (default: a temporary directory), the tree is not
+# overrides it. The workloads come from test/bench/workloads.h, the benchmark's own. Everything is built in $AB_BUILD (default: a temporary directory), the tree is not
 # touched.
 set -euo pipefail
 rev=HEAD boost=0 cxx=clang++
@@ -23,16 +23,15 @@ done
 shift $((OPTIND - 1))
 [ $# -ge 1 ] || { sed -n '2,12p' "$0"; exit 1; }
 root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
-nb=${NANOBENCH_INCLUDE:-$root/test/third-party}
 build=${AB_BUILD:-$(mktemp -d)}
 mkdir -p "$build"
 # the baseline header, in its own namespace and macro prefix, beside the candidate one
 git -C "$root" show "$rev:include/ankerl/unordered_dense.h" \
     | sed 's/ankerl::unordered_dense/udmbase::unordered_dense/g; s/ANKERL_UNORDERED_DENSE/UDMBASE_UNORDERED_DENSE/g; s/namespace ankerl/namespace udmbase/g; s|#        include "stl.h"|#        include <ankerl/stl.h>|' \
     > "$build/base.h"
-flags=(-O3 -DNDEBUG -std=c++17 -I"$build" -I"$root/include" -I"$nb")
+flags=(-O3 -DNDEBUG -std=c++17 -I"$build" -I"$root/include" -I"$root/test")
 [ $boost = 1 ] && flags+=(-DUDM_AB_HAVE_BOOST)
-[ -f "$build/nanobench_$cxx.o" ] || (cd "$build" && printf '#define ANKERL_NANOBENCH_IMPLEMENT\n#include <nanobench.h>\n' > nb.cpp && "$cxx" "${flags[@]}" -c nb.cpp -o "nanobench_$cxx.o")
+[ -f "$build/nanobench_$cxx.o" ] || (cd "$build" && printf '#define ANKERL_NANOBENCH_IMPLEMENT\n#include <third-party/nanobench.h>\n' > nb.cpp && "$cxx" "${flags[@]}" -c nb.cpp -o "nanobench_$cxx.o")
 "$cxx" "${flags[@]}" "$root/scripts/ab/ab.cpp" "$build/nanobench_$cxx.o" -o "$build/ab"
 echo "baseline $rev vs working tree, $cxx, in $build" >&2
 "$build/ab" "$1" "${2:-12}" "$boost"

--- a/scripts/ab/run.sh
+++ b/scripts/ab/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Paired A/B of the working-tree header against a git revision of it (default: HEAD).
+#
+#   scripts/ab/run.sh [-r REV] [-b] [-c COMPILER] <workload|all> [epochs] 
+#
+#   -r REV       baseline revision (default HEAD)
+#   -b           also measure boost::unordered_flat_map (needs boost headers)
+#   -c COMPILER  default clang++
+#
+# Needs nanobench >= 4.6 for Bench::compare(); point NANOBENCH_INCLUDE at its include directory.
+# Everything is built in $AB_BUILD (default: a temporary directory), the tree is not touched.
+set -euo pipefail
+rev=HEAD boost=0 cxx=clang++
+while getopts "r:bc:" opt; do
+    case $opt in
+        r) rev=$OPTARG ;;
+        b) boost=1 ;;
+        c) cxx=$OPTARG ;;
+        *) exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
+[ $# -ge 1 ] || { sed -n '2,12p' "$0"; exit 1; }
+root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+nb=${NANOBENCH_INCLUDE:?set NANOBENCH_INCLUDE to a nanobench >= 4.6 include directory}
+build=${AB_BUILD:-$(mktemp -d)}
+mkdir -p "$build"
+# the baseline header, in its own namespace and macro prefix, beside the candidate one
+git -C "$root" show "$rev:include/ankerl/unordered_dense.h" \
+    | sed 's/ankerl::unordered_dense/udmbase::unordered_dense/g; s/ANKERL_UNORDERED_DENSE/UDMBASE_UNORDERED_DENSE/g; s/namespace ankerl/namespace udmbase/g; s|#        include "stl.h"|#        include <ankerl/stl.h>|' \
+    > "$build/base.h"
+flags=(-O3 -DNDEBUG -std=c++17 -I"$build" -I"$root/include" -I"$nb")
+[ $boost = 1 ] && flags+=(-DUDM_AB_HAVE_BOOST)
+[ -f "$build/nanobench_$cxx.o" ] || (cd "$build" && printf '#define ANKERL_NANOBENCH_IMPLEMENT\n#include <nanobench.h>\n' > nb.cpp && "$cxx" "${flags[@]}" -c nb.cpp -o "nanobench_$cxx.o")
+"$cxx" "${flags[@]}" "$root/scripts/ab/ab.cpp" "$build/nanobench_$cxx.o" -o "$build/ab"
+echo "baseline $rev vs working tree, $cxx, in $build" >&2
+"$build/ab" "$1" "${2:-12}" "$boost"

--- a/scripts/ab/run.sh
+++ b/scripts/ab/run.sh
@@ -7,8 +7,9 @@
 #   -b           also measure boost::unordered_flat_map (needs boost headers)
 #   -c COMPILER  default clang++
 #
-# Needs nanobench >= 4.6 for Bench::compare(); point NANOBENCH_INCLUDE at its include directory.
-# Everything is built in $AB_BUILD (default: a temporary directory), the tree is not touched.
+# Uses the vendored nanobench (test/third-party, >= 4.6 for Bench::compare()); NANOBENCH_INCLUDE
+# overrides it. Everything is built in $AB_BUILD (default: a temporary directory), the tree is not
+# touched.
 set -euo pipefail
 rev=HEAD boost=0 cxx=clang++
 while getopts "r:bc:" opt; do
@@ -22,7 +23,7 @@ done
 shift $((OPTIND - 1))
 [ $# -ge 1 ] || { sed -n '2,12p' "$0"; exit 1; }
 root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
-nb=${NANOBENCH_INCLUDE:?set NANOBENCH_INCLUDE to a nanobench >= 4.6 include directory}
+nb=${NANOBENCH_INCLUDE:-$root/test/third-party}
 build=${AB_BUILD:-$(mktemp -d)}
 mkdir -p "$build"
 # the baseline header, in its own namespace and macro prefix, beside the candidate one

--- a/src/ankerl.unordered_dense.cpp
+++ b/src/ankerl.unordered_dense.cpp
@@ -15,6 +15,14 @@ module;
 import std;
 #endif
 
+// The vector probe reads four buckets at once through x86 intrinsics, and those are declared by a
+// header included here, in the global module fragment. A translation unit that imports this module
+// does not include that header, and clang does not carry the declarations across the module
+// boundary either -- instantiating the probe in the importing translation unit then fails to find
+// _mm_cmpeq_epi32. So a module is built with the scalar probe. Everything else the module offers is
+// unaffected, and a consumer that includes the header directly still gets the vector probe.
+#define ANKERL_UNORDERED_DENSE_HAS_SSE2 0 // NOLINT(cppcoreguidelines-macro-usage)
+
 #include <ankerl/unordered_dense.h>
 
 export module ankerl.unordered_dense;

--- a/test/app/hashers.h
+++ b/test/app/hashers.h
@@ -55,4 +55,14 @@ struct narrow_avalanching_hash {
     }
 };
 
+// Returns the key: a test that wants to choose the bucket a key lands in, and its fingerprint,
+// spells them out in the key. Avalanching, so that mixed_hash() passes it through untouched.
+struct identity_hash {
+    using is_avalanching = void;
+
+    [[nodiscard]] auto operator()(std::uint64_t key) const noexcept -> std::uint64_t {
+        return key;
+    }
+};
+
 } // namespace test

--- a/test/bench/quick_overall_map.cpp
+++ b/test/bench/quick_overall_map.cpp
@@ -2,13 +2,13 @@
 
 #include <app/doctest.h>           // for TestCase, skip, ResultBuilder
 #include <app/geomean.h>           // for geomean
-#include <third-party/nanobench.h> // for Rng, doNotOptimizeAway, Bench
+#include <bench/workloads.h>       // for insert_erase, iterate, find_50, find_all
+#include <third-party/nanobench.h> // for Bench
 
 #include <fmt/format.h> // for print, format
 
 #include <chrono>        // for duration, operator-, high_resolu...
 #include <cstdint>       // for uint64_t
-#include <cstring>       // for size_t, memcpy
 #include <deque>         // for deque
 #include <string>        // for string, basic_string, operator==
 #include <string_view>   // for string_view, literals
@@ -19,137 +19,26 @@ using namespace std::literals;
 
 namespace {
 
-template <typename K>
-inline auto init_key() -> K {
-    return {};
-}
-
-template <typename T>
-inline void randomize_key(ankerl::nanobench::Rng* rng, int n, T* key) {
-    // we limit ourselves to 32bit n
-    auto limited = (((*rng)() >> 32U) * static_cast<uint64_t>(n)) >> 32U;
-    *key = static_cast<T>(limited);
-}
-
-template <>
-[[nodiscard]] inline auto init_key<std::string>() -> std::string {
-    std::string str;
-    str.resize(200);
-    return str;
-}
-
-inline void randomize_key(ankerl::nanobench::Rng* rng, int n, std::string* key) {
-    uint64_t k{};
-    randomize_key(rng, n, &k);
-    std::memcpy(key->data(), &k, sizeof(k));
-}
-
-template <typename T>
-inline void set_key(uint64_t v, T* key) {
-    *key = static_cast<T>(v);
-}
-
-inline void set_key(uint64_t v, std::string* key) {
-    std::memcpy(key->data(), &v, sizeof(v));
-}
-
-// Random insert & erase
 template <typename Map>
 void bench_random_insert_erase(ankerl::nanobench::Bench* bench, std::string_view name) {
     bench->run(fmt::format("{} random insert erase", name), [&] {
-        ankerl::nanobench::Rng rng(123);
-        size_t verifier{};
-        Map map;
-        auto key = init_key<typename Map::key_type>();
-        for (int n = 1; n < 20000; ++n) {
-            for (int i = 0; i < 200; ++i) {
-                randomize_key(&rng, n, &key);
-                map[key];
-                randomize_key(&rng, n, &key);
-                verifier += map.erase(key);
-            }
-        }
-        CHECK(verifier == 1994641U);
-        CHECK(map.size() == 9987U);
+        auto r = workloads::insert_erase<Map>();
+        CHECK(r.erased == 1994641U);
+        CHECK(r.size == 9987U);
     });
 }
 
-// iterate
 template <typename Map>
 void bench_iterate(ankerl::nanobench::Bench* bench, std::string_view name) {
-    size_t const num_elements = 5000;
-
-    auto key = init_key<typename Map::key_type>();
-
-    // insert
     bench->run(fmt::format("{} iterate while adding then removing", name), [&] {
-        ankerl::nanobench::Rng rng(555);
-        Map map;
-        size_t result = 0;
-        for (size_t n = 0; n < num_elements; ++n) {
-            randomize_key(&rng, 1000000, &key);
-            map[key] = n;
-            for (auto const& key_val : map) {
-                result += key_val.second;
-            }
-        }
-
-        rng = ankerl::nanobench::Rng(555);
-        do {
-            randomize_key(&rng, 1000000, &key);
-            map.erase(key);
-            for (auto const& key_val : map) {
-                result += key_val.second;
-            }
-        } while (!map.empty());
-
-        CHECK(result == 62282755409U);
+        CHECK(workloads::iterate<Map>() == 62282755409U);
     });
 }
 
-// Random finds against a map that grows to ~50k entries while it is searched. Half of the
-// lookups find a key that is in the map, chosen at random among those; the other half look for a
-// key that cannot be. Which of the two each lookup is, is decided by an rng of its own, so nothing
-// here repeats. It used to: the searches replayed the insertion sequence from the same seed, and
-// a branch predictor with a long history learned half of the outcomes (0.6 mispredictions per
-// lookup where a random sequence costs 1.35). A change that trades instructions for
-// mispredictions looked worse here than it was.
 template <typename Map>
 void bench_random_find(ankerl::nanobench::Bench* bench, std::string_view name) {
     bench->run(fmt::format("{} 50% probability to find", name), [&] {
-        ankerl::nanobench::Rng insert_rng(123123);
-        ankerl::nanobench::Rng search_rng(987654321);
-        constexpr auto never_inserted = uint64_t{1} << 63U;
-
-        std::vector<uint64_t> inserted;
-        size_t checksum = 0;
-        Map map;
-        auto key = init_key<typename Map::key_type>();
-        for (size_t i = 0; i < 100000; ++i) {
-            // half of the candidates go in; the first one always, so there is something to find
-            auto candidate = insert_rng() & ~never_inserted;
-            if (inserted.empty() || (insert_rng() & 1U) != 0) {
-                set_key(candidate, &key);
-                if (map.emplace(key, i).second) {
-                    inserted.push_back(candidate);
-                }
-            }
-
-            // search 100 entries in the map
-            for (size_t search = 0; search < 100; ++search) {
-                auto r = search_rng();
-                if ((r & 1U) != 0) {
-                    set_key(inserted[((r >> 32U) * inserted.size()) >> 32U], &key);
-                } else {
-                    set_key(r | never_inserted, &key);
-                }
-                auto it = map.find(key);
-                if (it != map.end()) {
-                    checksum += it->second;
-                }
-            }
-        }
-        CHECK(checksum == 124865472559U);
+        CHECK(workloads::find_50<Map>() == 124865472559U);
     });
 }
 
@@ -226,6 +115,26 @@ TEST_CASE("bench_quick_overall_udm" * doctest::test_suite("bench") * doctest::sk
     bench_all<map_str_t>(&bench, "ankerl::unordered_dense::map<std::string, size_t>");
 
     fmt::print("{} bench_quick_overall_map_udm\n", geomean1(bench));
+}
+
+// The two ends of what a workload's hit rate can do to the probe; not part of the score.
+TEST_CASE("bench_find_all_hits_or_misses_udm" * doctest::test_suite("bench") * doctest::skip()) {
+    ankerl::nanobench::Bench bench;
+    bench.title("find").minEpochTime(100ms);
+    using map_t = ankerl::unordered_dense::map<uint64_t, size_t>;
+    using map_str_t = ankerl::unordered_dense::map<std::string, size_t, hash_str_t>;
+    bench.run("map<uint64_t, size_t> all hits", [] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_t, true>());
+    });
+    bench.run("map<uint64_t, size_t> no hits", [] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_t, false>());
+    });
+    bench.run("map<std::string, size_t> all hits", [] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_str_t, true>());
+    });
+    bench.run("map<std::string, size_t> no hits", [] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_str_t, false>());
+    });
 }
 
 TEST_CASE("bench_quick_overall_segmented_vector" * doctest::test_suite("bench") * doctest::skip()) {

--- a/test/bench/quick_overall_map.cpp
+++ b/test/bench/quick_overall_map.cpp
@@ -44,6 +44,15 @@ inline void randomize_key(ankerl::nanobench::Rng* rng, int n, std::string* key) 
     std::memcpy(key->data(), &k, sizeof(k));
 }
 
+template <typename T>
+inline void set_key(uint64_t v, T* key) {
+    *key = static_cast<T>(v);
+}
+
+inline void set_key(uint64_t v, std::string* key) {
+    std::memcpy(key->data(), &v, sizeof(v));
+}
+
 // Random insert & erase
 template <typename Map>
 void bench_random_insert_erase(ankerl::nanobench::Bench* bench, std::string_view name) {
@@ -98,56 +107,49 @@ void bench_iterate(ankerl::nanobench::Bench* bench, std::string_view name) {
     });
 }
 
-// 111.903 222
-// 112.023 123123
+// Random finds against a map that grows to ~50k entries while it is searched. Half of the
+// lookups find a key that is in the map, chosen at random among those; the other half look for a
+// key that cannot be. Which of the two each lookup is, is decided by an rng of its own, so nothing
+// here repeats. It used to: the searches replayed the insertion sequence from the same seed, and
+// a branch predictor with a long history learned half of the outcomes (0.6 mispredictions per
+// lookup where a random sequence costs 1.35). A change that trades instructions for
+// mispredictions looked worse here than it was.
 template <typename Map>
 void bench_random_find(ankerl::nanobench::Bench* bench, std::string_view name) {
-
     bench->run(fmt::format("{} 50% probability to find", name), [&] {
-        uint64_t const seed = 123123;
-        ankerl::nanobench::Rng numbers_insert_rng(seed);
-        size_t numbers_insert_rng_calls = 0;
+        ankerl::nanobench::Rng insert_rng(123123);
+        ankerl::nanobench::Rng search_rng(987654321);
+        constexpr auto never_inserted = uint64_t{1} << 63U;
 
-        ankerl::nanobench::Rng numbers_search_rng(seed);
-        size_t numbers_search_rng_calls = 0;
-
-        ankerl::nanobench::Rng insertion_rng(123);
-
+        std::vector<uint64_t> inserted;
         size_t checksum = 0;
-        size_t found = 0;
-        size_t not_found = 0;
-
         Map map;
         auto key = init_key<typename Map::key_type>();
         for (size_t i = 0; i < 100000; ++i) {
-            randomize_key(&numbers_insert_rng, 1000000, &key);
-            ++numbers_insert_rng_calls;
-
-            if (insertion_rng() & 1U) {
-                map[key] = i;
+            // half of the candidates go in; the first one always, so there is something to find
+            auto candidate = insert_rng() & ~never_inserted;
+            if (inserted.empty() || (insert_rng() & 1U) != 0) {
+                set_key(candidate, &key);
+                if (map.emplace(key, i).second) {
+                    inserted.push_back(candidate);
+                }
             }
 
             // search 100 entries in the map
             for (size_t search = 0; search < 100; ++search) {
-                randomize_key(&numbers_search_rng, 1000000, &key);
-                ++numbers_search_rng_calls;
-
+                auto r = search_rng();
+                if ((r & 1U) != 0) {
+                    set_key(inserted[((r >> 32U) * inserted.size()) >> 32U], &key);
+                } else {
+                    set_key(r | never_inserted, &key);
+                }
                 auto it = map.find(key);
                 if (it != map.end()) {
                     checksum += it->second;
-                    ++found;
-                } else {
-                    ++not_found;
-                }
-                if (numbers_insert_rng_calls == numbers_search_rng_calls) {
-                    numbers_search_rng = ankerl::nanobench::Rng(seed);
-                    numbers_search_rng_calls = 0;
                 }
             }
         }
-        ankerl::nanobench::doNotOptimizeAway(checksum);
-        ankerl::nanobench::doNotOptimizeAway(found);
-        ankerl::nanobench::doNotOptimizeAway(not_found);
+        CHECK(checksum == 124865472559U);
     });
 }
 

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -1,0 +1,171 @@
+#pragma once
+
+// The workloads of bench_quick_overall_udm, as functions of the map type that return what the
+// benchmark checks. Shared with scripts/ab, whose paired A/B replicates the benchmark exactly --
+// exactly because there is one copy.
+
+#include <third-party/nanobench.h> // for Rng
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace workloads {
+
+template <typename K>
+inline auto init_key() -> K {
+    return {};
+}
+
+template <>
+inline auto init_key<std::string>() -> std::string {
+    std::string str;
+    str.resize(200);
+    return str;
+}
+
+// the first 8 bytes of a string key carry the value; the rest stays zero
+template <typename T>
+inline void set_key(uint64_t v, T* key) {
+    *key = static_cast<T>(v);
+}
+
+inline void set_key(uint64_t v, std::string* key) {
+    std::memcpy(key->data(), &v, sizeof(v));
+}
+
+// a random key in [0, n)
+template <typename T>
+inline void randomize_key(ankerl::nanobench::Rng* rng, int n, T* key) {
+    // we limit ourselves to 32bit n
+    auto limited = (((*rng)() >> 32U) * static_cast<uint64_t>(n)) >> 32U;
+    set_key(limited, key);
+}
+
+struct insert_erase_result {
+    size_t erased;
+    size_t size;
+};
+
+// Random insert & erase, ~10k entries live
+template <typename Map>
+auto insert_erase() -> insert_erase_result {
+    ankerl::nanobench::Rng rng(123);
+    size_t erased{};
+    Map map;
+    auto key = init_key<typename Map::key_type>();
+    for (int n = 1; n < 20000; ++n) {
+        for (int i = 0; i < 200; ++i) {
+            randomize_key(&rng, n, &key);
+            map[key];
+            randomize_key(&rng, n, &key);
+            erased += map.erase(key);
+        }
+    }
+    return {erased, map.size()};
+}
+
+// iterate while adding, then while removing
+template <typename Map>
+auto iterate() -> size_t {
+    size_t const num_elements = 5000;
+    auto key = init_key<typename Map::key_type>();
+    ankerl::nanobench::Rng rng(555);
+    Map map;
+    size_t result = 0;
+    for (size_t n = 0; n < num_elements; ++n) {
+        randomize_key(&rng, 1000000, &key);
+        map[key] = n;
+        for (auto const& key_val : map) {
+            result += key_val.second;
+        }
+    }
+
+    rng = ankerl::nanobench::Rng(555);
+    do {
+        randomize_key(&rng, 1000000, &key);
+        map.erase(key);
+        for (auto const& key_val : map) {
+            result += key_val.second;
+        }
+    } while (!map.empty());
+    return result;
+}
+
+// Random finds against a map that grows to ~50k entries while it is searched. Half of the
+// lookups find a key that is in the map, chosen at random among those; the other half look for a
+// key that cannot be. Which of the two each lookup is, is decided by an rng of its own, so nothing
+// here repeats. It used to: the searches replayed the insertion sequence from the same seed, and
+// a branch predictor with a long history learned half of the outcomes (0.6 mispredictions per
+// lookup where a random sequence costs 1.35). A change that trades instructions for
+// mispredictions looked worse here than it was.
+template <typename Map>
+auto find_50() -> size_t {
+    ankerl::nanobench::Rng insert_rng(123123);
+    ankerl::nanobench::Rng search_rng(987654321);
+    constexpr auto never_inserted = uint64_t{1} << 63U;
+
+    std::vector<uint64_t> inserted;
+    inserted.reserve(100000);
+    size_t checksum = 0;
+    Map map;
+    auto key = init_key<typename Map::key_type>();
+    for (size_t i = 0; i < 100000; ++i) {
+        // half of the candidates go in; the first one always, so there is something to find
+        auto candidate = insert_rng() & ~never_inserted;
+        if (inserted.empty() || (insert_rng() & 1U) != 0) {
+            set_key(candidate, &key);
+            if (map.emplace(key, i).second) {
+                inserted.push_back(candidate);
+            }
+        }
+
+        // search 100 entries in the map
+        for (size_t search = 0; search < 100; ++search) {
+            auto r = search_rng();
+            if ((r & 1U) != 0) {
+                set_key(inserted[((r >> 32U) * inserted.size()) >> 32U], &key);
+            } else {
+                set_key(r | never_inserted, &key);
+            }
+            auto it = map.find(key);
+            if (it != map.end()) {
+                checksum += it->second;
+            }
+        }
+    }
+    return checksum;
+}
+
+// 50k entries, then 10M lookups that all hit (a random key that is there) or all miss (one that
+// cannot be): the two ends of what a workload's hit rate can do to the probe.
+template <typename Map, bool Hits>
+auto find_all() -> size_t {
+    ankerl::nanobench::Rng rng(999);
+    constexpr auto never_inserted = uint64_t{1} << 63U;
+    Map map;
+    std::vector<uint64_t> keys;
+    keys.reserve(50000);
+    auto key = init_key<typename Map::key_type>();
+    while (map.size() < 50000) {
+        auto v = rng() & ~never_inserted;
+        set_key(v, &key);
+        if (map.emplace(key, keys.size()).second) {
+            keys.push_back(v);
+        }
+    }
+    size_t checksum = 0;
+    auto const num_keys = keys.size();
+    for (size_t i = 0; i < 10000000; ++i) {
+        auto r = rng();
+        set_key(Hits ? keys[((r >> 32U) * num_keys) >> 32U] : (r | never_inserted), &key);
+        auto it = map.find(key);
+        if (it != map.end()) {
+            checksum += it->second;
+        }
+    }
+    return checksum;
+}
+
+} // namespace workloads

--- a/test/meson.build
+++ b/test/meson.build
@@ -244,9 +244,14 @@ benchmark(
     args: ['-ns', '-ts=bench'],
     verbose: true)
 
+# Meson's default is 30 seconds, which a sanitizer build of this suite no longer fits into: address
+# and undefined together, with detect_stack_use_after_return, cost it well over an order of
+# magnitude, and a Valgrind run costs more again. The timeout is here to catch a hang, so it only
+# has to be shorter than a CI job.
 test(
     'unit',
     test_exe,
+    timeout: 600,
     verbose: true)
 
 # libFuzzer targets. The unit suite replays data/fuzz/<name> on every build, which by construction

--- a/test/meson.build
+++ b/test/meson.build
@@ -74,6 +74,7 @@ test_sources = [
     'unit/not_moveable.cpp',
     'unit/pmr_move_with_allocators.cpp',
     'unit/precomputed_hash.cpp',
+    'unit/probe_wrap.cpp',
     'unit/pmr.cpp',
     'unit/reentrant.cpp',
     'unit/rehash.cpp',

--- a/test/third-party/nanobench.h
+++ b/test/third-party/nanobench.h
@@ -7,7 +7,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2019-2022 Martin Ankerl <martin.ankerl@gmail.com>
+// Copyright (c) 2019-2023 Martin Leitner-Ankerl <martin.ankerl@gmail.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -32,22 +32,32 @@
 
 // see https://semver.org/
 #define ANKERL_NANOBENCH_VERSION_MAJOR 4 // incompatible API changes
-#define ANKERL_NANOBENCH_VERSION_MINOR 3 // backwards-compatible changes
-#define ANKERL_NANOBENCH_VERSION_PATCH 7 // backwards-compatible bug fixes
+#define ANKERL_NANOBENCH_VERSION_MINOR 6 // backwards-compatible changes
+#define ANKERL_NANOBENCH_VERSION_PATCH 0 // backwards-compatible bug fixes
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // public facing api - as minimal as possible
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include <chrono>  // high_resolution_clock
-#include <cstring> // memcpy
-#include <iosfwd>  // for std::ostream* custom output target in Config
-#include <string>  // all names
-#include <vector>  // holds all results
+#include <chrono>        // high_resolution_clock
+#include <cmath>         // log & exp for the paired A/B statistics
+#include <cstring>       // memcpy
+#include <iosfwd>        // for std::ostream* custom output target in Config
+#include <string>        // all names
+#include <unordered_map> // holds context information of results
+#include <vector>        // holds all results
 
 #define ANKERL_NANOBENCH(x) ANKERL_NANOBENCH_PRIVATE_##x()
 
-#define ANKERL_NANOBENCH_PRIVATE_CXX() __cplusplus
+// MSVC reports __cplusplus as 199711L whatever /std: says, unless /Zc:__cplusplus is passed - and it
+// is not passed by default. _MSVC_LANG carries the real value. Getting this wrong does not fail to
+// compile, it silently takes the pre-C++17 branch on MSVC, which is how [[nodiscard]] was missing
+// there.
+#if defined(_MSVC_LANG)
+#    define ANKERL_NANOBENCH_PRIVATE_CXX() _MSVC_LANG
+#else
+#    define ANKERL_NANOBENCH_PRIVATE_CXX() __cplusplus
+#endif
 #define ANKERL_NANOBENCH_PRIVATE_CXX98() 199711L
 #define ANKERL_NANOBENCH_PRIVATE_CXX11() 201103L
 #define ANKERL_NANOBENCH_PRIVATE_CXX14() 201402L
@@ -55,8 +65,14 @@
 
 #if ANKERL_NANOBENCH(CXX) >= ANKERL_NANOBENCH(CXX17)
 #    define ANKERL_NANOBENCH_PRIVATE_NODISCARD() [[nodiscard]]
+#    define ANKERL_NANOBENCH_PRIVATE_HAS_STRING_VIEW() 1
 #else
 #    define ANKERL_NANOBENCH_PRIVATE_NODISCARD()
+#    define ANKERL_NANOBENCH_PRIVATE_HAS_STRING_VIEW() 0
+#endif
+
+#if ANKERL_NANOBENCH(HAS_STRING_VIEW)
+#    include <string_view> // the name() and run() overloads
 #endif
 
 #if defined(__clang__)
@@ -91,7 +107,7 @@
 #define ANKERL_NANOBENCH_PRIVATE_PERF_COUNTERS() 0
 #if defined(__linux__) && !defined(ANKERL_NANOBENCH_DISABLE_PERF_COUNTERS)
 #    include <linux/version.h>
-#    if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
+#    if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 3, 0)
 // PERF_COUNT_HW_REF_CPU_CYCLES only available since kernel 3.3
 // PERF_FLAG_FD_CLOEXEC since kernel 3.14
 #        undef ANKERL_NANOBENCH_PRIVATE_PERF_COUNTERS
@@ -111,12 +127,39 @@
 #    define ANKERL_NANOBENCH_PRIVATE_NOINLINE() __attribute__((noinline))
 #endif
 
+// Whether doNotOptimizeAway can use GCC-style inline assembly, which is both faster and a stronger barrier than the
+// function call it falls back to. Testing for _MSC_VER is not enough to rule it out: clang-cl and clang in MSVC
+// compatibility mode define _MSC_VER but not __GNUC__, even though they do understand the assembly.
+// See https://github.com/martinus/nanobench/issues/111
+#if defined(__clang__) || defined(__GNUC__)
+#    define ANKERL_NANOBENCH_PRIVATE_ASM_DONT_OPTIMIZE_AWAY() 1
+#else
+#    define ANKERL_NANOBENCH_PRIVATE_ASM_DONT_OPTIMIZE_AWAY() 0
+#endif
+
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 // See https://stackoverflow.com/a/31798726/48181
 #if defined(__GNUC__) && __GNUC__ < 5
 #    define ANKERL_NANOBENCH_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
 #else
 #    define ANKERL_NANOBENCH_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
+#endif
+
+// noexcept may be missing for std::string.
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58265
+#define ANKERL_NANOBENCH_PRIVATE_NOEXCEPT_STRING_MOVE() std::is_nothrow_move_assignable<std::string>::value
+
+// nanobench throws only for programming errors in a render template - a tag that does not exist, a
+// section in the wrong place. With exceptions turned off there is nothing sensible left to do but
+// stop, so the argument is never evaluated and the message building disappears entirely.
+//
+// std::abort() rather than a per-compiler intrinsic on purpose: the branch that would pick one is
+// the branch no CI leg can reach, and an untested call into CRT internals is exactly the kind of
+// thing that turns out not to compile the first time someone actually needs it.
+#if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+#    define ANKERL_NANOBENCH_THROW(...) throw __VA_ARGS__
+#else
+#    define ANKERL_NANOBENCH_THROW(...) std::abort()
 #endif
 
 // declarations ///////////////////////////////////////////////////////////////////////////////////
@@ -131,6 +174,44 @@ struct Config;
 class Result;
 class Rng;
 class BigO;
+class CompareResult;
+
+namespace detail {
+template <typename SetupOp>
+class SetupRunner;
+
+// One of compare()'s alternatives, with its type forgotten so that they can live in a vector.
+//
+// The alternatives all have different types, so holding them needs either type erasure or a template
+// recursion that walks the pack at every step. This is the erasure, and it costs nothing that
+// matters: `run` points at an instantiation that knows the concrete type, so the measuring loop is
+// inside a function where the operation still inlines exactly as it would otherwise. What is added
+// is one indirect call per *epoch*, against an epoch of a millisecond.
+//
+// std::function would not do, because it would put that indirection in the inner loop instead.
+struct ErasedOp {
+    void (*run)(void* op, uint64_t numIters); // NOLINT(misc-non-private-member-variables-in-classes)
+    void* op;                                 // NOLINT(misc-non-private-member-variables-in-classes)
+};
+
+template <typename Op>
+void runErasedOp(void* op, uint64_t numIters) {
+    auto& concrete = *static_cast<Op*>(op);
+    for (uint64_t i = 0; i < numIters; ++i) {
+        concrete();
+    }
+}
+
+template <typename Op>
+ErasedOp eraseOp(Op&& op) {
+    using Bare = typename std::remove_reference<Op>::type;
+    // The operation is only ever called, never written to, so casting a const one back to non-const
+    // to fit it through void* is safe - a const lambda's operator() is const or it could not be
+    // called at all.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return ErasedOp{&runErasedOp<Bare>, const_cast<void*>(static_cast<void const*>(&op))};
+}
+} // namespace detail
 
 /**
  * @brief Renders output from a mustache-like template and benchmark results.
@@ -144,44 +225,52 @@ class BigO;
  * * `{{#result}}` Marks the begin of the result layer. Whatever comes after this will be instantiated as often as
  *   a benchmark result is available. Within it, you can use these tags:
  *
- *    * `{{title}}` See Bench::title().
+ *    * `{{title}}` See Bench::title.
  *
- *    * `{{name}}` Benchmark name, usually directly provided with Bench::run(), but can also be set with Bench::name().
+ *    * `{{name}}` Benchmark name, usually directly provided with Bench::run, but can also be set with Bench::name.
  *
- *    * `{{unit}}` Unit, e.g. `byte`. Defaults to `op`, see Bench::title().
+ *    * `{{unit}}` Unit, e.g. `byte`. Defaults to `op`, see Bench::unit.
  *
- *    * `{{batch}}` Batch size, see Bench::batch().
+ *    * `{{batch}}` Batch size, see Bench::batch.
  *
- *    * `{{complexityN}}` Value used for asymptotic complexity calculation. See Bench::complexityN().
+ *    * `{{complexityN}}` Value used for asymptotic complexity calculation. See Bench::complexityN.
  *
- *    * `{{epochs}}` Number of epochs, see Bench::epochs().
+ *    * `{{epochs}}` Number of epochs, see Bench::epochs.
  *
  *    * `{{clockResolution}}` Accuracy of the clock, i.e. what's the smallest time possible to measure with the clock.
  *      For modern systems, this can be around 20 ns. This value is automatically determined by nanobench at the first
  *      benchmark that is run, and used as a static variable throughout the application's runtime.
  *
- *    * `{{clockResolutionMultiple}}` Configuration multiplier for `clockResolution`. See Bench::clockResolutionMultiple().
+ *    * `{{clockResolutionMultiple}}` Configuration multiplier for `clockResolution`. See Bench::clockResolutionMultiple.
  *      This is the target runtime for each measurement (epoch). That means the more accurate your clock is, the faster
  *      will be the benchmark. Basing the measurement's runtime on the clock resolution is the main reason why nanobench is so fast.
  *
  *    * `{{maxEpochTime}}` Configuration for a maximum time each measurement (epoch) is allowed to take. Note that at least
- *      a single iteration will be performed, even when that takes longer than maxEpochTime. See Bench::maxEpochTime().
+ *      a single iteration will be performed, even when that takes longer than maxEpochTime. See Bench::maxEpochTime.
  *
- *    * `{{minEpochTime}}` Minimum epoch time, defaults to 1ms. See Bench::minEpochTime().
+ *    * `{{minEpochTime}}` Minimum epoch time, defaults to 1ms. See Bench::minEpochTime.
  *
- *    * `{{minEpochIterations}}` See Bench::minEpochIterations().
+ *    * `{{minEpochIterations}}` See Bench::minEpochIterations.
  *
- *    * `{{epochIterations}}` See Bench::epochIterations().
+ *    * `{{epochIterations}}` See Bench::epochIterations.
  *
- *    * `{{warmup}}` Number of iterations used before measuring starts. See Bench::warmup().
+ *    * `{{warmup}}` Number of iterations used before measuring starts. See Bench::warmup.
  *
- *    * `{{relative}}` True or false, depending on the setting you have used. See Bench::relative().
+ *    * `{{relative}}` True or false, depending on the setting you have used. See Bench::relative.
+ *
+ *    * `{{context(variableName)}}` See Bench::context.
  *
  *    Apart from these tags, it is also possible to use some mathematical operations on the measurement data. The operations
  *    are of the form `{{command(name)}}`.  Currently `name` can be one of `elapsed`, `iterations`. If performance counters
  *    are available (currently only on current Linux systems), you also have `pagefaults`, `cpucycles`,
- *    `contextswitches`, `instructions`, `branchinstructions`, and `branchmisses`. All the measuers (except `iterations`) are
+ *    `contextswitches`, `instructions`, `branchinstructions`, and `branchmisses`. All the measures (except `iterations`) are
  *    provided for a single iteration (so `elapsed` is the time a single iteration took). The following tags are available:
+ *
+ *    `elapsed` is in **seconds**, which is rarely the unit a report wants. Since the template language has no arithmetic
+ *    to scale it afterwards, the time measure also comes in `elapsedms`, `elapsedus` and `elapsedns` — the same value in
+ *    milliseconds, microseconds and nanoseconds. So `{{minimum(elapsedms)}}` is the fastest iteration in milliseconds.
+ *    Note this is unrelated to Bench::timeUnit(), which only sets the unit of the `ns/op` column in the table.
+ *    `{{medianAbsolutePercentError(...)}}` is a relative error, so it is the same number whichever of them you ask for.
  *
  *    * `{{median(<name>)}}` Calculate median of a measurement data set, e.g. `{{median(elapsed)}}`.
  *
@@ -201,7 +290,7 @@ class BigO;
  *      This measurement is a bit hard to interpret, but it is very robust against outliers. E.g. a value of 5% means that half of the
  *      measurements deviate less than 5% from the median, and the other deviate more than 5% from the median.
  *
- *    * `{{sum(<name>)}}` Sums of all the measurements. E.g. `{{sum(iterations)}}` will give you the total number of iterations
+ *    * `{{sum(<name>)}}` Sum of all the measurements. E.g. `{{sum(iterations)}}` will give you the total number of iterations
 *        measured in this benchmark.
  *
  *    * `{{minimum(<name>)}}` Minimum of all measurements.
@@ -244,21 +333,21 @@ class BigO;
  *  For the layer tags *result* and *measurement* you additionally can use these special markers:
  *
  *  * ``{{#-first}}`` - Begin marker of a template that will be instantiated *only for the first* entry in the layer. Use is only
- *    allowed between the begin and end marker of the layer allowed. So between ``{{#result}}`` and ``{{/result}}``, or between
+ *    allowed between the begin and end marker of the layer. So between ``{{#result}}`` and ``{{/result}}``, or between
  *    ``{{#measurement}}`` and ``{{/measurement}}``. Finish the template with ``{{/-first}}``.
  *
  *  * ``{{^-first}}`` - Begin marker of a template that will be instantiated *for each except the first* entry in the layer. This,
- *    this is basically the inversion of ``{{#-first}}``. Use is only allowed between the begin and end marker of the layer allowed.
+ *    this is basically the inversion of ``{{#-first}}``. Use is only allowed between the begin and end marker of the layer.
  *    So between ``{{#result}}`` and ``{{/result}}``, or between ``{{#measurement}}`` and ``{{/measurement}}``.
  *
  *  * ``{{/-first}}`` - End marker for either ``{{#-first}}`` or ``{{^-first}}``.
  *
  *  * ``{{#-last}}`` - Begin marker of a template that will be instantiated *only for the last* entry in the layer. Use is only
- *    allowed between the begin and end marker of the layer allowed. So between ``{{#result}}`` and ``{{/result}}``, or between
+ *    allowed between the begin and end marker of the layer. So between ``{{#result}}`` and ``{{/result}}``, or between
  *    ``{{#measurement}}`` and ``{{/measurement}}``. Finish the template with ``{{/-last}}``.
  *
  *  * ``{{^-last}}`` - Begin marker of a template that will be instantiated *for each except the last* entry in the layer. This,
- *    this is basically the inversion of ``{{#-last}}``. Use is only allowed between the begin and end marker of the layer allowed.
+ *    this is basically the inversion of ``{{#-last}}``. Use is only allowed between the begin and end marker of the layer.
  *    So between ``{{#result}}`` and ``{{/result}}``, or between ``{{#measurement}}`` and ``{{/measurement}}``.
  *
  *  * ``{{/-last}}`` - End marker for either ``{{#-last}}`` or ``{{^-last}}``.
@@ -316,7 +405,7 @@ char const* csv() noexcept;
   See the tutorial at :ref:`tutorial-template-html` for an example.
   @endverbatim
 
-  @see ankerl::nanobench::render()
+  @see also ankerl::nanobench::render()
  */
 char const* htmlBoxplot() noexcept;
 
@@ -378,30 +467,36 @@ struct PerfCountSet {
 ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
 struct Config {
     // actual benchmark config
-    std::string mBenchmarkTitle = "benchmark";
-    std::string mBenchmarkName = "noname";
-    std::string mUnit = "op";
-    double mBatch = 1.0;
-    double mComplexityN = -1.0;
-    size_t mNumEpochs = 11;
-    size_t mClockResolutionMultiple = static_cast<size_t>(1000);
-    std::chrono::nanoseconds mMaxEpochTime = std::chrono::milliseconds(100);
-    std::chrono::nanoseconds mMinEpochTime = std::chrono::milliseconds(1);
-    uint64_t mMinEpochIterations{1};
-    uint64_t mEpochIterations{0}; // If not 0, run *exactly* these number of iterations per epoch.
-    uint64_t mWarmup = 0;
-    std::ostream* mOut = nullptr;
-    std::chrono::duration<double> mTimeUnit = std::chrono::nanoseconds{1};
-    std::string mTimeUnitName = "ns";
-    bool mShowPerformanceCounters = true;
-    bool mIsRelative = false;
+    std::string mBenchmarkTitle = "benchmark";                               // NOLINT(misc-non-private-member-variables-in-classes)
+    std::string mBenchmarkName = "noname";                                   // NOLINT(misc-non-private-member-variables-in-classes)
+    std::string mUnit = "op";                                                // NOLINT(misc-non-private-member-variables-in-classes)
+    double mBatch = 1.0;                                                     // NOLINT(misc-non-private-member-variables-in-classes)
+    double mComplexityN = -1.0;                                              // NOLINT(misc-non-private-member-variables-in-classes)
+    size_t mNumEpochs = 11;                                                  // NOLINT(misc-non-private-member-variables-in-classes)
+    size_t mClockResolutionMultiple = static_cast<size_t>(1000);             // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::nanoseconds mMaxEpochTime = std::chrono::milliseconds(100); // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::nanoseconds mMinEpochTime = std::chrono::milliseconds(1);   // NOLINT(misc-non-private-member-variables-in-classes)
+    uint64_t mMinEpochIterations{1};                                         // NOLINT(misc-non-private-member-variables-in-classes)
+    // If not 0, run *exactly* these number of iterations per epoch.
+    uint64_t mEpochIterations{0};                                          // NOLINT(misc-non-private-member-variables-in-classes)
+    uint64_t mWarmup = 0;                                                  // NOLINT(misc-non-private-member-variables-in-classes)
+    std::ostream* mOut = nullptr;                                          // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::duration<double> mTimeUnit = std::chrono::nanoseconds{1}; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::string mTimeUnitName = "ns";                                      // NOLINT(misc-non-private-member-variables-in-classes)
+    bool mShowPerformanceCounters = true;                                  // NOLINT(misc-non-private-member-variables-in-classes)
+    bool mIsRelative = false;                                              // NOLINT(misc-non-private-member-variables-in-classes)
+    std::unordered_map<std::string, std::string> mContext{};               // NOLINT(misc-non-private-member-variables-in-classes)
+    // One bit per Column, set when that column is hidden - so the default of 0 shows everything and
+    // stays the table nanobench has always printed.
+    uint32_t mHiddenColumns{};                  // NOLINT(misc-non-private-member-variables-in-classes)
+    std::vector<std::string> mContextColumns{}; // NOLINT(misc-non-private-member-variables-in-classes)
 
     Config();
     ~Config();
-    Config& operator=(Config const&);
-    Config& operator=(Config&&);
-    Config(Config const&);
-    Config(Config&&) noexcept;
+    Config& operator=(Config const& other);
+    Config& operator=(Config&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
+    Config(Config const& other);
+    Config(Config&& other) noexcept;
 };
 ANKERL_NANOBENCH(IGNORE_PADDED_POP)
 
@@ -418,16 +513,19 @@ public:
         instructions,
         branchinstructions,
         branchmisses,
+
+        /// Number of measures, and what fromString() returns for a name it does not know. Passing it
+        /// to the accessors below is not an error: it reads as a measure that was never recorded.
         _size
     };
 
-    explicit Result(Config const& benchmarkConfig);
+    explicit Result(Config benchmarkConfig);
 
     ~Result();
-    Result& operator=(Result const&);
-    Result& operator=(Result&&);
-    Result(Result const&);
-    Result(Result&&) noexcept;
+    Result& operator=(Result const& other);
+    Result& operator=(Result&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
+    Result(Result const& other);
+    Result(Result&& other) noexcept;
 
     // adds new measurement results
     // all values are scaled by iters (except iters...)
@@ -442,6 +540,8 @@ public:
     ANKERL_NANOBENCH(NODISCARD) double sumProduct(Measure m1, Measure m2) const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double minimum(Measure m) const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double maximum(Measure m) const noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::string const& context(char const* variableName) const;
+    ANKERL_NANOBENCH(NODISCARD) std::string const& context(std::string const& variableName) const;
 
     ANKERL_NANOBENCH(NODISCARD) bool has(Measure m) const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double get(size_t idx, Measure m) const;
@@ -452,10 +552,96 @@ public:
     static Measure fromString(std::string const& str);
 
 private:
+    // The per-epoch values of one measure. Every accessor above goes through this, so how the
+    // measures are stored - including the extra slot the constructor explains - is written down once
+    // rather than asserted at a dozen call sites.
+    ANKERL_NANOBENCH(NODISCARD) std::vector<double> const& measurements(Measure m) const;
+
     Config mConfig{};
     std::vector<std::vector<double>> mNameToMeasurements{};
 };
 ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+/**
+ * @brief The outcome of a paired comparison, see Bench::compare().
+ *
+   @verbatim embed:rst
+   :cpp:func:`relative() <ankerl::nanobench::Bench::relative()>` compares the median of one benchmark
+   run entirely before another, which measures the machine's drift as much as the code: nanobench's
+   own test suite has a case where two *identical* workloads came out 38% apart on a CI runner, while
+   each reported an ``err%`` of 0.5. Whatever ``err%`` is measuring there, it is not the uncertainty
+   of the comparison.
+
+   A paired comparison measures the alternatives against each other within the same slice of time, so
+   anything that affects all of them - a frequency ramp, a noisy neighbour, thermal throttling -
+   cancels out of the ratios. What is reported is therefore an uncertainty about *the ratio*, which
+   is the number the caller actually wanted.
+
+   Entry 0 is the baseline that everything else is measured against.
+   @endverbatim
+ */
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+class CompareResult {
+public:
+    /// One alternative: its measurements, and how it compares to the baseline.
+    ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+    struct Entry {
+        // noexcept because it only moves, and both std::string's and Result's move constructors are:
+        // gcc's -Wnoexcept fails the build over the vector growth path otherwise.
+        Entry(std::string entryName, Result entryResult, double entryRelative, double entryRelativeLow, double entryRelativeHigh,
+              size_t entryTiedRounds) noexcept;
+
+        std::string name;    // NOLINT(misc-non-private-member-variables-in-classes)
+        Result result;       // NOLINT(misc-non-private-member-variables-in-classes)
+        double relative;     // NOLINT(misc-non-private-member-variables-in-classes)
+        double relativeLow;  // NOLINT(misc-non-private-member-variables-in-classes)
+        double relativeHigh; // NOLINT(misc-non-private-member-variables-in-classes)
+        size_t tiedRounds;   // NOLINT(misc-non-private-member-variables-in-classes)
+    };
+    ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+    CompareResult(std::vector<Entry> entries, size_t numRounds);
+
+    /// Number of alternatives compared, including the baseline.
+    ANKERL_NANOBENCH(NODISCARD) size_t size() const noexcept;
+
+    /// Entry 0 is the baseline.
+    ANKERL_NANOBENCH(NODISCARD) Entry const& operator[](size_t idx) const;
+
+    /// Number of paired rounds each alternative was measured over.
+    ANKERL_NANOBENCH(NODISCARD) size_t rounds() const noexcept;
+
+    /**
+     * @brief How many comparisons the intervals were corrected for: one per alternative besides the
+     *        baseline.
+     *
+       @verbatim embed:rst
+       With ten alternatives there are nine chances to be wrong at 5% each, so the intervals are
+       widened to keep the *whole table* at 95% rather than each row separately. See
+       :ref:`ab-comparison` for what that costs - less than it sounds, because the binomial tail is
+       steep.
+       @endverbatim
+     */
+    ANKERL_NANOBENCH(NODISCARD) size_t comparisons() const noexcept;
+
+    /**
+     * @brief True when this alternative's interval excludes the baseline, i.e. the measurement told
+     *        them apart. Always false for the baseline itself.
+     */
+    ANKERL_NANOBENCH(NODISCARD) bool isSignificant(size_t idx) const;
+
+    /// Index of the alternative with the lowest median time.
+    ANKERL_NANOBENCH(NODISCARD) size_t fastest() const;
+
+private:
+    std::vector<Entry> mEntries{};
+    size_t mRounds{};
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+
+/// Writes the comparison as a markdown table, in the same shape as an ordinary benchmark table, with
+/// a summary line under it.
+std::ostream& operator<<(std::ostream& os, CompareResult const& compareResult);
 
 /**
  * An extremely fast random generator. Currently, this implements *RomuDuoJr*, developed by Mark Overton. Source:
@@ -485,9 +671,9 @@ public:
     static constexpr uint64_t(max)();
 
     /**
-     * As a safety precausion, we don't allow copying. Copying a PRNG would mean you would have two random generators that produce the
+     * As a safety precaution, we don't allow copying. Copying a PRNG would mean you would have two random generators that produce the
      * same sequence, which is generally not what one wants. Instead create a new rng with the default constructor Rng(), which is
-     * automatically seeded from `std::random_device`. If you really need a copy, use copy().
+     * automatically seeded from `std::random_device`. If you really need a copy, use `copy()`.
      */
     Rng(Rng const&) = delete;
 
@@ -528,7 +714,7 @@ public:
      */
     explicit Rng(uint64_t seed) noexcept;
     Rng(uint64_t x, uint64_t y) noexcept;
-    Rng(std::vector<uint64_t> const& data);
+    explicit Rng(std::vector<uint64_t> const& data);
 
     /**
      * Creates a copy of the Rng, thus the copy provides exactly the same random sequence as the original.
@@ -543,8 +729,6 @@ public:
      * @return uint64_t The next 64 bit random value.
      */
     inline uint64_t operator()() noexcept;
-
-    // This is slightly biased. See
 
     /**
      * Generates a random number between 0 and range (excluding range).
@@ -561,9 +745,6 @@ public:
      * @return uint32_t Generated random values in range [0, range(.
      */
     inline uint32_t bounded(uint32_t range) noexcept;
-
-    // random double in range [0, 1(
-    // see http://prng.di.unimi.it/
 
     /**
      * Provides a random uniform double value between 0 and 1. This uses the method described in [Generating uniform doubles in the
@@ -589,13 +770,36 @@ public:
      *
      * @return Vector containing the full state:
      */
-    std::vector<uint64_t> state() const;
+    ANKERL_NANOBENCH(NODISCARD) std::vector<uint64_t> state() const;
 
 private:
     static constexpr uint64_t rotl(uint64_t x, unsigned k) noexcept;
 
     uint64_t mX;
     uint64_t mY;
+};
+
+/**
+ * @brief A column of the markdown table, for Bench::hideColumn() and Bench::showColumn().
+ *
+ * The names in brackets are the headers the column is printed with; `op` follows Bench::unit(), and the
+ * time unit follows Bench::timeUnit().
+ *
+ * @see ankerl::nanobench::Bench::hideColumn()
+ */
+enum class Column : size_t {
+    relative,      ///< `relative` - only shown when Bench::relative() is set.
+    complexityN,   ///< `complexityN` - only shown when Bench::complexityN() is set.
+    timePerUnit,   ///< `ns/op` - time for one unit.
+    unitPerSecond, ///< `op/s` - units per second.
+    error,         ///< `err%` - median absolute percentage error over the epochs.
+    instructions,  ///< `ins/op` - retired instructions, Linux only.
+    cycles,        ///< `cyc/op` - CPU cycles, Linux only.
+    ipc,           ///< `IPC` - instructions per cycle, Linux only.
+    branches,      ///< `bra/op` - retired branch instructions, Linux only.
+    branchMisses,  ///< `miss%` - percentage of branches mispredicted, Linux only.
+    total,         ///< `total` - wall clock time spent measuring this row.
+    _size          ///< Not a column; the number of them.
 };
 
 /**
@@ -620,8 +824,8 @@ public:
      */
     Bench();
 
-    Bench(Bench&& other);
-    Bench& operator=(Bench&& other);
+    Bench(Bench&& other) noexcept;
+    Bench& operator=(Bench&& other) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE));
     Bench(Bench const& other);
     Bench& operator=(Bench const& other);
     ~Bench() noexcept;
@@ -652,6 +856,14 @@ public:
     ANKERL_NANOBENCH(NOINLINE)
     Bench& run(std::string const& benchmarkName, Op&& op);
 
+#if ANKERL_NANOBENCH(HAS_STRING_VIEW)
+    /// Same as run(char const* benchmarkName, Op op), for a std::string_view name. Only available
+    /// when compiling as C++17 or newer.
+    template <typename Op>
+    ANKERL_NANOBENCH(NOINLINE)
+    Bench& run(std::string_view benchmarkName, Op&& op);
+#endif
+
     /**
      * @brief Same as run(char const* benchmarkName, Op op), but instead uses the previously set name.
      * @tparam Op The code to benchmark.
@@ -661,18 +873,116 @@ public:
     Bench& run(Op&& op);
 
     /**
+     * @brief Compares alternatives against each other, paired and interleaved.
+     *
+     * Takes `name, op` pairs - two or more of them. The first is the baseline everything else is
+     * measured against, exactly as with relative(), but measured against it *at the same time*
+     * rather than one after the other. Drift the machine introduces - a frequency ramp, a noisy
+     * neighbour, thermal throttling - then hits every alternative alike and cancels out of the
+     * ratios.
+     *
+     * @code
+     * ankerl::nanobench::Bench().epochs(52).compare(
+     *     "std::mt19937", [&] { ... },     // the baseline
+     *     "sfc4",         [&] { ... },
+     *     "romu",         [&] { ... });
+     * @endcode
+     *
+     * Prints an ordinary nanobench table with two extra columns - the ratio to the baseline and a
+     * confidence interval for it - and a summary line underneath.
+     *
+     @verbatim embed:rst
+     A worked example with output, and the reasoning behind each choice below, is in the tutorial at
+     :ref:`ab-comparison`.
+
+     What it does, in order:
+
+     #. Calibrates an iteration count once, up front, and uses the **same** count for every
+        alternative for the whole run. An epoch's fixed overhead is divided by that count, so two
+        different counts would amortize it differently and bias the ratio - 1.2% on 200us epochs, and
+        no amount of pairing removes it. The shared count is the slowest alternative's, raised where
+        that would leave the fastest one's epoch too short for the clock to resolve, and capped so
+        the slowest one still fits in maxEpochTime().
+     #. Runs one epoch of each per round, interleaved, so drift is common to the round.
+     #. Orders each block of N rounds as a randomly chosen cyclic Latin square, so every alternative
+        occupies every position exactly once per block and their mean positions are equal - which is
+        what cancels a drift that is linear over the block. For two alternatives this is exactly
+        ABBA/BAAB.
+     #. Reduces each round to ``ln(t_baseline) - ln(t_alternative)``, dropping rounds where either
+        side measured zero.
+     #. Reports the median of those as the ratio, with a sign-test interval around it, widened to
+        keep the whole table at 95% rather than each row separately.
+
+     .. note::
+
+        Use more rounds than the default 11. An epoch is about a millisecond, so ``epochs(52)`` costs
+        a tenth of a second per alternative and buys an interval narrow enough to act on. The count is
+        rounded up to a whole number of blocks, and raised if it is too small to support an interval
+        at all.
+
+     .. warning::
+
+        Interleaving means each alternative runs with the others' cache and branch predictor state.
+        That is usually the more honest measurement for "which should I ship", but it is a different
+        measurement from running one alone - use :cpp:func:`run() <ankerl::nanobench::Bench::run()>`
+        for that.
+
+     @endverbatim
+     *
+     * @tparam Args Alternating names and operations.
+     * @param args `name, op` pairs; at least two.
+     * @return The ratios and their intervals; also written to output() unless that is nullptr.
+     */
+    template <typename... Args>
+    ANKERL_NANOBENCH(NOINLINE)
+    CompareResult compare(Args&&... args);
+
+    /**
      * @brief Title of the benchmark, will be shown in the table header. Changing the title will start a new markdown table.
      *
      * @param benchmarkTitle The title of the benchmark.
      */
     Bench& title(char const* benchmarkTitle);
     Bench& title(std::string const& benchmarkTitle);
+
+    /**
+     * @brief Gets the title of the benchmark
+     */
     ANKERL_NANOBENCH(NODISCARD) std::string const& title() const noexcept;
 
     /// Name of the benchmark, will be shown in the table row.
     Bench& name(char const* benchmarkName);
     Bench& name(std::string const& benchmarkName);
+#if ANKERL_NANOBENCH(HAS_STRING_VIEW)
+    /// Only available when compiling as C++17 or newer. @see name()
+    Bench& name(std::string_view benchmarkName);
+#endif
     ANKERL_NANOBENCH(NODISCARD) std::string const& name() const noexcept;
+
+    /**
+     * @brief Set context information.
+     *
+     * The information can be accessed using custom render templates via `{{context(variableName)}}`.
+     * Trying to render a variable that hasn't been set before raises an exception.
+     * Not included in (default) markdown table.
+     *
+     * @see clearContext, render
+     *
+     * @param variableName The name of the context variable.
+     * @param variableValue The value of the context variable.
+     */
+    Bench& context(char const* variableName, char const* variableValue);
+    Bench& context(std::string const& variableName, std::string const& variableValue);
+
+    /**
+     * @brief Reset context information.
+     *
+     * This may improve efficiency when using many context entries,
+     * or improve robustness by removing spurious context entries.
+     *
+     * @see context
+     */
+    Bench& clearContext();
 
     /**
      * @brief Sets the batch size.
@@ -766,10 +1076,10 @@ public:
     /**
      * @brief Upper limit for the runtime of each epoch.
      *
-     * As a safety precausion if the clock is not very accurate, we can set an upper limit for the maximum evaluation time per
+     * As a safety precaution if the clock is not very accurate, we can set an upper limit for the maximum evaluation time per
      * epoch. Default is 100ms. At least a single evaluation of the benchmark is performed.
      *
-     * @see minEpochTime(), minEpochIterations()
+     * @see minEpochTime, minEpochIterations
      *
      * @param t Maximum target runtime for a single epoch.
      */
@@ -779,10 +1089,10 @@ public:
     /**
      * @brief Minimum time each epoch should take.
      *
-     * Default is zero, so we are fully relying on clockResolutionMultiple(). In most cases this is exactly what you want. If you see
+     * Default is 1ms, so we are mostly relying on clockResolutionMultiple(). In most cases this is exactly what you want. If you see
      * that the evaluation is unreliable with a high `err%`, you can increase either minEpochTime() or minEpochIterations().
      *
-     * @see maxEpochTime(), minEpochIterations()
+     * @see maxEpochTime, minEpochIterations
      *
      * @param t Minimum time each epoch should take.
      */
@@ -793,9 +1103,9 @@ public:
      * @brief Sets the minimum number of iterations each epoch should take.
      *
      * Default is 1, and we rely on clockResolutionMultiple(). If the `err%` is high and you want a more smooth result, you might want
-     * to increase the minimum number or iterations, or increase the minEpochTime().
+     * to increase the minimum number of iterations, or increase the minEpochTime().
      *
-     * @see minEpochTime(), maxEpochTime(), minEpochIterations()
+     * @see minEpochTime, maxEpochTime, minEpochIterations
      *
      * @param numIters Minimum number of iterations per epoch.
      */
@@ -826,10 +1136,11 @@ public:
     /**
      * @brief Marks the next run as the baseline.
      *
-     * Call `relative(true)` to mark the run as the baseline. Successive runs will be compared to this run. It is calculated by
+     * Call `relative(true)` to mark the run as the baseline. Successive runs will be compared to this run. Just like all the
+     * other columns, the comparison is per unit, so it stays meaningful when the runs use a different Bench::batch:
      *
      * @f[
-     * 100\% * \frac{baseline}{runtime}
+     * 100\% * \frac{baseline / baselineBatch}{runtime / batch}
      * @f]
      *
      *  * 100% means it is exactly as fast as the baseline
@@ -853,6 +1164,51 @@ public:
      */
     Bench& performanceCounters(bool showPerformanceCounters) noexcept;
     ANKERL_NANOBENCH(NODISCARD) bool performanceCounters() const noexcept;
+
+    /**
+     * @brief Removes a column from the table.
+     *
+     * The full table is over 150 characters wide, which wraps in most terminals. Hide what you are not
+     * reading:
+     *
+     *     bench.hideColumn(Column::instructions)
+     *          .hideColumn(Column::cycles)
+     *          .hideColumn(Column::ipc);
+     *
+     * Hiding a column only changes what is printed - the measurement still happens, and results() and
+     * the render templates are unaffected. To stop *measuring* the performance counters as well, use
+     * performanceCounters(false), which hides all five of their columns at once.
+     *
+     * @param column The column to hide.
+     */
+    Bench& hideColumn(Column column) noexcept;
+
+    /// Shows a column hidden with hideColumn() again. @see hideColumn()
+    Bench& showColumn(Column column) noexcept;
+
+    /// True when @p column is not hidden. A column can still be absent from the table for other
+    /// reasons - `relative` without relative(), or the counter columns off Linux. @see hideColumn()
+    ANKERL_NANOBENCH(NODISCARD) bool isColumnVisible(Column column) const noexcept;
+
+    /**
+     * @brief Adds a column showing the value of a context variable.
+     *
+     * Context variables set with context() are otherwise only reachable from a render template, which
+     * makes parameterised benchmarks awkward to read on the console. This puts one in the table:
+     *
+     *     bench.context("threads", std::to_string(n))
+     *          .contextColumn("threads")
+     *          .run(...);
+     *
+     * The column is added once per name, in the order given, before the benchmark name. A row whose
+     * context does not have the variable is left blank.
+     *
+     * @param variableName Name of the context variable to show. @see context()
+     */
+    Bench& contextColumn(std::string const& variableName);
+
+    /// Removes all columns added with contextColumn(). @see contextColumn()
+    Bench& clearContextColumns() noexcept;
 
     /**
      * @brief Retrieves all benchmark results collected by the bench object so far.
@@ -886,10 +1242,10 @@ public:
       @endverbatim
 
       @tparam T Any type is cast to `double`.
-      @param b Length of N for the next benchmark run, so it is possible to calculate `bigO`.
+      @param n Length of N for the next benchmark run, so it is possible to calculate `bigO`.
      */
     template <typename T>
-    Bench& complexityN(T b) noexcept;
+    Bench& complexityN(T n) noexcept;
     ANKERL_NANOBENCH(NODISCARD) double complexityN() const noexcept;
 
     /*!
@@ -967,7 +1323,85 @@ public:
     Bench& config(Config const& benchmarkConfig);
     ANKERL_NANOBENCH(NODISCARD) Config const& config() const noexcept;
 
+    /*!
+      @brief Runs `setupOp()` once before each epoch, without measuring it.
+
+      Use this to restore whatever state your benchmark consumes, when that restoration would otherwise
+      pollute the measurement:
+
+      @code
+      bench.setup([&] { data = pristine; })
+           .run("consume data", [&] { consume(data); });
+      @endcode
+
+      @verbatim embed:rst
+      .. important::
+
+         The setup runs **once per epoch, not once per iteration**. An epoch calls ``op()`` many times
+         (see :cpp:func:`epochIterations() <ankerl::nanobench::Bench::epochIterations()>`), and the setup
+         does not run again in between. So this helps when your operation can be repeated as-is and only
+         the *starting* state has to be established - and it does **not** help when every single call
+         mutates the data such that the next call would measure something different.
+
+         For that second case, set :cpp:func:`epochIterations(1) <ankerl::nanobench::Bench::epochIterations()>`
+         so an epoch is a single call, which makes setup effectively per-iteration - at the cost of much
+         noisier results, since one call is then timed against the clock's resolution. The alternative,
+         and usually the better measurement, is to time the setup separately and subtract it.
+
+         Timers are deliberately not started and stopped around each iteration: for anything fast that
+         costs more than the thing being measured, and the performance counters would have to be
+         restarted too.
+
+      .. note::
+
+         The returned object keeps a reference to this ``Bench``, so don't let it outlive it - call
+         ``run()`` on the same expression, as above.
+
+      @endverbatim
+
+      @tparam SetupOp The untimed code to run before each epoch.
+      @param setupOp The setup to run.
+     */
+    template <typename SetupOp>
+    detail::SetupRunner<SetupOp> setup(SetupOp setupOp);
+
 private:
+    // Collects the `name, op` pack into two flat vectors, once. Everything after this point is
+    // ordinary index-based code in the implementation block rather than more template recursion.
+    static void compareCollect(std::vector<std::string>& /*names*/, std::vector<detail::ErasedOp>& /*ops*/) {}
+
+    template <typename Name, typename Op, typename... Rest>
+    static void compareCollect(std::vector<std::string>& names, std::vector<detail::ErasedOp>& ops, Name&& name, Op&& op,
+                               Rest&&... rest) {
+        names.emplace_back(std::forward<Name>(name));
+        ops.push_back(detail::eraseOp(op));
+        compareCollect(names, ops, std::forward<Rest>(rest)...);
+    }
+
+    // The measuring half, which no longer needs to know the operations' types.
+    ANKERL_NANOBENCH(NODISCARD)
+    CompareResult compareImpl(std::vector<std::string> const& names, std::vector<detail::ErasedOp> const& ops);
+
+    // Number of iterations of `op` that makes one epoch last at least `target`.
+    ANKERL_NANOBENCH(NODISCARD)
+    uint64_t compareCalibrate(detail::ErasedOp const& op, Clock::duration target) const;
+
+    // The one iteration count the whole experiment runs at. Fixed for every alternative and every
+    // round: a count that drifted between them would be a second thing changing while the comparison
+    // is being made, and an epoch's fixed overhead is divided by it, so two different counts amortize
+    // that overhead differently and bias the ratio.
+    ANKERL_NANOBENCH(NODISCARD)
+    uint64_t compareIterations(std::vector<detail::ErasedOp> const& ops) const;
+
+    // Runs `numIters` iterations of `op` as one epoch, appending the measurement to `result`.
+    static void compareEpoch(detail::ErasedOp const& op, uint64_t numIters, Result& result);
+
+    template <typename SetupOp, typename Op>
+    Bench& runImpl(SetupOp& setupOp, Op&& op);
+
+    template <typename SetupOp>
+    friend class detail::SetupRunner;
+
     Config mConfig{};
     std::vector<Result> mResults{};
 };
@@ -984,7 +1418,7 @@ void doNotOptimizeAway(Arg&& arg);
 
 namespace detail {
 
-#if defined(_MSC_VER)
+#if !ANKERL_NANOBENCH(ASM_DONT_OPTIMIZE_AWAY)
 void doNotOptimizeAwaySink(void const*);
 
 template <typename T>
@@ -994,7 +1428,7 @@ void doNotOptimizeAway(T const& val);
 
 // These assembly magic is directly from what Google Benchmark is doing. I have previously used what facebook's folly was doing, but
 // this seemed to have compilation problems in some cases. Google Benchmark seemed to be the most well tested anyways.
-// see https://github.com/google/benchmark/blob/master/include/benchmark/benchmark.h#L307
+// see https://github.com/google/benchmark/blob/v1.7.1/include/benchmark/benchmark.h#L443-L446
 template <typename T>
 void doNotOptimizeAway(T const& val) {
     // NOLINTNEXTLINE(hicpp-no-assembler)
@@ -1019,7 +1453,11 @@ void doNotOptimizeAway(T& val) {
 ANKERL_NANOBENCH(IGNORE_EFFCPP_PUSH)
 class IterationLogic {
 public:
-    explicit IterationLogic(Bench const& config) noexcept;
+    explicit IterationLogic(Bench const& bench);
+    IterationLogic(IterationLogic&&) = delete;
+    IterationLogic& operator=(IterationLogic&&) = delete;
+    IterationLogic(IterationLogic const&) = delete;
+    IterationLogic& operator=(IterationLogic const&) = delete;
     ~IterationLogic();
 
     ANKERL_NANOBENCH(NODISCARD) uint64_t numIters() const noexcept;
@@ -1036,7 +1474,9 @@ ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
 class PerformanceCounters {
 public:
     PerformanceCounters(PerformanceCounters const&) = delete;
+    PerformanceCounters(PerformanceCounters&&) = delete;
     PerformanceCounters& operator=(PerformanceCounters const&) = delete;
+    PerformanceCounters& operator=(PerformanceCounters&&) = delete;
 
     PerformanceCounters();
     ~PerformanceCounters();
@@ -1060,6 +1500,133 @@ ANKERL_NANOBENCH(IGNORE_PADDED_POP)
 // Gets the singleton
 PerformanceCounters& performanceCounters();
 
+// How long one epoch should take: the clock's resolution multiplied up until the measurement sits
+// well above the clock's own noise, then clamped into [minEpochTime, maxEpochTime]. The minimum is
+// applied last, so it wins when the two bounds conflict.
+//
+// Both run() and compare() size their epochs with this. It is a function rather than a line in each
+// of them because it is a rule, and a rule with two copies is a rule with two behaviours.
+Clock::duration targetRuntimePerEpoch(Bench const& bench);
+
+// Whether hideColumn() left this column visible. Takes the Config rather than the Bench because the
+// table writers only have the Config - every Result carries a copy of the one it was measured under.
+ANKERL_NANOBENCH(NODISCARD) bool isColumnVisible(Config const& config, Column column) noexcept;
+
+// The frequency-scaling and pyperf warnings, and the note that the kernel refused the performance
+// counters. Declared up here because compare() is a template defined above the implementation block
+// and has to be able to call them - a program whose only nanobench call is compare() needs the
+// warning at least as much as one that calls run().
+void printStabilityInformationOnce(std::ostream* outStream);
+void printPerformanceCounterHintOnce(std::ostream* outStream, bool wantsPerformanceCounters);
+
+// The last table settings written to this stream. When they change, a new header is written.
+uint64_t& streamHeaderHash(std::ostream& os);
+
+// The arithmetic that turns what the kernel hands back into the numbers of the ins/op, cyc/op, IPC,
+// bra/op and miss% columns. It lives out here, rather than inside the Linux-only counter class,
+// because it is the part that can be silently wrong: a counter that is quietly 5% low looks exactly
+// like a correct one. Out here it is compiled and testable on every platform, while
+// perf_event_open() - which cannot be exercised in a container at all - stays where it is.
+//
+// All of these saturate at 0 rather than wrapping: a correction larger than the measurement means
+// the measurement was noise, not that the value is enormous.
+
+// a - b, or 0 when b is the larger. The one place that saturation is written down: hand-rolled, it
+// was six ternaries that had already drifted between '>' and '>=' without anyone noticing, because at
+// a == b the two spellings agree.
+uint64_t saturatingSub(uint64_t a, uint64_t b) noexcept;
+
+// Rounded integer division, for spreading a measured overhead over the iterations it covers.
+uint64_t divRounded(uint64_t a, uint64_t divisor) noexcept;
+
+// How many uint64_t a PERF_FORMAT_GROUP | PERF_FORMAT_ID read needs for `numEvents` events: three
+// header words (nr, time_enabled, time_running), then a value and an id per event. That layout used
+// to be written down separately at the buffer sizing, at the buffer initialization and here - three
+// places to keep in step on a code path most containers and VMs cannot run at all.
+size_t perfReadFormatSize(size_t numEvents) noexcept;
+
+// Index of the i-th event's value in such a read, which is exactly where the i events before it end.
+size_t perfValueIndex(uint64_t i) noexcept;
+
+// Extrapolates a counter that the kernel could only keep active for part of the measurement, the way
+// `perf stat` does. Returns the value unchanged when it was active throughout.
+uint64_t scaleMultiplexed(uint64_t value, uint64_t timeEnabled, uint64_t timeRunning) noexcept;
+
+// Subtracts the calibrated overhead of measuring, plus the per-iteration overhead of the loop doing
+// the measuring, from a raw counter value. Pass 0 for a correction that does not apply.
+uint64_t correctOverhead(uint64_t value, uint64_t measuringOverhead, uint64_t loopOverheadPerIteration, uint64_t numIters) noexcept;
+
+// The loop's own per-iteration cost, from a calibration run of `numIters` operations and one of
+// twice as many: whatever the second run did not cost twice over is the loop rather than the work.
+uint64_t loopOverheadPerIteration(uint64_t single, uint64_t doubled, uint64_t measuringOverhead, uint64_t numIters) noexcept;
+
+// Removes the branch that the measuring loop itself takes once per iteration, plus the one that ends
+// it, from a raw branch count.
+uint64_t correctBranchInstructions(uint64_t rawBranchInstructions, uint64_t numIters) noexcept;
+
+// Paired statistics, for Bench::compare(). Pure functions over the per-round measurements, so they are
+// testable without running a benchmark at all - which matters, because the alternative is judging a
+// confidence interval by looking at it.
+
+// ln(a[i]) - ln(b[i]) for each round. Working in log space turns a speedup, which is multiplicative,
+// into a difference, which is what every statistic below assumes. Rounds where either side measured
+// 0 - a clock too coarse for the operation - carry no ratio and are dropped.
+std::vector<double> pairedLogRatios(std::vector<double> const& a, std::vector<double> const& b);
+
+// The same, over two Results' per-round elapsed times. compare() runs one epoch of every alternative
+// per round, so their measurements line up round for round and can be paired directly - not only
+// against the baseline, but between any two of them.
+std::vector<double> pairedLogRatios(Result const& a, Result const& b);
+
+// Median of a copy of the values. 0.0 when there are none.
+double medianOf(std::vector<double> values);
+
+// The pair of 0-based order statistics that bracket the median with at least `confidence`
+// probability: the largest k with P(Bin(n, 1/2) < k) <= (1 - confidence) / 2 gives the interval
+// [x_(k), x_(n+1-k)]. Returns {1, 0} - an empty range - when no such interval exists, which is the
+// case for fewer than six observations at 95%.
+std::pair<size_t, size_t> medianIntervalIndices(size_t n, double confidence);
+
+// Rounds whose two sides measured the same time to the last tick the clock could report, i.e. a log
+// ratio of exactly 0. Not evidence of equality - evidence that the clock ran out of resolution.
+size_t countTiedRounds(std::vector<double> const& logRatios);
+
+// Confidence each individual interval is built at, so that all `numComparisons` of them together
+// hold at 95%. Bonferroni: simple, assumption-free, and conservative here because the comparisons
+// share a baseline and are therefore correlated. One function, because the table and the summary
+// line underneath it must not be able to report intervals at two different confidences.
+double bonferroniConfidence(size_t numComparisons) noexcept;
+
+// Distribution-free confidence interval for the median, from those order statistics.
+//
+// The sign test, and it is chosen for what it does *not* assume. It needs the observations to be
+// independent and nothing else - no shape, no symmetry, no finite variance, no asymptotics - and it
+// is exact at every n rather than approximately right for large ones. The alternatives all want
+// more: a t-interval wants normality, a bootstrap wants its own asymptotics and converges slowly
+// for a median in particular, and Wilcoxon wants the differences to be symmetric about their
+// median. That last one is exactly what paired timings do not give you, because an operation can be
+// arbitrarily slower but never faster than its floor, so the differences are skewed whenever one
+// side has the heavier tail. Measured on such data: sign 96.7% coverage of a nominal 95%, Wilcoxon
+// 91.5%.
+//
+// The price is width - roughly 10% wider than a bootstrap - and slight over-coverage from the
+// discreteness. Both err towards saying "no difference resolved", which is the right direction for
+// a tool whose output ends up in a pull request.
+std::pair<double, double> medianInterval(std::vector<double> values, double confidence);
+
+// Branch misses cannot exceed the branches they were taken from, and the loop is assumed to mispredict
+// its own exit once - so at least one miss is always attributed to it.
+double correctBranchMisses(uint64_t rawBranchMisses, double correctedBranchInstructions) noexcept;
+
+// Applies a "key=value,key=value" string - the contents of NANOBENCH_CONFIG - to bench, by calling
+// the setter each key is named after. Separate from reading the environment so that it can be tested
+// by handing it a string, rather than through a variable that is spelled putenv on one platform and
+// _putenv_s on another.
+//
+// An entry that cannot be applied appends one message to errors and is skipped; every other entry
+// still applies. Nothing throws, so a typo behaves the same for a consumer built -fno-exceptions.
+void applyConfigString(Bench& bench, std::string const& configStr, std::vector<std::string>& errors);
+
 } // namespace detail
 
 class BigO {
@@ -1081,11 +1648,11 @@ public:
         : BigO(bigOName, mapRangeMeasure(rangeMeasure, rangeToN)) {}
 
     template <typename Op>
-    BigO(std::string const& bigOName, RangeMeasure const& rangeMeasure, Op rangeToN)
-        : BigO(bigOName, mapRangeMeasure(rangeMeasure, rangeToN)) {}
+    BigO(std::string bigOName, RangeMeasure const& rangeMeasure, Op rangeToN)
+        : BigO(std::move(bigOName), mapRangeMeasure(rangeMeasure, rangeToN)) {}
 
     BigO(char const* bigOName, RangeMeasure const& scaledRangeMeasure);
-    BigO(std::string const& bigOName, RangeMeasure const& scaledRangeMeasure);
+    BigO(std::string bigOName, RangeMeasure const& scaledRangeMeasure);
     ANKERL_NANOBENCH(NODISCARD) std::string const& name() const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double constant() const noexcept;
     ANKERL_NANOBENCH(NODISCARD) double normalizedRootMeanSquare() const noexcept;
@@ -1127,7 +1694,7 @@ uint64_t Rng::operator()() noexcept {
 
 ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
 uint32_t Rng::bounded(uint32_t range) noexcept {
-    uint64_t r32 = static_cast<uint32_t>(operator()());
+    uint64_t const r32 = static_cast<uint32_t>(operator()());
     auto multiresult = r32 * range;
     return static_cast<uint32_t>(multiresult >> 32U);
 }
@@ -1136,18 +1703,23 @@ double Rng::uniform01() noexcept {
     auto i = (UINT64_C(0x3ff) << 52U) | (operator()() >> 12U);
     // can't use union in c++ here for type puning, it's undefined behavior.
     // std::memcpy is optimized anyways.
-    double d;
+    double d{};
     std::memcpy(&d, &i, sizeof(double));
     return d - 1.0;
 }
 
 template <typename Container>
 void Rng::shuffle(Container& container) noexcept {
-    auto size = static_cast<uint32_t>(container.size());
-    for (auto i = size; i > 1U; --i) {
+    auto i = container.size();
+    while (i > 1U) {
         using std::swap;
-        auto p = bounded(i); // number in [0, i)
-        swap(container[i - 1], container[p]);
+        auto n = operator()();
+        // using decltype(i) instead of size_t to be compatible to containers with 32bit index (see #80)
+        auto b1 = static_cast<decltype(i)>((static_cast<uint32_t>(n) * static_cast<uint64_t>(i)) >> 32U);
+        swap(container[--i], container[b1]);
+
+        auto b2 = static_cast<decltype(i)>(((n >> 32U) * static_cast<uint64_t>(i)) >> 32U);
+        swap(container[--i], container[b2]);
     }
 }
 
@@ -1156,26 +1728,93 @@ constexpr uint64_t Rng::rotl(uint64_t x, unsigned k) noexcept {
     return (x << k) | (x >> (64U - k));
 }
 
+namespace detail {
+
+// A setup lambda that captures little - or nothing - is smaller than the alignment of the Bench
+// reference next to it, so this pads. That is unavoidable here and harmless, but a consumer building
+// with -Weverything sees it as an error in nanobench's own header.
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
+template <typename SetupOp>
+class SetupRunner {
+public:
+    explicit SetupRunner(SetupOp setupOp, Bench& bench)
+        : mSetupOp(std::move(setupOp))
+        , mBench(bench) {}
+
+    template <typename Op>
+    ANKERL_NANOBENCH_NO_SANITIZE("integer")
+    Bench& run(Op&& op) {
+        return mBench.runImpl(mSetupOp, std::forward<Op>(op));
+    }
+
+    // Bench::run() takes a name, so setup().run() has to as well - otherwise adding a setup to an
+    // existing benchmark means rewriting its call site to use name() separately.
+    template <typename Op>
+    Bench& run(char const* benchmarkName, Op&& op) {
+        mBench.name(benchmarkName);
+        return run(std::forward<Op>(op));
+    }
+
+    template <typename Op>
+    Bench& run(std::string const& benchmarkName, Op&& op) {
+        mBench.name(benchmarkName);
+        return run(std::forward<Op>(op));
+    }
+
+private:
+    SetupOp mSetupOp;
+    Bench& mBench;
+};
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
+} // namespace detail
+
 template <typename Op>
 ANKERL_NANOBENCH_NO_SANITIZE("integer")
 Bench& Bench::run(Op&& op) {
+    auto setupOp = [] {};
+    return runImpl(setupOp, std::forward<Op>(op));
+}
+
+template <typename SetupOp, typename Op>
+ANKERL_NANOBENCH_NO_SANITIZE("integer")
+Bench& Bench::runImpl(SetupOp& setupOp, Op&& op) {
     // It is important that this method is kept short so the compiler can do better optimizations/ inlining of op()
     detail::IterationLogic iterationLogic(*this);
     auto& pc = detail::performanceCounters();
 
     while (auto n = iterationLogic.numIters()) {
+        setupOp();
+
         pc.beginMeasure();
-        Clock::time_point before = Clock::now();
+        Clock::time_point const before = Clock::now();
         while (n-- > 0) {
             op();
         }
-        Clock::time_point after = Clock::now();
+        Clock::time_point const after = Clock::now();
         pc.endMeasure();
         pc.updateResults(iterationLogic.numIters());
         iterationLogic.add(after - before, pc);
     }
     iterationLogic.moveResultTo(mResults);
     return *this;
+}
+
+template <typename... Args>
+CompareResult Bench::compare(Args&&... args) {
+    static_assert(sizeof...(args) % 2 == 0, "compare() takes `name, op` pairs");
+    static_assert(sizeof...(args) >= 4, "compare() needs at least two alternatives to compare");
+
+    std::vector<std::string> names;
+    std::vector<detail::ErasedOp> ops;
+    names.reserve(sizeof...(args) / 2);
+    ops.reserve(sizeof...(args) / 2);
+    compareCollect(names, ops, std::forward<Args>(args)...);
+    return compareImpl(names, ops);
+}
+
+template <typename SetupOp>
+detail::SetupRunner<SetupOp> Bench::setup(SetupOp setupOp) {
+    return detail::SetupRunner<SetupOp>(std::move(setupOp), *this);
 }
 
 // Performs all evaluations.
@@ -1190,6 +1829,14 @@ Bench& Bench::run(std::string const& benchmarkName, Op&& op) {
     name(benchmarkName);
     return run(std::forward<Op>(op));
 }
+
+#if ANKERL_NANOBENCH(HAS_STRING_VIEW)
+template <typename Op>
+Bench& Bench::run(std::string_view benchmarkName, Op&& op) {
+    name(benchmarkName);
+    return run(std::forward<Op>(op));
+}
+#endif
 
 template <typename Op>
 BigO Bench::complexityBigO(char const* benchmarkName, Op op) const {
@@ -1231,7 +1878,7 @@ void doNotOptimizeAway(Arg&& arg) {
 
 namespace detail {
 
-#if defined(_MSC_VER)
+#if !ANKERL_NANOBENCH(ASM_DONT_OPTIMIZE_AWAY)
 template <typename T>
 void doNotOptimizeAway(T const& val) {
     doNotOptimizeAwaySink(&val);
@@ -1256,11 +1903,11 @@ void doNotOptimizeAway(T const& val) {
 #    include <fstream>   // ifstream to parse proc files
 #    include <iomanip>   // setw, setprecision
 #    include <iostream>  // cout
+#    include <limits>    // numeric_limits, to parse NANOBENCH_CONFIG without overflowing
 #    include <numeric>   // accumulate
 #    include <random>    // random_device
 #    include <sstream>   // to_s in Number
 #    include <stdexcept> // throw for rendering templates
-#    include <tuple>     // std::tie
 #    if defined(__linux__)
 #        include <unistd.h> //sysconf
 #    endif
@@ -1270,7 +1917,6 @@ void doNotOptimizeAway(T const& val) {
 #        include <linux/perf_event.h>
 #        include <sys/ioctl.h>
 #        include <sys/syscall.h>
-#        include <unistd.h>
 #    endif
 
 // declarations ///////////////////////////////////////////////////////////////////////////////////
@@ -1281,12 +1927,12 @@ namespace nanobench {
 // helper stuff that is only intended to be used internally
 namespace detail {
 
-struct TableInfo;
-
 // formatting utilities
 namespace fmt {
 
-class NumSep;
+// groups the integer digits of an already formatted number in threes
+std::string addThousandsSeparators(std::string str, char sep);
+
 class StreamStateRestorer;
 class Number;
 class MarkDownColumn;
@@ -1313,6 +1959,18 @@ inline double d(T t) noexcept {
 }
 inline double d(Clock::duration duration) noexcept {
     return std::chrono::duration_cast<std::chrono::duration<double>>(duration).count();
+}
+
+// Rounds to the nearest uint64_t. Casting a double that doesn't fit is undefined behavior, so the value is clamped
+// into a safe range first. The comparisons are written so that a NaN takes the same path as a negative value.
+inline uint64_t u64(double val) noexcept {
+    auto const maxVal = d((std::numeric_limits<uint64_t>::max)() / 2U);
+    if (!(val > 0.0)) {
+        return 0;
+    }
+    // +0.5 for correct rounding when casting
+    // NOLINTNEXTLINE(bugprone-incorrect-roundings)
+    return static_cast<uint64_t>((val < maxVal ? val : maxVal) + 0.5);
 }
 
 // Calculates clock resolution once, and remembers the result
@@ -1436,31 +2094,48 @@ struct Node {
     template <size_t N>
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     bool operator==(char const (&str)[N]) const noexcept {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         return static_cast<size_t>(std::distance(begin, end) + 1) == N && 0 == strncmp(str, begin, N - 1);
     }
 };
 ANKERL_NANOBENCH(IGNORE_PADDED_POP)
 
+// A node points into the template rather than owning its text, and these two are the only places that
+// have to know it: everywhere else asks for the text or writes it out. Free functions rather than
+// members, so Node stays the plain aggregate that parseMustacheTemplate() brace-initializes.
+static std::string text(Node const& n) {
+    return {n.begin, n.end};
+}
+
+static void writeTo(Node const& n, std::ostream& out) {
+    out.write(n.begin, std::distance(n.begin, n.end));
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
 static std::vector<Node> parseMustacheTemplate(char const** tpl) {
     std::vector<Node> nodes;
 
     while (true) {
-        auto begin = std::strstr(*tpl, "{{");
-        auto end = begin;
+        auto const* begin = std::strstr(*tpl, "{{");
+        auto const* end = begin;
         if (begin != nullptr) {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             begin += 2;
             end = std::strstr(begin, "}}");
         }
 
         if (begin == nullptr || end == nullptr) {
             // nothing found, finish node
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             nodes.emplace_back(Node{*tpl, *tpl + std::strlen(*tpl), std::vector<Node>{}, Node::Type::content});
             return nodes;
         }
 
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         nodes.emplace_back(Node{*tpl, begin - 2, std::vector<Node>{}, Node::Type::content});
 
         // we found a tag
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         *tpl = end + 2;
         switch (*begin) {
         case '/':
@@ -1468,10 +2143,12 @@ static std::vector<Node> parseMustacheTemplate(char const** tpl) {
             return nodes;
 
         case '#':
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             nodes.emplace_back(Node{begin + 1, end, parseMustacheTemplate(tpl), Node::Type::section});
             break;
 
         case '^':
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             nodes.emplace_back(Node{begin + 1, end, parseMustacheTemplate(tpl), Node::Type::inverted_section});
             break;
 
@@ -1484,8 +2161,8 @@ static std::vector<Node> parseMustacheTemplate(char const** tpl) {
 
 static bool generateFirstLast(Node const& n, size_t idx, size_t size, std::ostream& out) {
     ANKERL_NANOBENCH_LOG("n.type=" << static_cast<int>(n.type));
-    bool matchFirst = n == "-first";
-    bool matchLast = n == "-last";
+    bool const matchFirst = n == "-first";
+    bool const matchLast = n == "-last";
     if (!matchFirst && !matchLast) {
         return false;
     }
@@ -1500,7 +2177,7 @@ static bool generateFirstLast(Node const& n, size_t idx, size_t size, std::ostre
     if (doWrite) {
         for (auto const& child : n.children) {
             if (child.type == Node::Type::content) {
-                out.write(child.begin, std::distance(child.begin, child.end));
+                writeTo(child, out);
             }
         }
     }
@@ -1518,7 +2195,7 @@ static bool matchCmdArgs(std::string const& str, std::vector<std::string>& match
     matchResult.emplace_back(str.substr(0, idxOpen));
 
     // split by comma
-    matchResult.emplace_back(std::string{});
+    matchResult.emplace_back();
     for (size_t i = idxOpen + 1; i != idxClose; ++i) {
         if (str[i] == ' ' || str[i] == '\t') {
             // skip whitespace
@@ -1526,7 +2203,7 @@ static bool matchCmdArgs(std::string const& str, std::vector<std::string>& match
         }
         if (str[i] == ',') {
             // got a comma => new string
-            matchResult.emplace_back(std::string{});
+            matchResult.emplace_back();
             continue;
         }
         // no whitespace no comma, append
@@ -1535,50 +2212,96 @@ static bool matchCmdArgs(std::string const& str, std::vector<std::string>& match
     return true;
 }
 
+// One tag: writes `value` when the node names it, and reports whether it did.
+template <size_t N, typename T>
+// NOLINTNEXTLINE(hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+static bool writeTag(Node const& n, char const (&tagName)[N], T const& value, std::ostream& out) {
+    if (!(n == tagName)) {
+        return false;
+    }
+    out << value;
+    return true;
+}
+
 static bool generateConfigTag(Node const& n, Config const& config, std::ostream& out) {
     using detail::d;
 
-    if (n == "title") {
-        out << config.mBenchmarkTitle;
-        return true;
-    } else if (n == "name") {
-        out << config.mBenchmarkName;
-        return true;
-    } else if (n == "unit") {
-        out << config.mUnit;
-        return true;
-    } else if (n == "batch") {
-        out << config.mBatch;
-        return true;
-    } else if (n == "complexityN") {
-        out << config.mComplexityN;
-        return true;
-    } else if (n == "epochs") {
-        out << config.mNumEpochs;
-        return true;
-    } else if (n == "clockResolution") {
+    // Not part of the chain below: the chain evaluates the arguments of every tag up to the one that
+    // matches, and measuring the clock's resolution the first time is the one that is not free.
+    if (n == "clockResolution") {
         out << d(detail::clockResolution());
         return true;
-    } else if (n == "clockResolutionMultiple") {
-        out << config.mClockResolutionMultiple;
+    }
+
+    // '||' short-circuits, so at most one of these writes anything and nothing past the match is even
+    // evaluated. Written out as fourteen copies of writeTag()'s body, this was a four-line stanza per
+    // tag whose only compiler-visible mistake - forgetting the `return true` - fell through to
+    // "command not understood" at runtime.
+    return writeTag(n, "title", config.mBenchmarkTitle, out) || writeTag(n, "name", config.mBenchmarkName, out) ||
+           writeTag(n, "unit", config.mUnit, out) || writeTag(n, "batch", config.mBatch, out) ||
+           writeTag(n, "complexityN", config.mComplexityN, out) || writeTag(n, "epochs", config.mNumEpochs, out) ||
+           writeTag(n, "clockResolutionMultiple", config.mClockResolutionMultiple, out) ||
+           writeTag(n, "maxEpochTime", d(config.mMaxEpochTime), out) || writeTag(n, "minEpochTime", d(config.mMinEpochTime), out) ||
+           writeTag(n, "minEpochIterations", config.mMinEpochIterations, out) ||
+           writeTag(n, "epochIterations", config.mEpochIterations, out) || writeTag(n, "warmup", config.mWarmup, out) ||
+           writeTag(n, "relative", config.mIsRelative, out);
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+// `elapsed` is seconds, which is rarely the unit anyone wants in a report, and the template language
+// has no arithmetic to fix that afterwards (issue #107). So a time measure may carry a unit suffix -
+// `elapsedms`, `elapsedus`, `elapsedns` - and this resolves it to the measure plus the factor to
+// multiply by. Plain `elapsed` keeps its meaning, so existing templates render byte for byte as
+// before.
+static Result::Measure measureFromString(std::string const& str, double& scale) {
+    scale = 1.0;
+    auto m = Result::fromString(str);
+    if (Result::Measure::_size != m) {
+        return m;
+    }
+
+    if (str == "elapsedms") {
+        scale = 1e3;
+        return Result::Measure::elapsed;
+    }
+    if (str == "elapsedus") {
+        scale = 1e6;
+        return Result::Measure::elapsed;
+    }
+    if (str == "elapsedns") {
+        scale = 1e9;
+        return Result::Measure::elapsed;
+    }
+    return Result::Measure::_size;
+}
+
+// The one-argument measure commands - {{median(elapsed)}} and friends. Split out of
+// generateResultTag so that adding the unit-scaled measures did not push its cognitive complexity
+// past what clang-tidy accepts.
+static bool generateMeasureTag(std::string const& command, Result const& r, Result::Measure m, double scale, std::ostream& out) {
+    if (command == "median") {
+        out << r.median(m) * scale;
         return true;
-    } else if (n == "maxEpochTime") {
-        out << d(config.mMaxEpochTime);
+    }
+    if (command == "average") {
+        out << r.average(m) * scale;
         return true;
-    } else if (n == "minEpochTime") {
-        out << d(config.mMinEpochTime);
+    }
+    if (command == "medianAbsolutePercentError") {
+        // a relative error is the same number whatever the unit, so this one is not scaled
+        out << r.medianAbsolutePercentError(m);
         return true;
-    } else if (n == "minEpochIterations") {
-        out << config.mMinEpochIterations;
+    }
+    if (command == "sum") {
+        out << r.sum(m) * scale;
         return true;
-    } else if (n == "epochIterations") {
-        out << config.mEpochIterations;
+    }
+    if (command == "minimum") {
+        out << r.minimum(m) * scale;
         return true;
-    } else if (n == "warmup") {
-        out << config.mWarmup;
-        return true;
-    } else if (n == "relative") {
-        out << config.mIsRelative;
+    }
+    if (command == "maximum") {
+        out << r.maximum(m) * scale;
         return true;
     }
     return false;
@@ -1594,40 +2317,31 @@ static std::ostream& generateResultTag(Node const& n, Result const& r, std::ostr
     // std::cmatch matchResult;
     // if (std::regex_match(n.begin, n.end, matchResult, regOpArg1)) {
     std::vector<std::string> matchResult;
-    if (matchCmdArgs(std::string(n.begin, n.end), matchResult)) {
+    if (matchCmdArgs(text(n), matchResult)) {
         if (matchResult.size() == 2) {
-            auto m = Result::fromString(matchResult[1]);
+            if (matchResult[0] == "context") {
+                return out << r.context(matchResult[1]);
+            }
+
+            double scale = 1.0;
+            auto m = measureFromString(matchResult[1], scale);
             if (m == Result::Measure::_size) {
                 return out << 0.0;
             }
-
-            if (matchResult[0] == "median") {
-                return out << r.median(m);
-            }
-            if (matchResult[0] == "average") {
-                return out << r.average(m);
-            }
-            if (matchResult[0] == "medianAbsolutePercentError") {
-                return out << r.medianAbsolutePercentError(m);
-            }
-            if (matchResult[0] == "sum") {
-                return out << r.sum(m);
-            }
-            if (matchResult[0] == "minimum") {
-                return out << r.minimum(m);
-            }
-            if (matchResult[0] == "maximum") {
-                return out << r.maximum(m);
+            if (generateMeasureTag(matchResult[0], r, m, scale, out)) {
+                return out;
             }
         } else if (matchResult.size() == 3) {
-            auto m1 = Result::fromString(matchResult[1]);
-            auto m2 = Result::fromString(matchResult[2]);
+            double scale1 = 1.0;
+            double scale2 = 1.0;
+            auto m1 = measureFromString(matchResult[1], scale1);
+            auto m2 = measureFromString(matchResult[2], scale2);
             if (m1 == Result::Measure::_size || m2 == Result::Measure::_size) {
                 return out << 0.0;
             }
 
             if (matchResult[0] == "sumProduct") {
-                return out << r.sumProduct(m1, m2);
+                return out << r.sumProduct(m1, m2) * scale1 * scale2;
             }
         }
     }
@@ -1636,7 +2350,7 @@ static std::ostream& generateResultTag(Node const& n, Result const& r, std::ostr
     // static std::regex const regOpArg2("^([a-zA-Z]+)\\(([a-zA-Z]*)\\s*,\\s+([a-zA-Z]*)\\)$");
 
     // nothing matches :(
-    throw std::runtime_error("command '" + std::string(n.begin, n.end) + "' not understood");
+    ANKERL_NANOBENCH_THROW(std::runtime_error("command '" + text(n) + "' not understood"));
 }
 
 static void generateResultMeasurement(std::vector<Node> const& nodes, size_t idx, Result const& r, std::ostream& out) {
@@ -1645,21 +2359,22 @@ static void generateResultMeasurement(std::vector<Node> const& nodes, size_t idx
             ANKERL_NANOBENCH_LOG("n.type=" << static_cast<int>(n.type));
             switch (n.type) {
             case Node::Type::content:
-                out.write(n.begin, std::distance(n.begin, n.end));
+                writeTo(n, out);
                 break;
 
             case Node::Type::inverted_section:
-                throw std::runtime_error("got a inverted section inside measurement");
+                ANKERL_NANOBENCH_THROW(std::runtime_error("got a inverted section inside measurement"));
 
             case Node::Type::section:
-                throw std::runtime_error("got a section inside measurement");
+                ANKERL_NANOBENCH_THROW(std::runtime_error("got a section inside measurement"));
 
             case Node::Type::tag: {
-                auto m = Result::fromString(std::string(n.begin, n.end));
+                double scale = 1.0;
+                auto m = measureFromString(text(n), scale);
                 if (m == Result::Measure::_size || !r.has(m)) {
                     out << 0.0;
                 } else {
-                    out << r.get(idx, m);
+                    out << r.get(idx, m) * scale;
                 }
                 break;
             }
@@ -1675,11 +2390,11 @@ static void generateResult(std::vector<Node> const& nodes, size_t idx, std::vect
             ANKERL_NANOBENCH_LOG("n.type=" << static_cast<int>(n.type));
             switch (n.type) {
             case Node::Type::content:
-                out.write(n.begin, std::distance(n.begin, n.end));
+                writeTo(n, out);
                 break;
 
             case Node::Type::inverted_section:
-                throw std::runtime_error("got a inverted section inside result");
+                ANKERL_NANOBENCH_THROW(std::runtime_error("got a inverted section inside result"));
 
             case Node::Type::section:
                 if (n == "measurement") {
@@ -1687,7 +2402,7 @@ static void generateResult(std::vector<Node> const& nodes, size_t idx, std::vect
                         generateResultMeasurement(n.children, i, r, out);
                     }
                 } else {
-                    throw std::runtime_error("got a section inside result");
+                    ANKERL_NANOBENCH_THROW(std::runtime_error("got a section inside result"));
                 }
                 break;
 
@@ -1708,33 +2423,20 @@ char const* getEnv(char const* name);
 bool isEndlessRunning(std::string const& name);
 bool isWarningsEnabled();
 
+// Applies NANOBENCH_CONFIG to a freshly built Bench, printing whatever it could not use. Every Bench
+// re-reads and re-parses the variable; only the complaining is once per process.
+void applyEnvConfig(Bench& bench);
+
 template <typename T>
-T parseFile(std::string const& filename);
+T parseFile(std::string const& filename, bool* fail);
 
 void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<std::string>& recommendations);
-void printStabilityInformationOnce(std::ostream* os);
-
-// remembers the last table settings used. When it changes, a new table header is automatically written for the new entry.
-uint64_t& singletonHeaderHash() noexcept;
 
 // determines resolution of the given clock. This is done by measuring multiple times and returning the minimum time difference.
 Clock::duration calcClockResolution(size_t numEvaluations) noexcept;
 
 // formatting utilities
 namespace fmt {
-
-// adds thousands separator to numbers
-ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
-class NumSep : public std::numpunct<char> {
-public:
-    explicit NumSep(char sep);
-    char do_thousands_sep() const override;
-    std::string do_grouping() const override;
-
-private:
-    char mSep;
-};
-ANKERL_NANOBENCH(IGNORE_PADDED_POP)
 
 // RAII to save & restore a stream's state
 ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
@@ -1766,8 +2468,7 @@ ANKERL_NANOBENCH(IGNORE_PADDED_POP)
 class Number {
 public:
     Number(int width, int precision, double value);
-    Number(int width, int precision, int64_t value);
-    std::string to_s() const;
+    ANKERL_NANOBENCH(NODISCARD) std::string to_s() const;
 
 private:
     friend std::ostream& operator<<(std::ostream& os, Number const& n);
@@ -1779,25 +2480,34 @@ private:
 };
 
 // helper replacement for std::to_string of signed/unsigned numbers so we are locale independent
-std::string to_s(uint64_t s);
+std::string to_s(uint64_t n);
 
 std::ostream& operator<<(std::ostream& os, Number const& n);
 
+ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
 class MarkDownColumn {
 public:
-    MarkDownColumn(int w, int prec, std::string const& tit, std::string const& suff, double val);
-    std::string title() const;
-    std::string separator() const;
-    std::string invalid() const;
-    std::string value() const;
+    MarkDownColumn(int w, int prec, std::string tit, std::string suff, double val) noexcept;
+    // a column holding text instead of a number, for the context columns
+    MarkDownColumn(int w, std::string tit, std::string text) noexcept;
+    ANKERL_NANOBENCH(NODISCARD) std::string title() const;
+    ANKERL_NANOBENCH(NODISCARD) std::string separator() const;
+    ANKERL_NANOBENCH(NODISCARD) std::string invalid() const;
+    ANKERL_NANOBENCH(NODISCARD) std::string value() const;
 
 private:
+    // the column's padding convention, stated once: right aligned in mWidth, one trailing space
+    ANKERL_NANOBENCH(NODISCARD) std::string padded(std::string const& text) const;
+
     int mWidth;
     int mPrecision;
     std::string mTitle;
     std::string mSuffix;
     double mValue;
+    std::string mText{};
+    bool mIsText{false};
 };
+ANKERL_NANOBENCH(IGNORE_PADDED_POP)
 
 // Formats any text as markdown code, escaping backticks.
 class MarkDownCode {
@@ -1823,8 +2533,9 @@ std::ostream& operator<<(std::ostream& os, MarkDownCode const& mdCode);
 namespace ankerl {
 namespace nanobench {
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void render(char const* mustacheTemplate, std::vector<Result> const& results, std::ostream& out) {
-    detail::fmt::StreamStateRestorer restorer(out);
+    detail::fmt::StreamStateRestorer const restorer(out);
 
     out.precision(std::numeric_limits<double>::digits10);
     auto nodes = templates::parseMustacheTemplate(&mustacheTemplate);
@@ -1833,11 +2544,11 @@ void render(char const* mustacheTemplate, std::vector<Result> const& results, st
         ANKERL_NANOBENCH_LOG("n.type=" << static_cast<int>(n.type));
         switch (n.type) {
         case templates::Node::Type::content:
-            out.write(n.begin, std::distance(n.begin, n.end));
+            templates::writeTo(n, out);
             break;
 
         case templates::Node::Type::inverted_section:
-            throw std::runtime_error("unknown list '" + std::string(n.begin, n.end) + "'");
+            ANKERL_NANOBENCH_THROW(std::runtime_error("unknown list '" + templates::text(n) + "'"));
 
         case templates::Node::Type::section:
             if (n == "result") {
@@ -1847,9 +2558,9 @@ void render(char const* mustacheTemplate, std::vector<Result> const& results, st
                 }
             } else if (n == "measurement") {
                 if (results.size() != 1) {
-                    throw std::runtime_error(
+                    ANKERL_NANOBENCH_THROW(std::runtime_error(
                         "render: can only use section 'measurement' here if there is a single result, but there are " +
-                        detail::fmt::to_s(results.size()));
+                        detail::fmt::to_s(results.size())));
                 }
                 // when we only have a single result, we can immediately go into its measurement.
                 auto const& r = results.front();
@@ -1857,7 +2568,7 @@ void render(char const* mustacheTemplate, std::vector<Result> const& results, st
                     generateResultMeasurement(n.children, i, r, out);
                 }
             } else {
-                throw std::runtime_error("render: unknown section '" + std::string(n.begin, n.end) + "'");
+                ANKERL_NANOBENCH_THROW(std::runtime_error("render: unknown section '" + templates::text(n) + "'"));
             }
             break;
 
@@ -1868,7 +2579,7 @@ void render(char const* mustacheTemplate, std::vector<Result> const& results, st
             } else {
                 // This just uses the last result's config.
                 if (!generateConfigTag(n, results.back().config(), out)) {
-                    throw std::runtime_error("unknown tag '" + std::string(n.begin, n.end) + "'");
+                    ANKERL_NANOBENCH_THROW(std::runtime_error("unknown tag '" + templates::text(n) + "'"));
                 }
             }
             break;
@@ -1902,21 +2613,39 @@ PerformanceCounters& performanceCounters() {
     return pc;
 }
 
+Clock::duration targetRuntimePerEpoch(Bench const& bench) {
+    auto target = detail::clockResolution() * bench.clockResolutionMultiple();
+    if (target > bench.maxEpochTime()) {
+        target = bench.maxEpochTime();
+    }
+    if (target < bench.minEpochTime()) {
+        target = bench.minEpochTime();
+    }
+    return target;
+}
+
 // Windows version of doNotOptimizeAway
-// see https://github.com/google/benchmark/blob/master/include/benchmark/benchmark.h#L307
-// see https://github.com/facebook/folly/blob/master/folly/Benchmark.h#L280
-// see https://docs.microsoft.com/en-us/cpp/preprocessor/optimize
-#    if defined(_MSC_VER)
-#        pragma optimize("", off)
+// see https://github.com/google/benchmark/blob/v1.7.1/include/benchmark/benchmark.h#L514
+// see https://github.com/facebook/folly/blob/v2023.01.30.00/folly/lang/Hint-inl.h#L54-L58
+// see https://learn.microsoft.com/en-us/cpp/preprocessor/optimize
+#    if !ANKERL_NANOBENCH(ASM_DONT_OPTIMIZE_AWAY)
+#        if defined(_MSC_VER)
+#            pragma optimize("", off)
+#        endif
 void doNotOptimizeAwaySink(void const*) {}
-#        pragma optimize("", on)
+#        if defined(_MSC_VER)
+#            pragma optimize("", on)
+#        endif
 #    endif
 
 template <typename T>
-T parseFile(std::string const& filename) {
-    std::ifstream fin(filename);
+T parseFile(std::string const& filename, bool* fail) {
+    std::ifstream fin(filename); // NOLINT(misc-const-correctness)
     T num{};
     fin >> num;
+    if (fail != nullptr) {
+        *fail = fin.fail();
+    }
     return num;
 }
 
@@ -1925,32 +2654,293 @@ char const* getEnv(char const* name) {
 #        pragma warning(push)
 #        pragma warning(disable : 4996) // getenv': This function or variable may be unsafe.
 #    endif
-    return std::getenv(name);
+    return std::getenv(name); // NOLINT(concurrency-mt-unsafe)
 #    if defined(_MSC_VER)
 #        pragma warning(pop)
 #    endif
 }
 
 bool isEndlessRunning(std::string const& name) {
-    auto endless = getEnv("NANOBENCH_ENDLESS");
+    auto const* const endless = getEnv("NANOBENCH_ENDLESS");
     return nullptr != endless && endless == name;
 }
 
 // True when environment variable NANOBENCH_SUPPRESS_WARNINGS is either not set at all, or set to "0"
 bool isWarningsEnabled() {
-    auto suppression = getEnv("NANOBENCH_SUPPRESS_WARNINGS");
+    auto const* const suppression = getEnv("NANOBENCH_SUPPRESS_WARNINGS");
     return nullptr == suppression || suppression == std::string("0");
+}
+
+// NANOBENCH_CONFIG ///////////////////////////////////////////////////////////////////////////////
+//
+// The parsing below reports a bad value by returning the reason for it as a string, empty when the
+// value was fine. That is what keeps this usable from a Bench constructor: throwing would be worse
+// than the mistake it reports, and impossible for a consumer built with -fno-exceptions.
+//
+// The numbers are parsed by hand rather than through a stream or std::stoull. Both of those accept
+// "-1" as a uint64_t - the standard has them read a signed value and negate it - which would turn a
+// typo into 18446744073709551615 epochs. Doing it here also keeps the decimal point out of the
+// hands of the global locale, and lets a duration be scaled by an exact power of ten instead of a
+// double multiplication that turns 1.5s into 1499999999ns.
+
+// Everything before the unit of a duration, and every count: "1.5" gives digits 15 and one fraction
+// digit. A sign, an exponent, a second dot and anything that does not fit are all rejected - these
+// are epoch times and iteration counts, not a general purpose number format.
+static std::string parseDecimal(std::string const& str, uint64_t& digits, int& fractionDigits) {
+    digits = 0;
+    fractionDigits = 0;
+    bool seenDot = false;
+    bool seenDigit = false;
+    for (auto ch : str) {
+        if ('.' == ch) {
+            if (seenDot) {
+                return "is not a number";
+            }
+            seenDot = true;
+            continue;
+        }
+        if (ch < '0' || ch > '9') {
+            return "is not a number";
+        }
+        auto const digit = static_cast<uint64_t>(ch - '0');
+        if (digits > (std::numeric_limits<uint64_t>::max() - digit) / 10U) {
+            return "is too large";
+        }
+        digits = digits * 10U + digit;
+        seenDigit = true;
+        if (seenDot) {
+            ++fractionDigits;
+        }
+    }
+    return seenDigit ? std::string() : std::string("is not a number");
+}
+
+// Multiplies by ten `exponent` times, or divides that often when it is negative. Only the last
+// division rounds, so that the digits thrown away before it cannot round up twice.
+static bool scaleByPowerOfTen(uint64_t& value, int exponent) {
+    while (exponent > 0) {
+        if (value > std::numeric_limits<uint64_t>::max() / 10U) {
+            return false;
+        }
+        value *= 10U;
+        --exponent;
+    }
+    while (exponent < 0) {
+        auto const remainder = value % 10U;
+        value /= 10U;
+        if (-1 == exponent && remainder >= 5U) {
+            ++value;
+        }
+        ++exponent;
+    }
+    return true;
+}
+
+// The trailing ns/us/ms/s of a duration. exponent is then the power of ten that turns that unit into
+// nanoseconds, and numberLen how much of value is left in front of it.
+//
+// Every unit is an "s" with an optional metric prefix, which is worth saying that way rather than as
+// a list of four suffixes to try: a list has to put the two character units first, since every one
+// of them also ends in a match for "s", and nothing about the list says so.
+static bool splitTimeUnit(std::string const& value, int& exponent, size_t& numberLen) {
+    if (value.empty() || 's' != value[value.size() - 1]) {
+        return false;
+    }
+    numberLen = value.size() - 1;
+    exponent = 9;
+    if (numberLen > 0) {
+        auto const prefix = value[numberLen - 1];
+        if ('n' == prefix) {
+            exponent = 0;
+            --numberLen;
+        } else if ('u' == prefix) {
+            exponent = 3;
+            --numberLen;
+        } else if ('m' == prefix) {
+            exponent = 6;
+            --numberLen;
+        }
+    }
+    return true;
+}
+
+// A whole number of iterations or epochs.
+static std::string parseCount(std::string const& value, uint64_t& out) {
+    int fractionDigits = 0;
+    std::string reason = parseDecimal(value, out, fractionDigits);
+    if (reason.empty() && fractionDigits > 0) {
+        reason = "is not a whole number";
+    }
+    return reason;
+}
+
+// A number with a required unit, e.g. "1.5s". The unit is required because a bare number reads as
+// whatever the writer had in mind and would be taken as nanoseconds, so "minEpochTime=5" would
+// quietly become a 5ns floor - which is the trap that made one variable per setting, in nanoseconds,
+// the wrong shape for this.
+static std::string parseDuration(std::string const& value, std::chrono::nanoseconds& out) {
+    int unitExponent = 0;
+    size_t numberLen = 0;
+    if (!splitTimeUnit(value, unitExponent, numberLen)) {
+        return "is missing a time unit - use ns, us, ms or s";
+    }
+
+    // Nested, rather than the flatter chain of early returns this wants to be. `return reason;` is
+    // only elided when it is the *only* return of a named local, and clang's -Wnrvo is an error
+    // here; the early return above is fine because it returns a temporary built from a literal.
+    uint64_t digits = 0;
+    int fractionDigits = 0;
+    std::string reason = parseDecimal(value.substr(0, numberLen), digits, fractionDigits);
+    if (reason.empty()) {
+        using Rep = std::chrono::nanoseconds::rep;
+        if (scaleByPowerOfTen(digits, unitExponent - fractionDigits) &&
+            digits <= static_cast<uint64_t>(std::numeric_limits<Rep>::max())) {
+            out = std::chrono::nanoseconds(static_cast<Rep>(digits));
+        } else {
+            reason = "is too large";
+        }
+    }
+    return reason;
+}
+
+// One key, applied by calling the Bench setter it is named after. Going through the setter is what
+// "the keys are the Bench setter names" has to mean to be worth writing down: minEpochIterations
+// turns 0 into 1, and a setter that grows a rule later gets it for a value from the environment too.
+//
+// Arg is spelled at the call site rather than deduced. Every one of these names a setter *and* a
+// getter, and naming the parameter type outright makes picking between them ordinary overload
+// resolution rather than deduction against an overload set.
+template <typename Arg>
+static bool setCount(Bench& bench, std::string const& key, char const* name, Bench& (Bench::*setter)(Arg), std::string const& value,
+                     std::string& reason) {
+    if (key != name) {
+        return false;
+    }
+    uint64_t parsed = 0;
+    reason = parseCount(value, parsed);
+    // size_t is 32 bits on a third of the matrix, and a count that does not survive the trip would
+    // otherwise run a quietly different benchmark than the one that was asked for
+    if (reason.empty() && static_cast<uint64_t>(static_cast<Arg>(parsed)) != parsed) {
+        reason = "is too large";
+    }
+    if (reason.empty()) {
+        (bench.*setter)(static_cast<Arg>(parsed));
+    }
+    return true;
+}
+
+static bool setDuration(Bench& bench, std::string const& key, char const* name, Bench& (Bench::*setter)(std::chrono::nanoseconds),
+                        std::string const& value, std::string& reason) {
+    if (key != name) {
+        return false;
+    }
+    std::chrono::nanoseconds parsed{};
+    reason = parseDuration(value, parsed);
+    if (reason.empty()) {
+        (bench.*setter)(parsed);
+    }
+    return true;
+}
+
+// Everything NANOBENCH_CONFIG understands, each key named exactly once. '||' short-circuits, so at
+// most one of these runs and nothing past the match is even evaluated.
+//
+// This is the shape generateConfigTag() uses for the same seven names in the other direction, and
+// for the reason its comment gives: as a stanza per key, the one mistake the compiler cannot see is
+// a key you classified and then forgot to assign, which falls through to whichever branch was last.
+static bool applyKnownKey(Bench& bench, std::string const& key, std::string const& value, std::string& reason) {
+    return setDuration(bench, key, "minEpochTime", &Bench::minEpochTime, value, reason) ||
+           setDuration(bench, key, "maxEpochTime", &Bench::maxEpochTime, value, reason) ||
+           setCount<size_t>(bench, key, "epochs", &Bench::epochs, value, reason) ||
+           setCount<uint64_t>(bench, key, "warmup", &Bench::warmup, value, reason) ||
+           setCount<uint64_t>(bench, key, "minEpochIterations", &Bench::minEpochIterations, value, reason) ||
+           setCount<uint64_t>(bench, key, "epochIterations", &Bench::epochIterations, value, reason) ||
+           setCount<size_t>(bench, key, "clockResolutionMultiple", &Bench::clockResolutionMultiple, value, reason);
+}
+
+// Sorted, and next to the chain above so that a key added to one and not the other is visible on one
+// screen. Only tuning knobs are there at all: name, title, unit, batch and timeUnit say what a
+// benchmark *is*, and letting a shell variable change those for a whole process would change what
+// the numbers mean rather than how long they take.
+static char const* configKeyList() {
+    return "clockResolutionMultiple, epochIterations, epochs, maxEpochTime, minEpochIterations, minEpochTime, warmup";
+}
+
+static void applyConfigEntry(Bench& bench, std::string const& key, std::string const& value, std::vector<std::string>& errors) {
+    std::string reason;
+    if (!applyKnownKey(bench, key, value, reason)) {
+        errors.push_back("NANOBENCH_CONFIG: unknown key '" + key + "' - valid keys are " + configKeyList());
+    } else if (!reason.empty()) {
+        errors.push_back("NANOBENCH_CONFIG: '" + key + "=" + value + "' " + reason);
+    }
+}
+
+// Whitespace around a key or a value is somebody laying the variable out to be read, not part of
+// what they typed.
+static std::string trimWhitespace(std::string const& str) {
+    char const* const spaces = " \t\n\r\f\v";
+    auto const first = str.find_first_not_of(spaces);
+    if (std::string::npos == first) {
+        return {};
+    }
+    return str.substr(first, str.find_last_not_of(spaces) - first + 1);
+}
+
+void applyConfigString(Bench& bench, std::string const& configStr, std::vector<std::string>& errors) {
+    size_t pos = 0;
+    while (pos < configStr.size()) {
+        auto const comma = configStr.find(',', pos);
+        auto const end = std::string::npos == comma ? configStr.size() : comma;
+        auto const entry = trimWhitespace(configStr.substr(pos, end - pos));
+        pos = end + 1;
+
+        // an empty variable, or a trailing comma, is nothing to complain about
+        if (entry.empty()) {
+            continue;
+        }
+        auto const equals = entry.find('=');
+        if (std::string::npos == equals) {
+            errors.push_back("NANOBENCH_CONFIG: '" + entry + "' is not a key=value pair");
+            continue;
+        }
+        applyConfigEntry(bench, trimWhitespace(entry.substr(0, equals)), trimWhitespace(entry.substr(equals + 1)), errors);
+    }
+}
+
+// Applies NANOBENCH_CONFIG to a freshly built Bench, so that anything the benchmark sets afterwards
+// still wins: the environment moves the default, it does not overrule a benchmark that needs a
+// particular setting to mean anything.
+void applyEnvConfig(Bench& bench) {
+    auto const* const configStr = getEnv("NANOBENCH_CONFIG");
+    if (nullptr == configStr) {
+        return;
+    }
+
+    std::vector<std::string> errors;
+    applyConfigString(bench, configStr, errors);
+
+    // Every Bench parses the variable, but a typo in it is one mistake and gets one message. This is
+    // deliberately not behind NANOBENCH_SUPPRESS_WARNINGS: that hides statements about the machine
+    // being unsuitable, whereas this is a mistake in something the user typed moments ago, and
+    // swallowing it is how somebody ends up believing a sweep ran when it did not.
+    static bool isFirstBench = true;
+    if (isFirstBench) {
+        isFirstBench = false;
+        for (auto const& error : errors) {
+            std::cerr << error << std::endl;
+        }
+    }
 }
 
 void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<std::string>& recommendations) {
     warnings.clear();
     recommendations.clear();
 
-    bool recommendCheckFlags = false;
-
 #    if defined(DEBUG)
     warnings.emplace_back("DEBUG defined");
-    recommendCheckFlags = true;
+    bool const recommendCheckFlags = true;
+#    else
+    bool const recommendCheckFlags = false;
 #    endif
 
     bool recommendPyPerf = false;
@@ -1959,16 +2949,15 @@ void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<
     if (nprocs <= 0) {
         warnings.emplace_back("couldn't figure out number of processors - no governor, turbo check possible");
     } else {
-
         // check frequency scaling
         for (long id = 0; id < nprocs; ++id) {
             auto idStr = detail::fmt::to_s(static_cast<uint64_t>(id));
             auto sysCpu = "/sys/devices/system/cpu/cpu" + idStr;
-            auto minFreq = parseFile<int64_t>(sysCpu + "/cpufreq/scaling_min_freq");
-            auto maxFreq = parseFile<int64_t>(sysCpu + "/cpufreq/scaling_max_freq");
+            auto minFreq = parseFile<int64_t>(sysCpu + "/cpufreq/scaling_min_freq", nullptr);
+            auto maxFreq = parseFile<int64_t>(sysCpu + "/cpufreq/scaling_max_freq", nullptr);
             if (minFreq != maxFreq) {
-                auto minMHz = static_cast<double>(minFreq) / 1000.0;
-                auto maxMHz = static_cast<double>(maxFreq) / 1000.0;
+                auto minMHz = d(minFreq) / 1000.0;
+                auto maxMHz = d(maxFreq) / 1000.0;
                 warnings.emplace_back("CPU frequency scaling enabled: CPU " + idStr + " between " +
                                       detail::fmt::Number(1, 1, minMHz).to_s() + " and " + detail::fmt::Number(1, 1, maxMHz).to_s() +
                                       " MHz");
@@ -1977,13 +2966,15 @@ void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<
             }
         }
 
-        auto currentGovernor = parseFile<std::string>("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
-        if ("performance" != currentGovernor) {
+        auto fail = false;
+        auto currentGovernor = parseFile<std::string>("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor", &fail);
+        if (!fail && "performance" != currentGovernor) {
             warnings.emplace_back("CPU governor is '" + currentGovernor + "' but should be 'performance'");
             recommendPyPerf = true;
         }
 
-        if (0 == parseFile<int>("/sys/devices/system/cpu/intel_pstate/no_turbo")) {
+        auto noTurbo = parseFile<int>("/sys/devices/system/cpu/intel_pstate/no_turbo", &fail);
+        if (!fail && noTurbo == 0) {
             warnings.emplace_back("Turbo is enabled, CPU frequency will fluctuate");
             recommendPyPerf = true;
         }
@@ -2000,7 +2991,7 @@ void gatherStabilityInformation(std::vector<std::string>& warnings, std::vector<
 
 void printStabilityInformationOnce(std::ostream* outStream) {
     static bool shouldPrint = true;
-    if (shouldPrint && outStream && isWarningsEnabled()) {
+    if (shouldPrint && (nullptr != outStream) && isWarningsEnabled()) {
         auto& os = *outStream;
         shouldPrint = false;
         std::vector<std::string> warnings;
@@ -2022,10 +3013,75 @@ void printStabilityInformationOnce(std::ostream* outStream) {
     }
 }
 
-// remembers the last table settings used. When it changes, a new table header is automatically written for the new entry.
-uint64_t& singletonHeaderHash() noexcept {
-    static uint64_t sHeaderHash{};
-    return sHeaderHash;
+// When perf_event_open is refused, the table simply comes out five columns narrower. That reads like a
+// nanobench bug rather than a setting of the machine, and people have gone looking for it more than once
+// (issues #106, #123). So say what happened - but only where those columns could have appeared at all:
+// on a platform that has no perf events in the first place nothing is wrong, and a note on every single
+// run would be pure noise.
+void printPerformanceCounterHintOnce(std::ostream* outStream, bool wantsPerformanceCounters) {
+#    if ANKERL_NANOBENCH(PERF_COUNTERS)
+    static bool shouldPrint = true;
+    if (!shouldPrint || !wantsPerformanceCounters || (nullptr == outStream) || !isWarningsEnabled()) {
+        return;
+    }
+    shouldPrint = false;
+
+    auto const& has = performanceCounters().has();
+    if (has.instructions || has.cpuCycles || has.branchInstructions || has.branchMisses) {
+        return;
+    }
+
+    *outStream << "Note: perf_event_open failed, so the ins/op, cyc/op, IPC, bra/op and miss% columns are missing." << std::endl
+               << "This is usually a container or VM without virtualized performance counters, or" << std::endl
+               << "/proc/sys/kernel/perf_event_paranoid being too restrictive." << std::endl
+               << std::endl;
+#    else
+    (void)outStream;
+    (void)wantsPerformanceCounters;
+#    endif
+}
+
+// Which index of the pword/iword array every stream carries is ours. Allocated once per process.
+static int streamHeaderHashIndex() {
+    static int const index = std::ios_base::xalloc();
+    return index;
+}
+
+// pword holds a raw void*, so what it points at has to be freed when the stream goes away.
+static void streamHeaderHashCallback(std::ios_base::event ev, std::ios_base& ios, int index) {
+    if (std::ios_base::erase_event == ev) {
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        delete static_cast<uint64_t*>(ios.pword(index));
+        ios.pword(index) = nullptr;
+    } else if (std::ios_base::copyfmt_event == ev) {
+        // copyfmt just copied our pointer into this stream; only one of the two may own it
+        ios.pword(index) = nullptr;
+    }
+}
+
+// This used to be a single process-wide value, so two Bench objects writing to different streams
+// overwrote each other's settings and the second table came out with no header at all (issue #112).
+//
+// The obvious fix - a static map keyed on the ostream* - grows for the lifetime of the process and,
+// worse, hands a freshly constructed stream the state of a destroyed one that happened to be
+// allocated at the same address, which shows up as a header going missing at random. iostreams
+// already provide per-stream storage whose lifetime is exactly the stream's, which is what this
+// wants.
+uint64_t& streamHeaderHash(std::ostream& os) {
+    auto const index = streamHeaderHashIndex();
+    void*& slot = os.pword(index);
+    if (nullptr == slot) {
+        // iword is a separate array at the same index; it records that the callback is registered so
+        // a stream never registers it twice. copyfmt copies iword and the callbacks together, so a
+        // stream copied from another is already covered.
+        if (0 == os.iword(index)) {
+            os.iword(index) = 1;
+            os.register_callback(streamHeaderHashCallback, index);
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        slot = new uint64_t{};
+    }
+    return *static_cast<uint64_t*>(slot);
 }
 
 ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
@@ -2050,8 +3106,130 @@ Clock::duration calcClockResolution(size_t numEvaluations) noexcept {
 
 // Calculates clock resolution once, and remembers the result
 Clock::duration clockResolution() noexcept {
-    static Clock::duration sResolution = calcClockResolution(20);
+    static Clock::duration const sResolution = calcClockResolution(20);
     return sResolution;
+}
+
+// Appends a column unless hideColumn() switched it off.
+//
+// Whether a column *can* be shown - is the counter available at all - and whether the caller wants it
+// are different questions, and interleaving them at every site made it easy to answer one where the
+// other was meant. The availability checks stay next to the values; the visibility policy is here,
+// for every builder below, so a change to how a column is gated is one edit rather than three.
+static void addColumn(std::vector<fmt::MarkDownColumn>& columns, Config const& config, Column column, int width, int precision,
+                      std::string title, std::string suffix, double value) {
+    if (isColumnVisible(config, column)) {
+        columns.emplace_back(width, precision, std::move(title), std::move(suffix), value);
+    }
+}
+
+// The ratio-to-baseline column both table writers put in front of the measurements. Its geometry is
+// here rather than at the two call sites: a header written at one width above rows written at
+// another lines up nowhere.
+static fmt::MarkDownColumn relativeColumn(double percent) {
+    return {11, 1, "relative", "%", percent};
+}
+
+// The performance counter columns of a row, empty when the counters are switched off or the kernel
+// refused them. Split out of measurementColumns() below only to keep both of them under clang-tidy's
+// cognitive complexity limit - the two are read as one list.
+static std::vector<fmt::MarkDownColumn> counterColumns(Config const& config, Result const& result) {
+    std::vector<fmt::MarkDownColumn> columns;
+    if (!config.mShowPerformanceCounters) {
+        return columns;
+    }
+
+    auto const hasIns = result.has(Result::Measure::instructions);
+    auto const hasCyc = result.has(Result::Measure::cpucycles);
+    double const rInsMedian = hasIns ? result.median(Result::Measure::instructions) : 0.0;
+    double const rCycMedian = hasCyc ? result.median(Result::Measure::cpucycles) : 0.0;
+
+    if (hasIns) {
+        addColumn(columns, config, Column::instructions, 18, 2, "ins/" + config.mUnit, "", rInsMedian / config.mBatch);
+    }
+    if (hasCyc) {
+        addColumn(columns, config, Column::cycles, 18, 2, "cyc/" + config.mUnit, "", rCycMedian / config.mBatch);
+    }
+
+    // Which columns a row has must depend only on what the machine can measure, never on what it
+    // measured: keying IPC off the values instead meant a row whose op reported zero instructions
+    // came out one cell short of the header it sits under, and the rest of the table with it.
+    if (hasIns && hasCyc) {
+        addColumn(columns, config, Column::ipc, 9, 3, "IPC", "", rCycMedian <= 0.0 ? 0.0 : rInsMedian / rCycMedian);
+    }
+
+    if (result.has(Result::Measure::branchinstructions)) {
+        double const rBraMedian = result.median(Result::Measure::branchinstructions);
+        addColumn(columns, config, Column::branches, 17, 2, "bra/" + config.mUnit, "", rBraMedian / config.mBatch);
+        if (result.has(Result::Measure::branchmisses)) {
+            double const misses = result.median(Result::Measure::branchmisses);
+            addColumn(columns, config, Column::branchMisses, 10, 1, "miss%", "%",
+                      rBraMedian < 1e-9 ? 0.0 : 100.0 * misses / rBraMedian);
+        }
+    }
+    return columns;
+}
+
+// The columns that describe what was measured, as opposed to how one row relates to another. Both
+// table writers are built out of these: IterationLogic prepends `relative`, a comparison prepends
+// `relative` and `95% CI`, and everything from here on is the same table in both.
+//
+// It is one function because it used to be two copies, and the copies drifted exactly the way copies
+// do: the comparison table silently lost the performance counters it collects anyway and the context
+// columns, and hideColumn() went inert there until it was patched separately. Adding a column here
+// adds it to both.
+//
+// Takes the Config rather than the Bench because a comparison has no Bench to ask - every Result
+// carries a copy of the config it was measured under, which is the same object either way.
+static std::vector<fmt::MarkDownColumn> measurementColumns(Config const& config, Result const& result) {
+    std::vector<fmt::MarkDownColumn> columns;
+
+    auto const median = result.median(Result::Measure::elapsed);
+
+    if (config.mComplexityN > 0.0) {
+        addColumn(columns, config, Column::complexityN, 14, 0, "complexityN", "", config.mComplexityN);
+    }
+
+    // context columns come before the measurements: they say which benchmark this row is, and that
+    // reads better on the left. A row without the variable gets a blank cell rather than a missing
+    // column, so the table stays rectangular.
+    for (auto const& variableName : config.mContextColumns) {
+        auto it = config.mContext.find(variableName);
+        auto const width = static_cast<int>((std::max)(variableName.size() + 3, static_cast<size_t>(11)));
+        columns.emplace_back(width, variableName, it == config.mContext.end() ? std::string() : it->second);
+    }
+
+    addColumn(columns, config, Column::timePerUnit, 22, 2, config.mTimeUnitName + "/" + config.mUnit, "",
+              median / (config.mTimeUnit.count() * config.mBatch));
+    addColumn(columns, config, Column::unitPerSecond, 22, 2, config.mUnit + "/s", "", median <= 0.0 ? 0.0 : config.mBatch / median);
+    addColumn(columns, config, Column::error, 10, 1, "err%", "%", result.medianAbsolutePercentError(Result::Measure::elapsed) * 100.0);
+
+    auto const counters = counterColumns(config, result);
+    columns.insert(columns.end(), counters.begin(), counters.end());
+
+    addColumn(columns, config, Column::total, 12, 2, "total", "",
+              result.sumProduct(Result::Measure::iterations, Result::Measure::elapsed));
+    return columns;
+}
+
+// The markdown table's header and separator lines.
+//
+// Both table writers go through this, because the table is not rectangular in the obvious sense: the
+// last cell holds the table's title on the header line and a benchmark's name on a data line, and the
+// separator's last cell is one dash per title character, so it is one character wider than the header
+// cell above it. What lines up - and what the tests assert on - is the offset of the last '|'. Two
+// spellings of that convention agree only until one of them changes.
+static void writeTableHeaderLines(std::ostream& os, std::vector<fmt::MarkDownColumn> const& columns, std::string const& title) {
+    os << std::endl;
+    for (auto const& col : columns) {
+        os << col.title();
+    }
+    os << "| " << title << std::endl;
+
+    for (auto const& col : columns) {
+        os << col.separator();
+    }
+    os << "|:" << std::string(title.size() + 1U, '-') << std::endl;
 }
 
 ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
@@ -2062,15 +3240,10 @@ struct IterationLogic::Impl {
         : mBench(bench)
         , mResult(bench.config()) {
         printStabilityInformationOnce(mBench.output());
+        printPerformanceCounterHintOnce(mBench.output(), mBench.performanceCounters());
 
         // determine target runtime per epoch
-        mTargetRuntimePerEpoch = detail::clockResolution() * mBench.clockResolutionMultiple();
-        if (mTargetRuntimePerEpoch > mBench.maxEpochTime()) {
-            mTargetRuntimePerEpoch = mBench.maxEpochTime();
-        }
-        if (mTargetRuntimePerEpoch < mBench.minEpochTime()) {
-            mTargetRuntimePerEpoch = mBench.minEpochTime();
-        }
+        mTargetRuntimePerEpoch = detail::targetRuntimePerEpoch(mBench);
 
         if (isEndlessRunning(mBench.name())) {
             std::cerr << "NANOBENCH_ENDLESS set: running '" << mBench.name() << "' endlessly" << std::endl;
@@ -2079,8 +3252,7 @@ struct IterationLogic::Impl {
         } else if (0 != mBench.warmup()) {
             mNumIters = mBench.warmup();
             mState = State::warmup;
-        } else if (0 != mBench.epochIterations()) {
-            // exact number of iterations
+        } else if (hasExactNumIters()) {
             mNumIters = mBench.epochIterations();
             mState = State::measuring;
         } else {
@@ -2089,27 +3261,39 @@ struct IterationLogic::Impl {
         }
     }
 
-    // directly calculates new iters based on elapsed&iters, and adds a 10% noise. Makes sure we don't underflow.
+    // True when an exact number of iterations per epoch was requested, which overrides any calculated one.
+    ANKERL_NANOBENCH(NODISCARD) bool hasExactNumIters() const noexcept {
+        return 0 != mBench.epochIterations();
+    }
+
+    // The number of iterations the next epoch should run, honoring an exact count if one was requested.
+    ANKERL_NANOBENCH(NODISCARD) uint64_t calcNextNumIters(std::chrono::nanoseconds elapsed, uint64_t iters) noexcept {
+        return hasExactNumIters() ? mBench.epochIterations() : calcBestNumIters(elapsed, iters);
+    }
+
+    // directly calculates new iters based on elapsed&iters, and stretches the epoch by 0-20% of random noise so epochs
+    // don't get into lockstep with periodic disturbances. Makes sure we don't under- or overflow.
     ANKERL_NANOBENCH(NODISCARD) uint64_t calcBestNumIters(std::chrono::nanoseconds elapsed, uint64_t iters) noexcept {
         auto doubleElapsed = d(elapsed);
         auto doubleTargetRuntimePerEpoch = d(mTargetRuntimePerEpoch);
         auto doubleNewIters = doubleTargetRuntimePerEpoch / doubleElapsed * d(iters);
 
+        // An elapsed time of 0 (possible with a coarse clock) makes the division above produce infinity, or even NaN
+        // when the target runtime is 0 as well. Comparing with '!(a >= b)' instead of 'a < b' replaces NaN with the
+        // minimum too, so an epoch never ends up with a nonsensical number of iterations.
         auto doubleMinEpochIters = d(mBench.minEpochIterations());
-        if (doubleNewIters < doubleMinEpochIters) {
+        if (!(doubleNewIters >= doubleMinEpochIters)) {
             doubleNewIters = doubleMinEpochIters;
         }
         doubleNewIters *= 1.0 + 0.2 * mRng.uniform01();
 
-        // +0.5 for correct rounding when casting
-        // NOLINTNEXTLINE(bugprone-incorrect-roundings)
-        return static_cast<uint64_t>(doubleNewIters + 0.5);
+        return u64(doubleNewIters);
     }
 
     ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined") void upscale(std::chrono::nanoseconds elapsed) {
         if (elapsed * 10 < mTargetRuntimePerEpoch) {
             // we are far below the target runtime. Multiply iterations by 10 (with overflow check)
-            if (mNumIters * 10 < mNumIters) {
+            if (mNumIters > (std::numeric_limits<uint64_t>::max)() / 10) {
                 // overflow :-(
                 showResult("iterations overflow. Maybe your code got optimized away?");
                 mNumIters = 0;
@@ -2128,11 +3312,12 @@ struct IterationLogic::Impl {
 
         switch (mState) {
         case State::warmup:
-            if (isCloseEnoughForMeasurements(elapsed)) {
+            // an exact number of iterations makes upscaling pointless, so warmup is over either way
+            if (hasExactNumIters() || isCloseEnoughForMeasurements(elapsed)) {
                 // if elapsed is close enough, we can skip upscaling and go right to measurements
                 // still, we don't add the result to the measurements.
                 mState = State::measuring;
-                mNumIters = calcBestNumIters(elapsed, mNumIters);
+                mNumIters = calcNextNumIters(elapsed, mNumIters);
             } else {
                 // not close enough: switch to upscaling
                 mState = State::upscaling_runtime;
@@ -2147,7 +3332,7 @@ struct IterationLogic::Impl {
                 mTotalElapsed += elapsed;
                 mTotalNumIters += mNumIters;
                 mResult.add(elapsed, mNumIters, pc);
-                mNumIters = calcBestNumIters(mTotalElapsed, mTotalNumIters);
+                mNumIters = calcNextNumIters(mTotalElapsed, mTotalNumIters);
             } else {
                 upscale(elapsed);
             }
@@ -2159,11 +3344,7 @@ struct IterationLogic::Impl {
             mTotalElapsed += elapsed;
             mTotalNumIters += mNumIters;
             mResult.add(elapsed, mNumIters, pc);
-            if (0 != mBench.epochIterations()) {
-                mNumIters = mBench.epochIterations();
-            } else {
-                mNumIters = calcBestNumIters(mTotalElapsed, mTotalNumIters);
-            }
+            mNumIters = calcNextNumIters(mTotalElapsed, mTotalNumIters);
             break;
 
         case State::endless:
@@ -2177,147 +3358,112 @@ struct IterationLogic::Impl {
             mNumIters = 0;
         }
 
-        ANKERL_NANOBENCH_LOG(mBench.name() << ": " << detail::fmt::Number(20, 3, static_cast<double>(elapsed.count())) << " elapsed, "
-                                           << detail::fmt::Number(20, 3, static_cast<double>(mTargetRuntimePerEpoch.count()))
-                                           << " target. oldIters=" << oldIters << ", mNumIters=" << mNumIters
-                                           << ", mState=" << static_cast<int>(mState));
+        ANKERL_NANOBENCH_LOG(mBench.name() << ": " << detail::fmt::Number(20, 3, d(elapsed.count())) << " elapsed, "
+                                           << detail::fmt::Number(20, 3, d(mTargetRuntimePerEpoch.count())) << " target. oldIters="
+                                           << oldIters << ", mNumIters=" << mNumIters << ", mState=" << static_cast<int>(mState));
     }
 
     void showResult(std::string const& errorMessage) const {
         ANKERL_NANOBENCH_LOG(errorMessage);
 
-        if (mBench.output() != nullptr) {
-            // prepare column data ///////
-            std::vector<fmt::MarkDownColumn> columns;
+        if (nullptr == mBench.output()) {
+            return;
+        }
 
-            auto rMedian = mResult.median(Result::Measure::elapsed);
+        // prepare column data ///////
+        std::vector<fmt::MarkDownColumn> columns;
 
-            if (mBench.relative()) {
-                double d = 100.0;
-                if (!mBench.results().empty()) {
-                    d = rMedian <= 0.0 ? 0.0 : mBench.results().front().median(Result::Measure::elapsed) / rMedian * 100.0;
-                }
-                columns.emplace_back(11, 1, "relative", "%", d);
+        if (mBench.relative()) {
+            double relativePercent = 100.0;
+            if (!mBench.results().empty()) {
+                // Every other column is per unit, so this one has to be as well. Comparing the raw epoch times would
+                // give a skewed percentage as soon as the baseline was run with a different batch size.
+                // See https://github.com/martinus/nanobench/issues/131
+                // This is (baseline / baselineBatch) / (rMedian / batch) as a single fraction, so one guard does.
+                auto const rMedian = mResult.median(Result::Measure::elapsed);
+                auto const& baseline = mBench.results().front();
+                auto const num = baseline.median(Result::Measure::elapsed) * mBench.batch();
+                auto const den = rMedian * baseline.config().mBatch;
+                relativePercent = den <= 0.0 ? 0.0 : num / den * 100.0;
             }
-
-            if (mBench.complexityN() > 0) {
-                columns.emplace_back(14, 0, "complexityN", "", mBench.complexityN());
-            }
-
-            columns.emplace_back(22, 2, mBench.timeUnitName() + "/" + mBench.unit(), "",
-                                 rMedian / (mBench.timeUnit().count() * mBench.batch()));
-            columns.emplace_back(22, 2, mBench.unit() + "/s", "", rMedian <= 0.0 ? 0.0 : mBench.batch() / rMedian);
-
-            double rErrorMedian = mResult.medianAbsolutePercentError(Result::Measure::elapsed);
-            columns.emplace_back(10, 1, "err%", "%", rErrorMedian * 100.0);
-
-            double rInsMedian = -1.0;
-            if (mBench.performanceCounters() && mResult.has(Result::Measure::instructions)) {
-                rInsMedian = mResult.median(Result::Measure::instructions);
-                columns.emplace_back(18, 2, "ins/" + mBench.unit(), "", rInsMedian / mBench.batch());
-            }
-
-            double rCycMedian = -1.0;
-            if (mBench.performanceCounters() && mResult.has(Result::Measure::cpucycles)) {
-                rCycMedian = mResult.median(Result::Measure::cpucycles);
-                columns.emplace_back(18, 2, "cyc/" + mBench.unit(), "", rCycMedian / mBench.batch());
-            }
-            if (rInsMedian > 0.0 && rCycMedian > 0.0) {
-                columns.emplace_back(9, 3, "IPC", "", rCycMedian <= 0.0 ? 0.0 : rInsMedian / rCycMedian);
-            }
-            if (mBench.performanceCounters() && mResult.has(Result::Measure::branchinstructions)) {
-                double rBraMedian = mResult.median(Result::Measure::branchinstructions);
-                columns.emplace_back(17, 2, "bra/" + mBench.unit(), "", rBraMedian / mBench.batch());
-                if (mResult.has(Result::Measure::branchmisses)) {
-                    double p = 0.0;
-                    if (rBraMedian >= 1e-9) {
-                        p = 100.0 * mResult.median(Result::Measure::branchmisses) / rBraMedian;
-                    }
-                    columns.emplace_back(10, 1, "miss%", "%", p);
-                }
-            }
-
-            columns.emplace_back(12, 2, "total", "", mResult.sumProduct(Result::Measure::iterations, Result::Measure::elapsed));
-
-            // write everything
-            auto& os = *mBench.output();
-
-            // combine all elements that are relevant for printing the header
-            uint64_t hash = 0;
-            hash = hash_combine(std::hash<std::string>{}(mBench.unit()), hash);
-            hash = hash_combine(std::hash<std::string>{}(mBench.title()), hash);
-            hash = hash_combine(std::hash<std::string>{}(mBench.timeUnitName()), hash);
-            hash = hash_combine(std::hash<double>{}(mBench.timeUnit().count()), hash);
-            hash = hash_combine(std::hash<bool>{}(mBench.relative()), hash);
-            hash = hash_combine(std::hash<bool>{}(mBench.performanceCounters()), hash);
-
-            if (hash != singletonHeaderHash()) {
-                singletonHeaderHash() = hash;
-
-                // no result yet, print header
-                os << std::endl;
-                for (auto const& col : columns) {
-                    os << col.title();
-                }
-                os << "| " << mBench.title() << std::endl;
-
-                for (auto const& col : columns) {
-                    os << col.separator();
-                }
-                os << "|:" << std::string(mBench.title().size() + 1U, '-') << std::endl;
-            }
-
-            if (!errorMessage.empty()) {
-                for (auto const& col : columns) {
-                    os << col.invalid();
-                }
-                os << "| :boom: " << fmt::MarkDownCode(mBench.name()) << " (" << errorMessage << ')' << std::endl;
-            } else {
-                for (auto const& col : columns) {
-                    os << col.value();
-                }
-                os << "| ";
-                auto showUnstable = isWarningsEnabled() && rErrorMedian >= 0.05;
-                if (showUnstable) {
-                    os << ":wavy_dash: ";
-                }
-                os << fmt::MarkDownCode(mBench.name());
-                if (showUnstable) {
-                    auto avgIters = static_cast<double>(mTotalNumIters) / static_cast<double>(mBench.epochs());
-                    // NOLINTNEXTLINE(bugprone-incorrect-roundings)
-                    auto suggestedIters = static_cast<uint64_t>(avgIters * 10 + 0.5);
-
-                    os << " (Unstable with ~" << detail::fmt::Number(1, 1, avgIters)
-                       << " iters. Increase `minEpochIterations` to e.g. " << suggestedIters << ")";
-                }
-                os << std::endl;
+            if (isColumnVisible(mBench.config(), Column::relative)) {
+                columns.push_back(relativeColumn(relativePercent));
             }
         }
+
+        // everything a comparison table shows too
+        auto const measurements = measurementColumns(mResult.config(), mResult);
+        columns.insert(columns.end(), measurements.begin(), measurements.end());
+
+        double const rErrorMedian = mResult.medianAbsolutePercentError(Result::Measure::elapsed);
+
+        // write everything
+        auto& os = *mBench.output();
+
+        // The shape of the table *is* the columns it has, so that is what decides whether the header
+        // above the previous row still fits this one. Hashing a hand-kept list of the config fields
+        // that influence the columns meant every conditional column had a second place to be
+        // remembered, two hundred lines from the one that adds it - and complexityN, which
+        // measurementColumns() adds only when it is set, had already been forgotten there.
+        uint64_t hash = 0;
+        hash = hash_combine(std::hash<std::string>{}(mBench.title()), hash);
+        for (auto const& col : columns) {
+            hash = hash_combine(std::hash<std::string>{}(col.title()), hash);
+        }
+
+        auto& lastHeaderHash = streamHeaderHash(os);
+        if (hash != lastHeaderHash) {
+            lastHeaderHash = hash;
+            writeTableHeaderLines(os, columns, mBench.title());
+        }
+
+        if (!errorMessage.empty()) {
+            for (auto const& col : columns) {
+                os << col.invalid();
+            }
+            os << "| :boom: " << fmt::MarkDownCode(mBench.name()) << " (" << errorMessage << ')' << std::endl;
+            return;
+        }
+
+        for (auto const& col : columns) {
+            os << col.value();
+        }
+        os << "| ";
+        auto showUnstable = isWarningsEnabled() && rErrorMedian >= 0.05;
+        if (showUnstable) {
+            os << ":wavy_dash: ";
+        }
+        os << fmt::MarkDownCode(mBench.name());
+        if (showUnstable) {
+            auto avgIters = d(mTotalNumIters) / d(mBench.epochs());
+            auto suggestedIters = u64(avgIters * 10);
+
+            os << " (Unstable with ~" << detail::fmt::Number(1, 1, avgIters) << " iters. Increase `minEpochIterations` to e.g. "
+               << suggestedIters << ")";
+        }
+        os << std::endl;
     }
 
     ANKERL_NANOBENCH(NODISCARD) bool isCloseEnoughForMeasurements(std::chrono::nanoseconds elapsed) const noexcept {
         return elapsed * 3 >= mTargetRuntimePerEpoch * 2;
     }
 
-    uint64_t mNumIters = 1;
-    Bench const& mBench;
-    std::chrono::nanoseconds mTargetRuntimePerEpoch{};
-    Result mResult;
-    Rng mRng{123};
-    std::chrono::nanoseconds mTotalElapsed{};
-    uint64_t mTotalNumIters = 0;
-
-    State mState = State::upscaling_runtime;
+    uint64_t mNumIters = 1;                            // NOLINT(misc-non-private-member-variables-in-classes)
+    Bench const& mBench;                               // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::nanoseconds mTargetRuntimePerEpoch{}; // NOLINT(misc-non-private-member-variables-in-classes)
+    Result mResult;                                    // NOLINT(misc-non-private-member-variables-in-classes)
+    Rng mRng{123};                                     // NOLINT(misc-non-private-member-variables-in-classes)
+    std::chrono::nanoseconds mTotalElapsed{};          // NOLINT(misc-non-private-member-variables-in-classes)
+    uint64_t mTotalNumIters = 0;                       // NOLINT(misc-non-private-member-variables-in-classes)
+    State mState = State::upscaling_runtime;           // NOLINT(misc-non-private-member-variables-in-classes)
 };
 ANKERL_NANOBENCH(IGNORE_PADDED_POP)
 
-IterationLogic::IterationLogic(Bench const& bench) noexcept
+IterationLogic::IterationLogic(Bench const& bench)
     : mPimpl(new Impl(bench)) {}
 
 IterationLogic::~IterationLogic() {
-    if (mPimpl) {
-        delete mPimpl;
-    }
+    delete mPimpl;
 }
 
 uint64_t IterationLogic::numIters() const noexcept {
@@ -2333,7 +3479,103 @@ void IterationLogic::moveResultTo(std::vector<Result>& results) noexcept {
     results.emplace_back(std::move(mPimpl->mResult));
 }
 
+// The counter arithmetic, deliberately outside the PERF_COUNTERS guard - see the declarations.
+
+uint64_t saturatingSub(uint64_t a, uint64_t b) noexcept {
+    return a >= b ? a - b : UINT64_C(0);
+}
+
+uint64_t divRounded(uint64_t a, uint64_t divisor) noexcept {
+    return (a + divisor / 2) / divisor;
+}
+
+size_t perfReadFormatSize(size_t numEvents) noexcept {
+    return 3U + numEvents * 2U;
+}
+
+size_t perfValueIndex(uint64_t i) noexcept {
+    return perfReadFormatSize(static_cast<size_t>(i));
+}
+
+uint64_t scaleMultiplexed(uint64_t value, uint64_t timeEnabled, uint64_t timeRunning) noexcept {
+    if (0U == timeRunning || timeEnabled <= timeRunning) {
+        // the event was active the whole time, nothing to extrapolate
+        return value;
+    }
+    // counts stay far below 2^53, so double is exact enough here and cannot overflow the way the
+    // integer multiplication would
+    return u64(d(value) * (d(timeEnabled) / d(timeRunning)));
+}
+
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+uint64_t correctOverhead(uint64_t value, uint64_t measuringOverhead, uint64_t loopOverheadPerIter, uint64_t numIters) noexcept {
+    return saturatingSub(saturatingSub(value, measuringOverhead), loopOverheadPerIter * numIters);
+}
+
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+uint64_t loopOverheadPerIteration(uint64_t single, uint64_t doubled, uint64_t measuringOverhead, uint64_t numIters) noexcept {
+    auto const m1 = saturatingSub(single, measuringOverhead);
+    auto const m2 = saturatingSub(doubled, measuringOverhead);
+    // the second run does the work twice, so twice the first run minus the second is what the loop
+    // costs on its own
+    return divRounded(saturatingSub(m1 * 2, m2), numIters);
+}
+
+ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
+uint64_t correctBranchInstructions(uint64_t rawBranchInstructions, uint64_t numIters) noexcept {
+    // one branch per iteration for the loop, plus the one that ends it
+    return saturatingSub(rawBranchInstructions, numIters + 1U);
+}
+
+double correctBranchMisses(uint64_t rawBranchMisses, double correctedBranchInstructions) noexcept {
+    auto branchMisses = d(rawBranchMisses);
+    if (branchMisses > correctedBranchInstructions) {
+        // can't have more branch misses than there were branches
+        branchMisses = correctedBranchInstructions;
+    }
+
+    // assuming at least one missed branch for the loop
+    branchMisses -= 1.0;
+    if (branchMisses < 1.0) {
+        branchMisses = 1.0;
+    }
+    return branchMisses;
+}
+
 #    if ANKERL_NANOBENCH(PERF_COUNTERS)
+
+// glibc declares ioctl()'s request parameter as unsigned long, musl as int. PERF_EVENT_IOC_ID and
+// friends carry the direction bits in the high end, so they don't fit into an int and passing one
+// straight through is a value-changing conversion that -Werror rejects on musl (issue #92). Deduce
+// the declared parameter type from ioctl() itself, so the same cast is right for either libc.
+#        if defined(__BIONIC__)
+// Except on bionic, which declares ioctl() *twice* - once taking int and once taking unsigned - for
+// exactly the reason above, so that either signedness compiles without a cast. Its header says out
+// loud that the overload breaks anyone taking ioctl()'s address, and points at naming a concrete
+// type instead: &::ioctl is an overload set, and nothing can be deduced from one. That deduction
+// failure is the whole of issue microsoft/vcpkg#53422 - nanobench built for no Android ABI at all.
+// unsigned is the overload to name, since it is the one PERF_EVENT_IOC_ID fits into.
+using IoctlRequest = unsigned;
+#        else
+// Never defined - only ever asked for its return type.
+template <typename Ret, typename Fd, typename Request>
+Request ioctlRequestType(Ret (*)(Fd, Request, ...));
+
+#            if defined(__cpp_noexcept_function_type)
+// Since C++17 noexcept is part of a function's type, and glibc declares ioctl() with __THROW - so
+// without this second overload the deduction above stops matching at -std=c++17.
+template <typename Ret, typename Fd, typename Request>
+Request ioctlRequestType(Ret (*)(Fd, Request, ...) noexcept);
+#            endif
+
+using IoctlRequest = decltype(ioctlRequestType(&::ioctl));
+#        endif
+
+template <typename Arg>
+int perfIoctl(int fd, unsigned long request, Arg arg) {
+    // NOLINTNEXTLINE(hicpp-signed-bitwise,cppcoreguidelines-pro-type-vararg)
+    return ioctl(fd, static_cast<IoctlRequest>(request), arg);
+}
 
 ANKERL_NANOBENCH(IGNORE_PADDED_PUSH)
 class LinuxPerformanceCounters {
@@ -2344,22 +3586,22 @@ public:
             , correctMeasuringOverhead(correctMeasuringOverhead_)
             , correctLoopOverhead(correctLoopOverhead_) {}
 
-        uint64_t* targetValue{};
-        bool correctMeasuringOverhead{};
-        bool correctLoopOverhead{};
+        uint64_t* targetValue{};         // NOLINT(misc-non-private-member-variables-in-classes)
+        bool correctMeasuringOverhead{}; // NOLINT(misc-non-private-member-variables-in-classes)
+        bool correctLoopOverhead{};      // NOLINT(misc-non-private-member-variables-in-classes)
     };
 
+    LinuxPerformanceCounters() = default;
+    LinuxPerformanceCounters(LinuxPerformanceCounters const&) = delete;
+    LinuxPerformanceCounters(LinuxPerformanceCounters&&) = delete;
+    LinuxPerformanceCounters& operator=(LinuxPerformanceCounters const&) = delete;
+    LinuxPerformanceCounters& operator=(LinuxPerformanceCounters&&) = delete;
     ~LinuxPerformanceCounters();
-
-    // quick operation
-    inline void start() {}
-
-    inline void stop() {}
 
     bool monitor(perf_sw_ids swId, Target target);
     bool monitor(perf_hw_id hwId, Target target);
 
-    bool hasError() const noexcept {
+    ANKERL_NANOBENCH(NODISCARD) bool hasError() const noexcept {
         return mHasError;
     }
 
@@ -2370,14 +3612,12 @@ public:
             return;
         }
 
-        // NOLINTNEXTLINE(hicpp-signed-bitwise)
-        mHasError = -1 == ioctl(mFd, PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP);
+        mHasError = -1 == perfIoctl(mFd, PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP);
         if (mHasError) {
             return;
         }
 
-        // NOLINTNEXTLINE(hicpp-signed-bitwise)
-        mHasError = -1 == ioctl(mFd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
+        mHasError = -1 == perfIoctl(mFd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
     }
 
     inline void endMeasure() {
@@ -2385,8 +3625,7 @@ public:
             return;
         }
 
-        // NOLINTNEXTLINE(hicpp-signed-bitwise)
-        mHasError = (-1 == ioctl(mFd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP));
+        mHasError = (-1 == perfIoctl(mFd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP));
         if (mHasError) {
             return;
         }
@@ -2394,37 +3633,51 @@ public:
         auto const numBytes = sizeof(uint64_t) * mCounters.size();
         auto ret = read(mFd, mCounters.data(), numBytes);
         mHasError = ret != static_cast<ssize_t>(numBytes);
+        if (!mHasError) {
+            scaleCounters();
+        }
     }
 
     void updateResults(uint64_t numIters);
 
-    // rounded integer division
-    template <typename T>
-    static inline T divRounded(T a, T divisor) {
-        return (a + divisor / 2) / divisor;
+    // Compensates the counters that were just read for multiplexing.
+    //
+    // When more events are monitored than the hardware can count at the same time, the kernel time-shares the counters
+    // between them. An event is then only active for a fraction of the measurement, and the value read back is just what
+    // happened while it was active. Scaling it up by enabled/running extrapolates to the whole measurement, which is
+    // exactly what `perf stat` does. Without this, cycles/instructions/branches are silently underreported - e.g. when
+    // the NMI watchdog occupies one of the counters, or in a VM that exposes a restricted PMU.
+    inline void scaleCounters() noexcept {
+        auto const enabled = timeEnabled() - mTotalTimeEnabledNanos;
+        auto const running = timeRunning() - mTotalTimeRunningNanos;
+        mTotalTimeEnabledNanos = timeEnabled();
+        mTotalTimeRunningNanos = timeRunning();
+
+        for (uint64_t i = 0; i < numEvents(); ++i) {
+            auto const idx = perfValueIndex(i);
+            mCounters[idx] = scaleMultiplexed(mCounters[idx], enabled, running);
+        }
     }
 
     ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
     static inline uint32_t mix(uint32_t x) noexcept {
-        x ^= x << 13;
-        x ^= x >> 17;
-        x ^= x << 5;
+        x ^= x << 13U;
+        x ^= x >> 17U;
+        x ^= x << 5U;
         return x;
     }
 
     template <typename Op>
     ANKERL_NANOBENCH_NO_SANITIZE("integer", "undefined")
     void calibrate(Op&& op) {
-        // clear current calibration data,
+        // clear current calibration data, so a measurement that fails below subtracts nothing rather
+        // than something stale
         for (auto& v : mCalibratedOverhead) {
             v = UINT64_C(0);
         }
 
-        // create new calibration data
-        auto newCalibration = mCalibratedOverhead;
-        for (auto& v : newCalibration) {
-            v = (std::numeric_limits<uint64_t>::max)();
-        }
+        // the new data is a minimum over 100 runs, so it starts at the maximum
+        std::vector<uint64_t> newCalibration(mCalibratedOverhead.size(), (std::numeric_limits<uint64_t>::max)());
         for (size_t iter = 0; iter < 100; ++iter) {
             beginMeasure();
             op();
@@ -2434,10 +3687,7 @@ public:
             }
 
             for (size_t i = 0; i < newCalibration.size(); ++i) {
-                auto diff = mCounters[i];
-                if (newCalibration[i] > diff) {
-                    newCalibration[i] = diff;
-                }
+                newCalibration[i] = (std::min)(newCalibration[i], mCounters[i]);
             }
         }
 
@@ -2448,7 +3698,7 @@ public:
             // marsaglia's xorshift: mov, sal/shr, xor. Times 3.
             // This has the nice property that the compiler doesn't seem to be able to optimize multiple calls any further.
             // see https://godbolt.org/z/49RVQ5
-            uint64_t const numIters = 100000U + (std::random_device{}() & 3);
+            uint64_t const numIters = 100000U + (std::random_device{}() & 3U);
             uint64_t n = numIters;
             uint32_t x = 1234567;
 
@@ -2472,12 +3722,7 @@ public:
             auto measure2 = mCounters;
 
             for (size_t i = 0; i < mCounters.size(); ++i) {
-                // factor 2 because we have two instructions per loop
-                auto m1 = measure1[i] > mCalibratedOverhead[i] ? measure1[i] - mCalibratedOverhead[i] : 0;
-                auto m2 = measure2[i] > mCalibratedOverhead[i] ? measure2[i] - mCalibratedOverhead[i] : 0;
-                auto overhead = m1 * 2 > m2 ? m1 * 2 - m2 : 0;
-
-                mLoopOverhead[i] = divRounded(overhead, numIters);
+                mLoopOverhead[i] = loopOverheadPerIteration(measure1[i], measure2[i], mCalibratedOverhead[i], numIters);
             }
         }
     }
@@ -2485,15 +3730,28 @@ public:
 private:
     bool monitor(uint32_t type, uint64_t eventid, Target target);
 
+    // The three header words of the last read, by name rather than by index.
+    ANKERL_NANOBENCH(NODISCARD) uint64_t numEvents() const noexcept {
+        return mCounters[0];
+    }
+    ANKERL_NANOBENCH(NODISCARD) uint64_t timeEnabled() const noexcept {
+        return mCounters[1];
+    }
+    ANKERL_NANOBENCH(NODISCARD) uint64_t timeRunning() const noexcept {
+        return mCounters[2];
+    }
+
     std::map<uint64_t, Target> mIdToTarget{};
 
-    // start with minimum size of 3 for read_format
-    std::vector<uint64_t> mCounters{3};
-    std::vector<uint64_t> mCalibratedOverhead{3};
-    std::vector<uint64_t> mLoopOverhead{3};
+    // no events monitored yet, so just the read_format header
+    std::vector<uint64_t> mCounters = std::vector<uint64_t>(perfReadFormatSize(0));
+    std::vector<uint64_t> mCalibratedOverhead = std::vector<uint64_t>(perfReadFormatSize(0));
+    std::vector<uint64_t> mLoopOverhead = std::vector<uint64_t>(perfReadFormatSize(0));
 
-    uint64_t mTimeEnabledNanos = 0;
-    uint64_t mTimeRunningNanos = 0;
+    // PERF_EVENT_IOC_RESET resets the counters, but not time_enabled/time_running: those keep accumulating over the
+    // whole lifetime of the event. So the times of a single measurement are the difference to the previous read.
+    uint64_t mTotalTimeEnabledNanos = 0;
+    uint64_t mTotalTimeRunningNanos = 0;
     int mFd = -1;
     bool mHasError = false;
 };
@@ -2525,33 +3783,17 @@ void LinuxPerformanceCounters::updateResults(uint64_t numIters) {
         return;
     }
 
-    mTimeEnabledNanos = mCounters[1] - mCalibratedOverhead[1];
-    mTimeRunningNanos = mCounters[2] - mCalibratedOverhead[2];
-
-    for (uint64_t i = 0; i < mCounters[0]; ++i) {
-        auto idx = static_cast<size_t>(3 + i * 2 + 0);
+    // mCounters has already been compensated for multiplexing in endMeasure(), and so has mCalibratedOverhead
+    for (uint64_t i = 0; i < numEvents(); ++i) {
+        auto idx = perfValueIndex(i);
         auto id = mCounters[idx + 1U];
 
         auto it = mIdToTarget.find(id);
         if (it != mIdToTarget.end()) {
-
             auto& tgt = it->second;
-            *tgt.targetValue = mCounters[idx];
-            if (tgt.correctMeasuringOverhead) {
-                if (*tgt.targetValue >= mCalibratedOverhead[idx]) {
-                    *tgt.targetValue -= mCalibratedOverhead[idx];
-                } else {
-                    *tgt.targetValue = 0U;
-                }
-            }
-            if (tgt.correctLoopOverhead) {
-                auto correctionVal = mLoopOverhead[idx] * numIters;
-                if (*tgt.targetValue >= correctionVal) {
-                    *tgt.targetValue -= correctionVal;
-                } else {
-                    *tgt.targetValue = 0U;
-                }
-            }
+            // a correction the target did not ask for is applied as a correction of zero
+            *tgt.targetValue = correctOverhead(mCounters[idx], tgt.correctMeasuringOverhead ? mCalibratedOverhead[idx] : UINT64_C(0),
+                                               tgt.correctLoopOverhead ? mLoopOverhead[idx] : UINT64_C(0), numIters);
         }
     }
 }
@@ -2582,6 +3824,7 @@ bool LinuxPerformanceCounters::monitor(uint32_t type, uint64_t eventid, Target t
     const unsigned long flags = 0;
 #        endif
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
     auto fd = static_cast<int>(syscall(__NR_perf_event_open, &pea, pid, cpu, mFd, flags));
     if (-1 == fd) {
         return false;
@@ -2591,8 +3834,7 @@ bool LinuxPerformanceCounters::monitor(uint32_t type, uint64_t eventid, Target t
         mFd = fd;
     }
     uint64_t id = 0;
-    // NOLINTNEXTLINE(hicpp-signed-bitwise)
-    if (-1 == ioctl(fd, PERF_EVENT_IOC_ID, &id)) {
+    if (-1 == perfIoctl(fd, PERF_EVENT_IOC_ID, &id)) {
         // couldn't get id
         return false;
     }
@@ -2601,7 +3843,7 @@ bool LinuxPerformanceCounters::monitor(uint32_t type, uint64_t eventid, Target t
     mIdToTarget.emplace(id, target);
 
     // prepare readformat with the correct size (after the insert)
-    auto size = 3 + 2 * mIdToTarget.size();
+    auto size = perfReadFormatSize(mIdToTarget.size());
     mCounters.resize(size);
     mCalibratedOverhead.resize(size);
     mLoopOverhead.resize(size);
@@ -2614,17 +3856,22 @@ PerformanceCounters::PerformanceCounters()
     , mVal()
     , mHas() {
 
-    mHas.pageFaults = mPc->monitor(PERF_COUNT_SW_PAGE_FAULTS, LinuxPerformanceCounters::Target(&mVal.pageFaults, true, false));
+    // HW events
     mHas.cpuCycles = mPc->monitor(PERF_COUNT_HW_REF_CPU_CYCLES, LinuxPerformanceCounters::Target(&mVal.cpuCycles, true, false));
-    mHas.contextSwitches =
-        mPc->monitor(PERF_COUNT_SW_CONTEXT_SWITCHES, LinuxPerformanceCounters::Target(&mVal.contextSwitches, true, false));
+    if (!mHas.cpuCycles) {
+        // Fallback to cycles counter, reference cycles not available in many systems.
+        mHas.cpuCycles = mPc->monitor(PERF_COUNT_HW_CPU_CYCLES, LinuxPerformanceCounters::Target(&mVal.cpuCycles, true, false));
+    }
     mHas.instructions = mPc->monitor(PERF_COUNT_HW_INSTRUCTIONS, LinuxPerformanceCounters::Target(&mVal.instructions, true, true));
     mHas.branchInstructions =
         mPc->monitor(PERF_COUNT_HW_BRANCH_INSTRUCTIONS, LinuxPerformanceCounters::Target(&mVal.branchInstructions, true, false));
     mHas.branchMisses = mPc->monitor(PERF_COUNT_HW_BRANCH_MISSES, LinuxPerformanceCounters::Target(&mVal.branchMisses, true, false));
-    // mHas.branchMisses = false;
 
-    mPc->start();
+    // SW events
+    mHas.pageFaults = mPc->monitor(PERF_COUNT_SW_PAGE_FAULTS, LinuxPerformanceCounters::Target(&mVal.pageFaults, true, false));
+    mHas.contextSwitches =
+        mPc->monitor(PERF_COUNT_SW_CONTEXT_SWITCHES, LinuxPerformanceCounters::Target(&mVal.contextSwitches, true, false));
+
     mPc->calibrate([] {
         auto before = ankerl::nanobench::Clock::now();
         auto after = ankerl::nanobench::Clock::now();
@@ -2639,9 +3886,8 @@ PerformanceCounters::PerformanceCounters()
 }
 
 PerformanceCounters::~PerformanceCounters() {
-    if (nullptr != mPc) {
-        delete mPc;
-    }
+    // no need to check for nullptr, delete nullptr has no effect
+    delete mPc;
 }
 
 void PerformanceCounters::beginMeasure() {
@@ -2676,18 +3922,6 @@ ANKERL_NANOBENCH(NODISCARD) PerfCountSet<bool> const& PerformanceCounters::has()
 // formatting utilities
 namespace fmt {
 
-// adds thousands separator to numbers
-NumSep::NumSep(char sep)
-    : mSep(sep) {}
-
-char NumSep::do_thousands_sep() const {
-    return mSep;
-}
-
-std::string NumSep::do_grouping() const {
-    return "\003";
-}
-
 // RAII to save & restore a stream's state
 StreamStateRestorer::StreamStateRestorer(std::ostream& s)
     : mStream(s)
@@ -2710,20 +3944,46 @@ void StreamStateRestorer::restore() {
     mStream.flags(mFmtFlags);
 }
 
-Number::Number(int width, int precision, int64_t value)
-    : mWidth(width)
-    , mPrecision(precision)
-    , mValue(static_cast<double>(value)) {}
-
 Number::Number(int width, int precision, double value)
     : mWidth(width)
     , mPrecision(precision)
     , mValue(value) {}
 
+// Groups the integer digits of an already formatted number in threes: "1234.50" -> "1,234.50".
+//
+// This used to be a std::numpunct facet imbued into the stream, which is the idiomatic way and works
+// right up until someone builds with -fno-rtti: installing a facet goes through __dynamic_cast, which
+// without RTTI reads through a null pointer and takes the process with it (issue #122). Grouping the
+// digits by hand costs a few lines, produces the same output for everyone, and drops an allocation
+// per formatted number along the way.
+//
+// Only a run of digits is touched, so "inf" and "nan" pass through unchanged.
+std::string addThousandsSeparators(std::string str, char sep) {
+    size_t const start = (!str.empty() && ('-' == str[0] || '+' == str[0])) ? 1U : 0U;
+    size_t end = start;
+    while (end < str.size() && str[end] >= '0' && str[end] <= '9') {
+        ++end;
+    }
+
+    // insert from the right, so the positions still to be visited stay valid
+    for (size_t pos = end; pos > start + 3;) {
+        pos -= 3;
+        str.insert(pos, 1, sep);
+    }
+    return str;
+}
+
 std::ostream& Number::write(std::ostream& os) const {
-    StreamStateRestorer restorer(os);
-    os.imbue(std::locale(os.getloc(), new NumSep(',')));
-    os << std::setw(mWidth) << std::setprecision(mPrecision) << std::fixed << mValue;
+    // No StreamStateRestorer: the only thing this used to change on os was the imbued locale, and
+    // std::setw below is consumed by the very next insertion.
+
+    // format without the stream's locale, so a global locale that already groups digits cannot group
+    // them a second time
+    std::stringstream ss;
+    ss.imbue(std::locale::classic());
+    ss << std::setprecision(mPrecision) << std::fixed << mValue;
+
+    os << std::setw(mWidth) << addThousandsSeparators(ss.str(), ',');
     return os;
 }
 
@@ -2747,17 +4007,30 @@ std::ostream& operator<<(std::ostream& os, Number const& n) {
     return n.write(os);
 }
 
-MarkDownColumn::MarkDownColumn(int w, int prec, std::string const& tit, std::string const& suff, double val)
+MarkDownColumn::MarkDownColumn(int w, int prec, std::string tit, std::string suff, double val) noexcept
     : mWidth(w)
     , mPrecision(prec)
-    , mTitle(tit)
-    , mSuffix(suff)
+    , mTitle(std::move(tit))
+    , mSuffix(std::move(suff))
     , mValue(val) {}
 
-std::string MarkDownColumn::title() const {
+MarkDownColumn::MarkDownColumn(int w, std::string tit, std::string text) noexcept
+    : mWidth(w)
+    , mPrecision(0)
+    , mTitle(std::move(tit))
+    , mSuffix()
+    , mValue(0.0)
+    , mText(std::move(text))
+    , mIsText(true) {}
+
+std::string MarkDownColumn::padded(std::string const& text) const {
     std::stringstream ss;
-    ss << '|' << std::setw(mWidth - 2) << std::right << mTitle << ' ';
+    ss << '|' << std::setw(mWidth - 2) << std::right << text << ' ';
     return ss.str();
+}
+
+std::string MarkDownColumn::title() const {
+    return padded(mTitle);
 }
 
 std::string MarkDownColumn::separator() const {
@@ -2775,6 +4048,10 @@ std::string MarkDownColumn::invalid() const {
 }
 
 std::string MarkDownColumn::value() const {
+    if (mIsText) {
+        // aligned like the header, so the ':' the separator puts on the right stays honest
+        return padded(mText);
+    }
     std::stringstream ss;
     auto width = mWidth - 2 - static_cast<int>(mSuffix.size());
     ss << '|' << Number(width, mPrecision, mValue) << mSuffix << ' ';
@@ -2785,7 +4062,7 @@ std::string MarkDownColumn::value() const {
 MarkDownCode::MarkDownCode(std::string const& what) {
     mWhat.reserve(what.size() + 2);
     mWhat.push_back('`');
-    for (char c : what) {
+    for (char const c : what) {
         mWhat.push_back(c);
         if ('`' == c) {
             mWhat.push_back('`');
@@ -2808,14 +4085,14 @@ std::ostream& operator<<(std::ostream& os, MarkDownCode const& mdCode) {
 Config::Config() = default;
 Config::~Config() = default;
 Config& Config::operator=(Config const&) = default;
-Config& Config::operator=(Config&&) = default;
+Config& Config::operator=(Config&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
 Config::Config(Config const&) = default;
 Config::Config(Config&&) noexcept = default;
 
 // provide implementation here so it's only generated once
 Result::~Result() = default;
 Result& Result::operator=(Result const&) = default;
-Result& Result::operator=(Result&&) = default;
+Result& Result::operator=(Result&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
 Result::Result(Result const&) = default;
 Result::Result(Result&&) noexcept = default;
 
@@ -2827,15 +4104,21 @@ inline constexpr typename std::underlying_type<T>::type u(T val) noexcept {
 } // namespace detail
 
 // Result returned after a benchmark has finished. Can be used as a baseline for relative().
-Result::Result(Config const& benchmarkConfig)
-    : mConfig(benchmarkConfig)
-    , mNameToMeasurements{detail::u(Result::Measure::_size)} {}
+Result::Result(Config benchmarkConfig)
+    : mConfig(std::move(benchmarkConfig))
+    // One slot per measure, plus one for _size itself. Result::fromString() returns _size for a name
+    // it does not know, so it reaches these accessors whenever a caller resolves a measure from
+    // user input - and reading one slot past the end of the storage is not the answer to a typo.
+    // With the extra slot it is a permanently empty measurement list, which reads as "nothing was
+    // measured": 0.0 from the statistics and false from has(), the same thing the mustache renderer
+    // already does with a measure it does not recognise.
+    , mNameToMeasurements{detail::u(Result::Measure::_size) + 1U} {}
 
 void Result::add(Clock::duration totalElapsed, uint64_t iters, detail::PerformanceCounters const& pc) {
     using detail::d;
     using detail::u;
 
-    double dIters = d(iters);
+    double const dIters = d(iters);
     mNameToMeasurements[u(Result::Measure::iterations)].push_back(dIters);
 
     mNameToMeasurements[u(Result::Measure::elapsed)].push_back(d(totalElapsed) / dIters);
@@ -2852,26 +4135,11 @@ void Result::add(Clock::duration totalElapsed, uint64_t iters, detail::Performan
         mNameToMeasurements[u(Result::Measure::instructions)].push_back(d(pc.val().instructions) / dIters);
     }
     if (pc.has().branchInstructions) {
-        double branchInstructions = 0.0;
-        // correcting branches: remove branch introduced by the while (...) loop for each iteration.
-        if (pc.val().branchInstructions > iters + 1U) {
-            branchInstructions = d(pc.val().branchInstructions - (iters + 1U));
-        }
+        double const branchInstructions = d(detail::correctBranchInstructions(pc.val().branchInstructions, iters));
         mNameToMeasurements[u(Result::Measure::branchinstructions)].push_back(branchInstructions / dIters);
 
         if (pc.has().branchMisses) {
-            // correcting branch misses
-            double branchMisses = d(pc.val().branchMisses);
-            if (branchMisses > branchInstructions) {
-                // can't have branch misses when there were branches...
-                branchMisses = branchInstructions;
-            }
-
-            // assuming at least one missed branch for the loop
-            branchMisses -= 1.0;
-            if (branchMisses < 1.0) {
-                branchMisses = 1.0;
-            }
+            auto const branchMisses = detail::correctBranchMisses(pc.val().branchMisses, branchInstructions);
             mNameToMeasurements[u(Result::Measure::branchmisses)].push_back(branchMisses / dIters);
         }
     }
@@ -2894,33 +4162,516 @@ inline double calcMedian(std::vector<double>& data) {
     return (data[midIdx - 1U] + data[midIdx]) / 2U;
 }
 
+namespace detail {
+
+std::vector<double> pairedLogRatios(std::vector<double> const& a, std::vector<double> const& b) {
+    std::vector<double> logRatios;
+    auto const numPairs = (std::min)(a.size(), b.size());
+    logRatios.reserve(numPairs);
+    for (size_t i = 0; i < numPairs; ++i) {
+        // A round where either side measured 0 carries no ratio at all - the logarithm of it is not a
+        // large number, it is negative infinity, and one of those poisons every statistic downstream.
+        if (a[i] > 0.0 && b[i] > 0.0) {
+            logRatios.push_back(std::log(a[i]) - std::log(b[i]));
+        }
+    }
+    return logRatios;
+}
+
+std::vector<double> pairedLogRatios(Result const& a, Result const& b) {
+    auto const perRound = [](Result const& result) {
+        std::vector<double> values;
+        values.reserve(result.size());
+        for (size_t r = 0; r < result.size(); ++r) {
+            values.push_back(result.get(r, Result::Measure::elapsed));
+        }
+        return values;
+    };
+    return pairedLogRatios(perRound(a), perRound(b));
+}
+
+double medianOf(std::vector<double> values) {
+    return calcMedian(values);
+}
+
+double bonferroniConfidence(size_t numComparisons) noexcept {
+    return 1.0 - 0.05 / d((std::max)(numComparisons, static_cast<size_t>(1)));
+}
+
+std::pair<size_t, size_t> medianIntervalIndices(size_t n, double confidence) {
+    auto const alphaHalf = (1.0 - confidence) / 2.0;
+    size_t k = 0;
+
+    if (n <= 1024U) {
+        // Exact: walk the binomial tail up from P(X = 0) = 2^-n, each term from the one before it.
+        // 2^-1024 is still a representable double, so nothing underflows into a wrong answer.
+        double p = std::pow(0.5, d(n));
+        double cumulative = 0.0;
+        for (size_t i = 0; i < n; ++i) {
+            if (i > 0U) {
+                p = p * d(n - i + 1U) / d(i);
+            }
+            if (cumulative + p > alphaHalf) {
+                break;
+            }
+            cumulative += p;
+            k = i + 1U;
+        }
+    } else {
+        // well past the point where the normal approximation of a binomial is worth arguing about
+        auto const z = 1.959963985;
+        auto const approx = d(n) / 2.0 - z * std::sqrt(d(n)) / 2.0;
+        k = approx <= 0.0 ? 0U : static_cast<size_t>(approx);
+    }
+
+    if (0U == k || 2U * k > n) {
+        // no interval at this confidence for this few observations
+        return {1U, 0U};
+    }
+    return {k - 1U, n - k};
+}
+
+size_t countTiedRounds(std::vector<double> const& logRatios) {
+    size_t tied = 0;
+    for (auto logRatio : logRatios) {
+        // written without == so that -Wfloat-equal stays on for everyone else
+        if (!(logRatio < 0.0) && !(logRatio > 0.0)) {
+            ++tied;
+        }
+    }
+    return tied;
+}
+
+std::pair<double, double> medianInterval(std::vector<double> values, double confidence) {
+    auto const indices = medianIntervalIndices(values.size(), confidence);
+    if (indices.first > indices.second) {
+        return {0.0, 0.0};
+    }
+    std::sort(values.begin(), values.end());
+    return {values[indices.first], values[indices.second]};
+}
+
+} // namespace detail
+
+CompareResult::Entry::Entry(std::string entryName, Result entryResult, double entryRelative, double entryRelativeLow,
+                            double entryRelativeHigh, size_t entryTiedRounds) noexcept
+    : name(std::move(entryName))
+    , result(std::move(entryResult))
+    , relative(entryRelative)
+    , relativeLow(entryRelativeLow)
+    , relativeHigh(entryRelativeHigh)
+    , tiedRounds(entryTiedRounds) {}
+
+CompareResult::CompareResult(std::vector<Entry> entries, size_t numRounds)
+    : mEntries(std::move(entries))
+    , mRounds(numRounds) {}
+
+size_t CompareResult::size() const noexcept {
+    return mEntries.size();
+}
+
+CompareResult::Entry const& CompareResult::operator[](size_t idx) const {
+    return mEntries.at(idx);
+}
+
+size_t CompareResult::rounds() const noexcept {
+    return mRounds;
+}
+
+size_t CompareResult::comparisons() const noexcept {
+    return mEntries.empty() ? 0U : mEntries.size() - 1U;
+}
+
+bool CompareResult::isSignificant(size_t idx) const {
+    if (0U == idx) {
+        // the baseline is not compared against itself
+        return false;
+    }
+    auto const& entry = mEntries.at(idx);
+    return entry.relativeLow > 1.0 || entry.relativeHigh < 1.0;
+}
+
+// The entry with the lowest median, ignoring index `skip` - pass size() to ignore nothing. Returns
+// size() when that leaves no entry at all. The winner and the runner-up are the same question asked
+// twice, and asking it twice is how the two answers come to disagree about ties.
+static size_t fastestExcept(CompareResult const& compareResult, size_t skip) {
+    size_t best = compareResult.size();
+    auto bestMedian = (std::numeric_limits<double>::max)();
+    for (size_t i = 0; i < compareResult.size(); ++i) {
+        if (i == skip) {
+            continue;
+        }
+        auto const median = compareResult[i].result.median(Result::Measure::elapsed);
+        if (median < bestMedian) {
+            bestMedian = median;
+            best = i;
+        }
+    }
+    return best;
+}
+
+size_t CompareResult::fastest() const {
+    auto const best = fastestExcept(*this, mEntries.size());
+    // with no entries there is nothing to pick, and 0 is what this has always answered
+    return best == mEntries.size() ? 0U : best;
+}
+
+// The table half of a comparison: an ordinary benchmark table with the ratio to the baseline and an
+// interval for it in front. Split out of operator<< because clang-tidy caps cognitive complexity at
+// 25 and the two halves together sat well over it.
+static void writeCompareTable(std::ostream& os, CompareResult const& compareResult) {
+    auto const& config = compareResult[0].result.config();
+    auto ratioText = [](double low, double high) {
+        std::ostringstream ss;
+        ss << detail::fmt::Number(1, 1, low * 100.0) << "% .. " << detail::fmt::Number(1, 1, high * 100.0) << "%";
+        return ss.str();
+    };
+
+    // The two extra columns are the comparison itself, so they are not hideable - without them this
+    // is just a table. Everything after them is the same set an ordinary table shows, performance
+    // counters included: a comparison collects them around every epoch either way, so leaving them
+    // out was paying for them and showing nothing.
+    auto columnsFor = [&](CompareResult::Entry const& entry, bool isBaseline) {
+        std::vector<detail::fmt::MarkDownColumn> columns;
+        columns.push_back(detail::relativeColumn(entry.relative * 100.0));
+        columns.emplace_back(22, "95% CI", isBaseline ? std::string() : ratioText(entry.relativeLow, entry.relativeHigh));
+        auto const measurements = detail::measurementColumns(entry.result.config(), entry.result);
+        columns.insert(columns.end(), measurements.begin(), measurements.end());
+        return columns;
+    };
+
+    // An ordinary table only reprints its header when the shape changes, and that state lives on the
+    // stream. A comparison table always prints its own header, so the remembered shape is now wrong:
+    // clear it, or the next run() on this stream matches against a header it never wrote and streams
+    // its rows straight under the comparison's summary with no header of their own.
+    detail::streamHeaderHash(os) = 0;
+
+    detail::writeTableHeaderLines(os, columnsFor(compareResult[0], true), config.mBenchmarkTitle);
+
+    for (size_t i = 0; i < compareResult.size(); ++i) {
+        auto const columns = columnsFor(compareResult[i], 0U == i);
+        for (auto const& col : columns) {
+            os << col.value();
+        }
+        os << "| " << detail::fmt::MarkDownCode(compareResult[i].name) << std::endl;
+    }
+}
+
+// Two alternatives read better as a sentence than as a row to look up.
+// One spelling of the interval, so the table and the two summary shapes cannot drift apart.
+static void writeCompareInterval(std::ostream& os, double low, double high) {
+    os << "95% CI [" << detail::fmt::Number(1, 2, low) << " .. " << detail::fmt::Number(1, 2, high) << "]";
+}
+
+static void writeComparePair(std::ostream& os, CompareResult const& compareResult) {
+    auto const baseline = detail::fmt::MarkDownCode(compareResult[0].name);
+    auto const& entry = compareResult[1];
+    auto const other = detail::fmt::MarkDownCode(entry.name);
+
+    if (!compareResult.isSignificant(1)) {
+        os << "    no difference resolved between " << baseline << " and " << other << std::endl
+           << "    ratio " << detail::fmt::Number(1, 2, entry.relative) << "x, ";
+        writeCompareInterval(os, entry.relativeLow, entry.relativeHigh);
+        return;
+    }
+
+    // stated the way round the reader asked the question, so the interval inverts with it
+    auto const faster = entry.relative > 1.0;
+    os << "    " << other << " ran " << detail::fmt::Number(1, 2, faster ? entry.relative : 1.0 / entry.relative)
+       << (faster ? "x faster than " : "x slower than ") << baseline << std::endl
+       << "    ";
+    writeCompareInterval(os, faster ? entry.relativeLow : 1.0 / entry.relativeHigh,
+                         faster ? entry.relativeHigh : 1.0 / entry.relativeLow);
+}
+
+// Picking the winner out of many is a selection, not a test: whichever came first is flattered by the
+// same luck that made it first. So the claim is not "this one is fastest" on its own, it is how far
+// ahead of the *runner-up* it is - and if that interval contains 1, the top two were not separated.
+static void writeCompareWinner(std::ostream& os, CompareResult const& compareResult) {
+    auto const best = compareResult.fastest();
+    auto runnerUp = fastestExcept(compareResult, best);
+    if (runnerUp == compareResult.size()) {
+        // a comparison of one: there is nothing to be ahead of, so it is compared against itself and
+        // the empty interval that comes out reads as "not separated"
+        runnerUp = best;
+    }
+
+    // The rounds are paired for every alternative, not only against the baseline, so the top two can
+    // be compared to each other after the fact from the per-round measurements.
+    auto const logRatios = detail::pairedLogRatios(compareResult[runnerUp].result, compareResult[best].result);
+    auto const confidence = detail::bonferroniConfidence(compareResult.comparisons());
+    auto const interval = detail::medianInterval(logRatios, confidence);
+    auto const lead = std::exp(detail::medianOf(logRatios));
+    auto const leadLow = std::exp(interval.first);
+    auto const leadHigh = std::exp(interval.second);
+
+    auto const bestCode = detail::fmt::MarkDownCode(compareResult[best].name);
+    auto const runnerUpCode = detail::fmt::MarkDownCode(compareResult[runnerUp].name);
+    if (leadLow > 1.0) {
+        os << "    " << bestCode << " is fastest of " << compareResult.size() << ", " << detail::fmt::Number(1, 2, lead)
+           << "x ahead of " << runnerUpCode << std::endl;
+    } else {
+        os << "    " << bestCode << " and " << runnerUpCode << " are the two fastest of " << compareResult.size()
+           << ", and were not separated" << std::endl;
+    }
+    os << "    ";
+    writeCompareInterval(os, leadLow, leadHigh);
+    os << ", intervals corrected for " << compareResult.comparisons() << " comparisons";
+}
+
+std::ostream& operator<<(std::ostream& os, CompareResult const& compareResult) {
+    detail::fmt::StreamStateRestorer const restorer(os);
+    if (0U == compareResult.size()) {
+        return os;
+    }
+
+    // The same table an ordinary benchmark prints, plus the ratio to the baseline and an interval for
+    // it. A ratio with no scale beside it cannot be told from the same ratio on a completely
+    // different scale, and a side that was wildly unstable is invisible in one - so the absolute
+    // numbers come first and the verdict after.
+    writeCompareTable(os, compareResult);
+
+    os << std::endl << "  Summary" << std::endl;
+    if (2U == compareResult.size()) {
+        writeComparePair(os, compareResult);
+    } else {
+        writeCompareWinner(os, compareResult);
+    }
+    os << ", " << compareResult.rounds() << " paired rounds, interleaved" << std::endl;
+
+    size_t tied = 0;
+    for (size_t i = 1; i < compareResult.size(); ++i) {
+        tied = (std::max)(tied, compareResult[i].tiedRounds);
+    }
+    if (0U != tied) {
+        os << "    up to " << tied << " of " << compareResult.rounds() << " rounds tied at the clock's resolution" << std::endl;
+    }
+    return os;
+}
+
+uint64_t Bench::compareIterations(std::vector<detail::ErasedOp> const& ops) const {
+    // An exact epochIterations() overrides any calculated count, exactly as it does in a normal run.
+    if (0 != epochIterations()) {
+        return epochIterations();
+    }
+
+    // The count that fills a normal epoch, per alternative. The smallest of them belongs to the
+    // slowest alternative - it needs the fewest iterations to fill an epoch - and the largest to the
+    // fastest.
+    auto const target = detail::targetRuntimePerEpoch(*this);
+    auto fewest = (std::numeric_limits<uint64_t>::max)();
+    uint64_t most = 0;
+    for (auto const& op : ops) {
+        auto const calibrated = compareCalibrate(op, target);
+        fewest = (std::min)(fewest, calibrated);
+        most = (std::max)(most, calibrated);
+    }
+
+    // Every count above fills the same target, so they are inversely proportional to the
+    // per-iteration times and convert to any other epoch length by scaling: a count that fills
+    // `target` times `wanted / target` is the count that fills `wanted`. Calibration stops at the
+    // first count that reaches the target rather than at the exact one, so the per-iteration time
+    // behind it is if anything underestimated and the scaled counts err upwards.
+    auto const targetSeconds = detail::d(target);
+    if (!(targetSeconds > 0.0)) {
+        // Nothing to scale by. A maxEpochTime of zero gets here, and every alternative then ran
+        // minEpochIterations during calibration, which is what `fewest` holds.
+        return fewest;
+    }
+    auto const scaled = [&](uint64_t iters, Clock::duration wanted) {
+        return detail::u64(detail::d(iters) * (detail::d(wanted) / targetSeconds));
+    };
+
+    // Taking `fewest` is what keeps the slowest alternative inside maxEpochTime, but on its own it
+    // makes every faster alternative run an epoch shorter than asked for by however much faster it
+    // is - a 1ns operation against a 50ns one gets a fiftieth of an epoch. So the count is raised
+    // until the *fastest* alternative clears the epoch this library calls long enough to measure:
+    // the clock's resolution times the multiple, which is where targetRuntimePerEpoch() starts from.
+    // That sits far below minEpochTime wherever the clock is good, so this binds only when the
+    // alternatives are orders of magnitude apart or the clock is coarse.
+    auto const measurable = scaled(most, detail::clockResolution() * clockResolutionMultiple());
+
+    // Raising it stretches the slowest alternative's epoch by the same factor, and maxEpochTime is
+    // the bound on that. A 1ns operation against a 1ms one cannot have both, and epochs a million
+    // times longer than asked for are the worse of the two failures.
+    auto const affordable = scaled(fewest, maxEpochTime());
+
+    return (std::max)(fewest, (std::min)(measurable, affordable));
+}
+
+uint64_t Bench::compareCalibrate(detail::ErasedOp const& op, Clock::duration target) const {
+    uint64_t numIters = minEpochIterations();
+    uint64_t reached = 0;
+    for (size_t attempt = 0; attempt < 64; ++attempt) {
+        Clock::time_point const before = Clock::now();
+        op.run(op.op, numIters);
+        auto const elapsed = Clock::now() - before;
+        if (elapsed >= target) {
+            // Measured again at the same count before it is believed. A single reading is one
+            // interruption away from being far too high, and this loop grows in steps of up to 10x -
+            // so one preempted attempt ends the search an order of magnitude early, and every
+            // alternative then runs epochs that much shorter than they were asked to be. That is not
+            // hypothetical: an Alpine leg on a shared two core runner returned 11111 for an operation
+            // whose 11111 iterations take 14us against a 100us target, because one attempt was
+            // interrupted for 86us. Two readings in a row have to cross.
+            if (reached == numIters) {
+                return numIters;
+            }
+            reached = numIters;
+            continue;
+        }
+        reached = 0;
+
+        // grow towards the target, but never by more than 10x at once - the same shape as the normal
+        // upscaling, so a wildly wrong first guess still converges in a few steps
+        auto const elapsedSeconds = detail::d(elapsed);
+        auto factor = elapsedSeconds > 0.0 ? detail::d(target) / elapsedSeconds : 10.0;
+        factor = (std::min)(10.0, (std::max)(1.5, factor));
+        if (numIters > (std::numeric_limits<uint64_t>::max)() / 16U) {
+            break;
+        }
+        numIters = detail::u64(detail::d(numIters) * factor) + 1U;
+    }
+    return numIters;
+}
+
+CompareResult Bench::compareImpl(std::vector<std::string> const& names, std::vector<detail::ErasedOp> const& ops) {
+    auto const numOps = ops.size();
+
+    // A comparison on a machine with frequency scaling on needs these at least as much as a run()
+    // does, and a program that only ever calls compare() would otherwise never see them.
+    detail::printStabilityInformationOnce(output());
+    detail::printPerformanceCounterHintOnce(output(), performanceCounters());
+
+    // Honored, though it is not the tool it looks like here: calibration below already runs each side
+    // for about a full epoch, and the serial correlation a warmup would be aimed at is removed by the
+    // pairing rather than by running longer first. Measured over 200 rounds, the raw per-round times
+    // carry a lag-1 autocorrelation around +0.10 while the paired differences carry -0.01 to -0.08,
+    // and dropping the first twenty rounds changes neither.
+    for (auto const& op : ops) {
+        op.run(op.op, warmup());
+    }
+
+    // One count for every alternative - see compareIterations() for why that matters so much.
+    auto const iters = compareIterations(ops);
+
+    std::vector<Result> results;
+    results.reserve(numOps);
+    for (auto const& name : names) {
+        Config entryConfig = mConfig;
+        entryConfig.mBenchmarkName = name;
+        results.emplace_back(std::move(entryConfig));
+    }
+
+    // Every alternative besides the baseline is one more chance to be wrong, so the intervals are
+    // widened to keep the whole table at 95% rather than each row separately.
+    auto const confidence = detail::bonferroniConfidence(numOps - 1U);
+
+    // Rounds come in blocks of one epoch per alternative, and the count is raised until the interval
+    // is possible at all - with many alternatives the corrected confidence needs more rounds before
+    // any pair of order statistics reaches it.
+    auto numRounds = ((epochs() + numOps - 1U) / numOps) * numOps;
+    while (true) {
+        auto const indices = detail::medianIntervalIndices(numRounds, confidence);
+        if (indices.first <= indices.second) {
+            break;
+        }
+        numRounds += numOps;
+    }
+
+    Rng orderRng;
+    std::vector<uint32_t> order(numOps);
+    for (size_t i = 0; i < numOps; ++i) {
+        order[i] = static_cast<uint32_t>(i);
+    }
+
+    for (size_t round = 0; round < numRounds; ++round) {
+        auto const positionInBlock = round % numOps;
+        if (0 == positionInBlock) {
+            // A fresh random permutation per block, then rotated one step per round: every
+            // alternative occupies every position exactly once over the block, so their mean
+            // positions are equal and a drift that is linear over the block cancels. For two
+            // alternatives this produces exactly ABBA or BAAB.
+            orderRng.shuffle(order);
+        }
+        for (size_t slot = 0; slot < numOps; ++slot) {
+            auto const which = order[(slot + positionInBlock) % numOps];
+            compareEpoch(ops[which], iters, results[which]);
+        }
+    }
+
+    std::vector<CompareResult::Entry> entries;
+    entries.reserve(numOps);
+    entries.emplace_back(names[0], std::move(results[0]), 1.0, 1.0, 1.0, static_cast<size_t>(0));
+    for (size_t i = 1; i < numOps; ++i) {
+        // ln(t_baseline) - ln(t_i), so a positive difference means the alternative was quicker and
+        // the ratio comes out above 1 - the same direction relative() reports. The baseline was moved
+        // into entries[0] above, which is where it is read from now.
+        auto const logRatios = detail::pairedLogRatios(entries[0].result, results[i]);
+        auto const interval = detail::medianInterval(logRatios, confidence);
+        entries.emplace_back(names[i], std::move(results[i]), std::exp(detail::medianOf(logRatios)), std::exp(interval.first),
+                             std::exp(interval.second), detail::countTiedRounds(logRatios));
+    }
+
+    CompareResult compareResult{std::move(entries), numRounds};
+    if (nullptr != output()) {
+        *output() << compareResult;
+    }
+    return compareResult;
+}
+
+void Bench::compareEpoch(detail::ErasedOp const& op, uint64_t numIters, Result& result) {
+    auto& pc = detail::performanceCounters();
+
+    pc.beginMeasure();
+    Clock::time_point const before = Clock::now();
+    op.run(op.op, numIters);
+    Clock::time_point const after = Clock::now();
+    pc.endMeasure();
+    pc.updateResults(numIters);
+
+    result.add(after - before, numIters, pc);
+}
+
+std::vector<double> const& Result::measurements(Measure m) const {
+    return mNameToMeasurements.at(detail::u(m));
+}
+
 double Result::median(Measure m) const {
     // create a copy so we can sort
-    auto data = mNameToMeasurements[detail::u(m)];
+    auto data = measurements(m);
     return calcMedian(data);
 }
 
 double Result::average(Measure m) const {
     using detail::d;
-    auto const& data = mNameToMeasurements[detail::u(m)];
+    auto const& data = measurements(m);
     if (data.empty()) {
         return 0.0;
     }
 
-    // create a copy so we can sort
     return sum(m) / d(data.size());
 }
 
 double Result::medianAbsolutePercentError(Measure m) const {
     // create copy
-    auto data = mNameToMeasurements[detail::u(m)];
+    auto data = measurements(m);
 
     // calculates MdAPE which is the median of percentage error
-    // see https://www.spiderfinancial.com/support/documentation/numxl/reference-manual/forecasting-performance/mdape
+    // see https://support.numxl.com/hc/en-us/articles/115001223503-MdAPE-Median-Absolute-Percentage-Error
     auto med = calcMedian(data);
+
+    // The error is relative to the measurement itself, so a measurement of 0 has none that is finite: it is 0 when the
+    // median is 0 as well (they agree), and infinite otherwise, which is the limit of |(x - med) / x| for x -> 0.
+    // Calculating it directly would give NaN, and a NaN in the data breaks the ordering that calcMedian's sort needs.
+    auto const zeroError = med <= 0.0 ? 0.0 : std::numeric_limits<double>::infinity();
 
     // transform the data to absolute error
     for (auto& x : data) {
+        if (x <= 0.0) {
+            x = zeroError;
+            continue;
+        }
         x = (x - med) / x;
         if (x < 0) {
             x = -x;
@@ -2930,13 +4681,13 @@ double Result::medianAbsolutePercentError(Measure m) const {
 }
 
 double Result::sum(Measure m) const noexcept {
-    auto const& data = mNameToMeasurements[detail::u(m)];
+    auto const& data = measurements(m);
     return std::accumulate(data.begin(), data.end(), 0.0);
 }
 
 double Result::sumProduct(Measure m1, Measure m2) const noexcept {
-    auto const& data1 = mNameToMeasurements[detail::u(m1)];
-    auto const& data2 = mNameToMeasurements[detail::u(m2)];
+    auto const& data1 = measurements(m1);
+    auto const& data2 = measurements(m2);
 
     if (data1.size() != data2.size()) {
         return 0.0;
@@ -2950,12 +4701,11 @@ double Result::sumProduct(Measure m1, Measure m2) const noexcept {
 }
 
 bool Result::has(Measure m) const noexcept {
-    return !mNameToMeasurements[detail::u(m)].empty();
+    return !measurements(m).empty();
 }
 
 double Result::get(size_t idx, Measure m) const {
-    auto const& data = mNameToMeasurements[detail::u(m)];
-    return data.at(idx);
+    return measurements(m).at(idx);
 }
 
 bool Result::empty() const noexcept {
@@ -2963,12 +4713,11 @@ bool Result::empty() const noexcept {
 }
 
 size_t Result::size() const noexcept {
-    auto const& data = mNameToMeasurements[detail::u(Measure::elapsed)];
-    return data.size();
+    return measurements(Measure::elapsed).size();
 }
 
 double Result::minimum(Measure m) const noexcept {
-    auto const& data = mNameToMeasurements[detail::u(m)];
+    auto const& data = measurements(m);
     if (data.empty()) {
         return 0.0;
     }
@@ -2978,7 +4727,7 @@ double Result::minimum(Measure m) const noexcept {
 }
 
 double Result::maximum(Measure m) const noexcept {
-    auto const& data = mNameToMeasurements[detail::u(m)];
+    auto const& data = measurements(m);
     if (data.empty()) {
         return 0.0;
     }
@@ -2987,36 +4736,51 @@ double Result::maximum(Measure m) const noexcept {
     return *std::max_element(data.begin(), data.end());
 }
 
+std::string const& Result::context(char const* variableName) const {
+    return mConfig.mContext.at(variableName);
+}
+
+std::string const& Result::context(std::string const& variableName) const {
+    return mConfig.mContext.at(variableName);
+}
+
 Result::Measure Result::fromString(std::string const& str) {
     if (str == "elapsed") {
         return Measure::elapsed;
-    } else if (str == "iterations") {
-        return Measure::iterations;
-    } else if (str == "pagefaults") {
-        return Measure::pagefaults;
-    } else if (str == "cpucycles") {
-        return Measure::cpucycles;
-    } else if (str == "contextswitches") {
-        return Measure::contextswitches;
-    } else if (str == "instructions") {
-        return Measure::instructions;
-    } else if (str == "branchinstructions") {
-        return Measure::branchinstructions;
-    } else if (str == "branchmisses") {
-        return Measure::branchmisses;
-    } else {
-        // not found, return _size
-        return Measure::_size;
     }
+    if (str == "iterations") {
+        return Measure::iterations;
+    }
+    if (str == "pagefaults") {
+        return Measure::pagefaults;
+    }
+    if (str == "cpucycles") {
+        return Measure::cpucycles;
+    }
+    if (str == "contextswitches") {
+        return Measure::contextswitches;
+    }
+    if (str == "instructions") {
+        return Measure::instructions;
+    }
+    if (str == "branchinstructions") {
+        return Measure::branchinstructions;
+    }
+    if (str == "branchmisses") {
+        return Measure::branchmisses;
+    }
+    // not found, return _size
+    return Measure::_size;
 }
 
 // Configuration of a microbenchmark.
 Bench::Bench() {
     mConfig.mOut = &std::cout;
+    detail::applyEnvConfig(*this);
 }
 
-Bench::Bench(Bench&&) = default;
-Bench& Bench::operator=(Bench&&) = default;
+Bench::Bench(Bench&&) noexcept = default;
+Bench& Bench::operator=(Bench&&) noexcept(ANKERL_NANOBENCH(NOEXCEPT_STRING_MOVE)) = default;
 Bench::Bench(Bench const&) = default;
 Bench& Bench::operator=(Bench const&) = default;
 Bench::~Bench() noexcept = default;
@@ -3045,6 +4809,49 @@ Bench& Bench::performanceCounters(bool showPerformanceCounters) noexcept {
 }
 bool Bench::performanceCounters() const noexcept {
     return mConfig.mShowPerformanceCounters;
+}
+
+namespace detail {
+
+// One bit of mHiddenColumns per Column, so there had better be at most 32 of them.
+static_assert(static_cast<size_t>(Column::_size) <= 32, "Column no longer fits in Config::mHiddenColumns");
+
+ANKERL_NANOBENCH(NODISCARD) inline uint32_t columnBit(Column column) noexcept {
+    return UINT32_C(1) << static_cast<uint32_t>(column);
+}
+
+bool isColumnVisible(Config const& config, Column column) noexcept {
+    return 0 == (config.mHiddenColumns & columnBit(column));
+}
+
+} // namespace detail
+
+Bench& Bench::hideColumn(Column column) noexcept {
+    mConfig.mHiddenColumns |= detail::columnBit(column);
+    return *this;
+}
+
+Bench& Bench::showColumn(Column column) noexcept {
+    mConfig.mHiddenColumns &= ~detail::columnBit(column);
+    return *this;
+}
+
+bool Bench::isColumnVisible(Column column) const noexcept {
+    return detail::isColumnVisible(mConfig, column);
+}
+
+Bench& Bench::contextColumn(std::string const& variableName) {
+    // adding the same name twice would print the same column twice
+    if (mConfig.mContextColumns.end() != std::find(mConfig.mContextColumns.begin(), mConfig.mContextColumns.end(), variableName)) {
+        return *this;
+    }
+    mConfig.mContextColumns.push_back(variableName);
+    return *this;
+}
+
+Bench& Bench::clearContextColumns() noexcept {
+    mConfig.mContextColumns.clear();
+    return *this;
 }
 
 // Operation unit. Defaults to "op", could be e.g. "byte" for string processing.
@@ -3080,14 +4887,12 @@ std::chrono::duration<double> const& Bench::timeUnit() const noexcept {
     return mConfig.mTimeUnit;
 }
 
-// If benchmarkTitle differs from currently set title, the stored results will be cleared.
 Bench& Bench::title(const char* benchmarkTitle) {
-    if (benchmarkTitle != mConfig.mBenchmarkTitle) {
-        mResults.clear();
-    }
-    mConfig.mBenchmarkTitle = benchmarkTitle;
-    return *this;
+    return title(std::string(benchmarkTitle));
 }
+
+// If benchmarkTitle differs from currently set title, the stored results will be cleared. One body
+// for both overloads, so that rule cannot come to mean two things.
 Bench& Bench::title(std::string const& benchmarkTitle) {
     if (benchmarkTitle != mConfig.mBenchmarkTitle) {
         mResults.clear();
@@ -3110,8 +4915,30 @@ Bench& Bench::name(std::string const& benchmarkName) {
     return *this;
 }
 
+#    if ANKERL_NANOBENCH(HAS_STRING_VIEW)
+Bench& Bench::name(std::string_view benchmarkName) {
+    mConfig.mBenchmarkName.assign(benchmarkName.data(), benchmarkName.size());
+    return *this;
+}
+#    endif
+
 std::string const& Bench::name() const noexcept {
     return mConfig.mBenchmarkName;
+}
+
+Bench& Bench::context(char const* variableName, char const* variableValue) {
+    mConfig.mContext[variableName] = variableValue;
+    return *this;
+}
+
+Bench& Bench::context(std::string const& variableName, std::string const& variableValue) {
+    mConfig.mContext[variableName] = variableValue;
+    return *this;
+}
+
+Bench& Bench::clearContext() {
+    mConfig.mContext.clear();
+    return *this;
 }
 
 // Number of epochs to evaluate. The reported result will be the median of evaluation of each epoch.
@@ -3141,7 +4968,7 @@ std::chrono::nanoseconds Bench::maxEpochTime() const noexcept {
     return mConfig.mMaxEpochTime;
 }
 
-// Sets the maximum time each epoch should take. Default is 100ms.
+// Sets the minimum time each epoch should take. Default is 1ms.
 Bench& Bench::minEpochTime(std::chrono::nanoseconds t) noexcept {
     mConfig.mMinEpochTime = t;
     return *this;
@@ -3271,8 +5098,8 @@ Rng::Rng(std::vector<uint64_t> const& data)
     : mX(0)
     , mY(0) {
     if (data.size() != 2) {
-        throw std::runtime_error("ankerl::nanobench::Rng::Rng: needed exactly 2 entries in data, but got " +
-                                 detail::fmt::to_s(data.size()));
+        ANKERL_NANOBENCH_THROW(std::runtime_error("ankerl::nanobench::Rng::Rng: needed exactly 2 entries in data, but got " +
+                                                  detail::fmt::to_s(data.size())));
     }
     mX = data[0];
     mY = data[1];
@@ -3295,32 +5122,44 @@ BigO::RangeMeasure BigO::collectRangeMeasure(std::vector<Result> const& results)
     return rangeMeasure;
 }
 
-BigO::BigO(std::string const& bigOName, RangeMeasure const& rangeMeasure)
-    : mName(bigOName) {
+BigO::BigO(std::string bigOName, RangeMeasure const& rangeMeasure)
+    : mName(std::move(bigOName)) {
+
+    // Nothing to fit against: leave the constant and the error at 0 rather than dividing by zero
+    // three times over. complexityBigO() reaches this whenever it is called on a Bench where no
+    // complexityN was ever set, since collectRangeMeasure() then returns nothing - the six models
+    // used to come out all-NaN, which prints as "nan" and, being unordered, is a poor thing to hand
+    // to std::sort.
+    if (rangeMeasure.empty()) {
+        return;
+    }
 
     // estimate the constant factor
     double sumRangeMeasure = 0.0;
     double sumRangeRange = 0.0;
 
-    for (size_t i = 0; i < rangeMeasure.size(); ++i) {
-        sumRangeMeasure += rangeMeasure[i].first * rangeMeasure[i].second;
-        sumRangeRange += rangeMeasure[i].first * rangeMeasure[i].first;
+    for (const auto& rm : rangeMeasure) {
+        sumRangeMeasure += rm.first * rm.second;
+        sumRangeRange += rm.first * rm.first;
     }
-    mConstant = sumRangeMeasure / sumRangeRange;
+    // a sum of squares, so this is only 0 when every n is
+    mConstant = sumRangeRange <= 0.0 ? 0.0 : sumRangeMeasure / sumRangeRange;
 
     // calculate root mean square
     double err = 0.0;
     double sumMeasure = 0.0;
-    for (size_t i = 0; i < rangeMeasure.size(); ++i) {
-        auto diff = mConstant * rangeMeasure[i].first - rangeMeasure[i].second;
+    for (const auto& rm : rangeMeasure) {
+        auto diff = mConstant * rm.first - rm.second;
         err += diff * diff;
 
-        sumMeasure += rangeMeasure[i].second;
+        sumMeasure += rm.second;
     }
 
-    auto n = static_cast<double>(rangeMeasure.size());
+    auto n = detail::d(rangeMeasure.size());
     auto mean = sumMeasure / n;
-    mNormalizedRootMeanSquare = std::sqrt(err / n) / mean;
+    // the error is relative to the mean measurement, so there is no relative error to report when
+    // everything measured as 0 - and 0/0 is not it
+    mNormalizedRootMeanSquare = mean <= 0.0 ? 0.0 : std::sqrt(err / n) / mean;
 }
 
 BigO::BigO(const char* bigOName, RangeMeasure const& rangeMeasure)
@@ -3339,7 +5178,8 @@ double BigO::normalizedRootMeanSquare() const noexcept {
 }
 
 bool BigO::operator<(BigO const& other) const noexcept {
-    return std::tie(mNormalizedRootMeanSquare, mName) < std::tie(other.mNormalizedRootMeanSquare, other.mName);
+    return (mNormalizedRootMeanSquare < other.mNormalizedRootMeanSquare) ||
+           (!(mNormalizedRootMeanSquare > other.mNormalizedRootMeanSquare) && mName < other.mName);
 }
 
 std::ostream& operator<<(std::ostream& os, BigO const& bigO) {
@@ -3347,7 +5187,7 @@ std::ostream& operator<<(std::ostream& os, BigO const& bigO) {
 }
 
 std::ostream& operator<<(std::ostream& os, std::vector<ankerl::nanobench::BigO> const& bigOs) {
-    detail::fmt::StreamStateRestorer restorer(os);
+    detail::fmt::StreamStateRestorer const restorer(os);
     os << std::endl << "|   coefficient |   err% | complexity" << std::endl << "|--------------:|-------:|------------" << std::endl;
     for (auto const& bigO : bigOs) {
         os << "|" << std::setw(14) << std::setprecision(7) << std::scientific << bigO.constant() << " ";

--- a/test/unit/probe_wrap.cpp
+++ b/test/unit/probe_wrap.cpp
@@ -1,6 +1,7 @@
 #include <ankerl/unordered_dense.h>
 
 #include <app/doctest.h>
+#include <app/hashers.h>
 
 #include <cstdint>
 #include <set>
@@ -8,21 +9,14 @@
 // The vector probe reads four buckets from any bucket index, so the array carries three sentinel
 // buckets past its end. A window that starts in the last three buckets and decides nothing has to
 // move on to bucket zero by however many *real* buckets it saw, not by four -- in the probe, where
-// the key is then found or placed on the far side of the wrap, and in the erase fixup, which looks
-// for the bucket that points at the moved last value the same way. None of that happens unless a
-// long robin hood chain runs across the end of the array, so this builds one on purpose: a hash
-// that returns the key itself, and keys that spell out the bucket and fingerprint they want.
+// the key is then found or placed on the far side of the wrap, and in the scan for the bucket that
+// points at a value, which erase runs from that value's home bucket. None of that happens unless
+// a long robin hood chain runs across the end of the array, so this builds one on purpose: keys
+// that spell out the bucket and fingerprint they want, through a hash that returns the key.
 
 namespace {
 
-struct identity_hash {
-    using is_avalanching = void;
-    auto operator()(uint64_t key) const noexcept -> uint64_t {
-        return key;
-    }
-};
-
-using wrap_map_t = ankerl::unordered_dense::map<uint64_t, uint64_t, identity_hash>;
+using wrap_map_t = ankerl::unordered_dense::map<uint64_t, uint64_t, test::identity_hash>;
 
 struct key_maker {
     unsigned shift;
@@ -33,12 +27,11 @@ struct key_maker {
     }
 };
 
-auto keys_of(wrap_map_t const& map) -> std::set<uint64_t> {
-    auto keys = std::set<uint64_t>();
-    for (auto const& kv : map) {
-        keys.insert(kv.first);
+void require_exactly(wrap_map_t const& map, std::set<uint64_t> const& expected) {
+    REQUIRE(map.size() == expected.size());
+    for (auto e : expected) {
+        REQUIRE(map.find(e) != map.end());
     }
-    return keys;
 }
 
 } // namespace
@@ -60,22 +53,26 @@ TEST_CASE("probe_wrap") {
         expected.insert(k);
     };
 
-    // a chain of 30 keys whose home is the fourth-to-last bucket: they occupy the last four
-    // buckets and then, wrapped, buckets 0 to 25, with distances 1 to 30
+    // The first value, whose home is the last bucket, and then a chain of 30 whose home is the
+    // fourth-to-last: they take the last four buckets and, wrapped, buckets 0 to 26 -- and push
+    // the first value past the wrap ahead of them, robin hood style, since it is closer to home.
+    auto const first = key(n - 1, 0, 0x33);
+    insert(first);
     for (uint64_t id = 0; id < 30; ++id) {
         insert(key(n - 4, id, 0x11));
     }
     REQUIRE(map.bucket_count() == n);
-    REQUIRE(keys_of(map) == expected);
+    require_exactly(map, expected);
 
     // Absent keys whose home is in the last three buckets. Every real bucket of their first window
     // holds a chain element that is further from home than the key would be, the rest of the window
     // is sentinel, so nothing is decided and the probe has to wrap.
     for (uint64_t home = n - 3; home < n; ++home) {
         for (uint64_t fp = 0; fp < 256; fp += 51) {
-            REQUIRE(map.find(key(home, 999, fp)) == map.end());
-            REQUIRE(!map.contains(key(home, 999, fp)));
-            REQUIRE(map.count(key(home, 999, fp)) == 0);
+            auto const absent = key(home, 999, fp);
+            REQUIRE(map.find(absent) == map.end());
+            REQUIRE(!map.contains(absent));
+            REQUIRE(map.count(absent) == 0);
         }
     }
 
@@ -85,13 +82,22 @@ TEST_CASE("probe_wrap") {
     REQUIRE(map.find(b) != map.end());
     REQUIRE(map.find(b)->second == b);
     REQUIRE(map.try_emplace(b, 0).second == false);
-    REQUIRE(keys_of(map) == expected);
+    require_exactly(map, expected);
 
     // Erasing it finds it the same way; afterwards it is gone and the chain is intact.
     REQUIRE(map.erase(b) == 1);
     expected.erase(b);
     REQUIRE(map.find(b) == map.end());
-    REQUIRE(keys_of(map) == expected);
+    require_exactly(map, expected);
+
+    // Erase by iterator looks for the bucket pointing at the value's index, from its home. The
+    // first value has index 0 and sits past the wrap, so the scan's first window is one real bucket
+    // and three sentinels -- which must not claim to hold index 0.
+    REQUIRE(map.begin()->first == first);
+    map.erase(map.begin());
+    expected.erase(first);
+    REQUIRE(map.find(first) == map.end());
+    require_exactly(map, expected);
 
     // The erase fixup: the last value's home is in the last three buckets, its bucket is beyond the
     // wrap. Erasing something else moves it, and the scan for its bucket has to wrap to find it.
@@ -101,10 +107,10 @@ TEST_CASE("probe_wrap") {
     expected.erase(key(n - 4, 5, 0x11));
     REQUIRE(map.find(last) != map.end());
     REQUIRE(map.find(last)->second == last);
-    REQUIRE(keys_of(map) == expected);
+    require_exactly(map, expected);
     REQUIRE(map.erase(last) == 1);
     expected.erase(last);
-    REQUIRE(keys_of(map) == expected);
+    require_exactly(map, expected);
 
     // Take the chain down from the front, so that what is left keeps shifting across the wrap.
     for (uint64_t id = 0; id < 30; ++id) {
@@ -112,10 +118,7 @@ TEST_CASE("probe_wrap") {
         if (expected.erase(k) != 0) {
             REQUIRE(map.erase(k) == 1);
         }
-        REQUIRE(keys_of(map) == expected);
-        for (auto e : expected) {
-            REQUIRE(map.find(e) != map.end());
-        }
+        require_exactly(map, expected);
     }
     REQUIRE(map.empty());
     REQUIRE(map.bucket_count() == n);
@@ -124,6 +127,6 @@ TEST_CASE("probe_wrap") {
     for (uint64_t id = 0; id < 30; ++id) {
         insert(key(n - 1, id, 0x55));
     }
-    REQUIRE(keys_of(map) == expected);
+    require_exactly(map, expected);
     REQUIRE(map.bucket_count() == n);
 }

--- a/test/unit/probe_wrap.cpp
+++ b/test/unit/probe_wrap.cpp
@@ -1,0 +1,129 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <cstdint>
+#include <set>
+
+// The vector probe reads four buckets from any bucket index, so the array carries three sentinel
+// buckets past its end. A window that starts in the last three buckets and decides nothing has to
+// move on to bucket zero by however many *real* buckets it saw, not by four -- in the probe, where
+// the key is then found or placed on the far side of the wrap, and in the erase fixup, which looks
+// for the bucket that points at the moved last value the same way. None of that happens unless a
+// long robin hood chain runs across the end of the array, so this builds one on purpose: a hash
+// that returns the key itself, and keys that spell out the bucket and fingerprint they want.
+
+namespace {
+
+struct identity_hash {
+    using is_avalanching = void;
+    auto operator()(uint64_t key) const noexcept -> uint64_t {
+        return key;
+    }
+};
+
+using wrap_map_t = ankerl::unordered_dense::map<uint64_t, uint64_t, identity_hash>;
+
+struct key_maker {
+    unsigned shift;
+
+    // home is the bucket the key lands in, fingerprint its low byte; id makes keys distinct
+    auto operator()(uint64_t home, uint64_t id, uint64_t fingerprint) const -> uint64_t {
+        return (home << shift) | (id << 8U) | fingerprint;
+    }
+};
+
+auto keys_of(wrap_map_t const& map) -> std::set<uint64_t> {
+    auto keys = std::set<uint64_t>();
+    for (auto const& kv : map) {
+        keys.insert(kv.first);
+    }
+    return keys;
+}
+
+} // namespace
+
+TEST_CASE("probe_wrap") {
+    auto map = wrap_map_t();
+    map.reserve(100);
+    auto const n = map.bucket_count();
+    REQUIRE(n >= 8);
+    REQUIRE((n & (n - 1)) == 0);
+    auto shift = unsigned{64};
+    for (auto b = n; b > 1; b /= 2) {
+        --shift;
+    }
+    auto const key = key_maker{shift};
+    auto expected = std::set<uint64_t>();
+    auto insert = [&](uint64_t k) {
+        REQUIRE(map.try_emplace(k, k).second);
+        expected.insert(k);
+    };
+
+    // a chain of 30 keys whose home is the fourth-to-last bucket: they occupy the last four
+    // buckets and then, wrapped, buckets 0 to 25, with distances 1 to 30
+    for (uint64_t id = 0; id < 30; ++id) {
+        insert(key(n - 4, id, 0x11));
+    }
+    REQUIRE(map.bucket_count() == n);
+    REQUIRE(keys_of(map) == expected);
+
+    // Absent keys whose home is in the last three buckets. Every real bucket of their first window
+    // holds a chain element that is further from home than the key would be, the rest of the window
+    // is sentinel, so nothing is decided and the probe has to wrap.
+    for (uint64_t home = n - 3; home < n; ++home) {
+        for (uint64_t fp = 0; fp < 256; fp += 51) {
+            REQUIRE(map.find(key(home, 999, fp)) == map.end());
+            REQUIRE(!map.contains(key(home, 999, fp)));
+            REQUIRE(map.count(key(home, 999, fp)) == 0);
+        }
+    }
+
+    // Placing such a key walks the same way and puts it behind the chain, on the far side.
+    auto const b = key(n - 1, 7, 0x33);
+    insert(b);
+    REQUIRE(map.find(b) != map.end());
+    REQUIRE(map.find(b)->second == b);
+    REQUIRE(map.try_emplace(b, 0).second == false);
+    REQUIRE(keys_of(map) == expected);
+
+    // Erasing it finds it the same way; afterwards it is gone and the chain is intact.
+    REQUIRE(map.erase(b) == 1);
+    expected.erase(b);
+    REQUIRE(map.find(b) == map.end());
+    REQUIRE(keys_of(map) == expected);
+
+    // The erase fixup: the last value's home is in the last three buckets, its bucket is beyond the
+    // wrap. Erasing something else moves it, and the scan for its bucket has to wrap to find it.
+    auto const last = key(n - 2, 8, 0x44);
+    insert(last);
+    REQUIRE(map.erase(key(n - 4, 5, 0x11)) == 1);
+    expected.erase(key(n - 4, 5, 0x11));
+    REQUIRE(map.find(last) != map.end());
+    REQUIRE(map.find(last)->second == last);
+    REQUIRE(keys_of(map) == expected);
+    REQUIRE(map.erase(last) == 1);
+    expected.erase(last);
+    REQUIRE(keys_of(map) == expected);
+
+    // Take the chain down from the front, so that what is left keeps shifting across the wrap.
+    for (uint64_t id = 0; id < 30; ++id) {
+        auto k = key(n - 4, id, 0x11);
+        if (expected.erase(k) != 0) {
+            REQUIRE(map.erase(k) == 1);
+        }
+        REQUIRE(keys_of(map) == expected);
+        for (auto e : expected) {
+            REQUIRE(map.find(e) != map.end());
+        }
+    }
+    REQUIRE(map.empty());
+    REQUIRE(map.bucket_count() == n);
+
+    // and the sentinels were never taken for empty buckets: the array is as usable as before
+    for (uint64_t id = 0; id < 30; ++id) {
+        insert(key(n - 1, id, 0x55));
+    }
+    REQUIRE(keys_of(map) == expected);
+    REQUIRE(map.bucket_count() == n);
+}


### PR DESCRIPTION
## What

The probe reads four consecutive buckets from the home bucket with SSE2 and decides on the lowest lane that is either a fingerprint match or a robin hood proof of absence. One data-dependent branch per lookup instead of one per bucket. The bucket array carries three sentinel buckets past the end so a window never runs off it (`bucket_count()` unchanged). One `probe()` now serves find, try_emplace and erase; the erase fixup scan matches value indices four at a time.

Configurations without a contiguous standard bucket (segmented, custom container, `bucket_type::big`, non-SSE2) keep the scalar probe.

## Why

On lookups whose outcome is random the scalar probe mispredicts 1.35 times per lookup, boost's grouped scan 0.42. Measured on a 7950X, that number *is* the gap to `boost::unordered_flat_map` on u64 keys (instruction counts are equal or lower), and `cycles ≈ 16 × mispredicts + instructions / 3.5` predicted every variant tried within a cycle.

## The benchmark was a replay, and now is not

`bench_quick_overall_udm`'s find workload reset its search rng to the insertion rng's seed, so its sequence of hits and misses repeated, and a modern branch predictor learned half of it: 0.60 mispredicts per lookup for the scalar probe, where a random sequence costs 1.35. That under-reported branchy probing and hid most of this change. As agreed, the workload now decides each lookup with an rng of its own (a random existing key, or one that cannot exist), still against a map that grows to ~50k. **Scores before and after are not comparable.** `find_random.cpp` still replays and is untouched.

## Measured (paired `compare()`, ms, base = main, same workload on both)

| workload | clang base → cand | boost |
|---|---|---|
| find64 (new) | 78.6 → 48.0 (**+64%**) | 40.1 |
| findstr (new) | 218 → 210 (**+4%**) | 182 |
| ie64 | 62.0 → 65.3 (−5%) | 57.1 |
| iestr | 226 → 212 (**+6%**) | 188 |
| rhit64 (all hits) | 145 → 80 (**+82%**) | 50 |
| rmiss64 (no hits) | 48 → 35 (**+35%**) | 28 |
| old replayed find64 | 61.4 → 57.9 (+6%) | 51.6 |
| old replayed findstr | 176 → 184 (−4.5%) | 175 |

gcc on the old workloads: find64 +6.5%, findstr +7%, ie64 −6%, iestr +19%.

Official `bench_quick_overall_udm` with the new find (clang, lower is better): main 0.0416, this branch 0.0378–0.0380 (**9% better**).

The two losses: the old `findstr` under clang is the ~10 cycles the vector decision (`movmskps → tzcnt → index load`) adds before the value load can issue, in a loop that at 250 instructions per lookup (150 of them the 200-byte hash) is latency bound; `ie64` is ~20 more instructions per insert/erase for 0.24 fewer mispredicts. The cost model and the dead ends of this session (AES hash, aligned groups, hybrid probe, stored hash bits) are in CLAUDE.md.

## Also

- `scripts/ab/run.sh`: the paired harness that produced these numbers (working tree vs any revision, optional boost; needs nanobench ≥ 4.6 for `compare()`).
- `test/unit/probe_wrap.cpp`: builds a robin hood chain across the end of the array so the wrap-around paths of the probe and the erase fixup run. The mutation sweep of the diff found them unreached.

## Verification

- 599/599 unit tests under clang 22 and gcc 16 (`-Werror`), ASan+UBSan green.
- Lint: clean on touched lines (this machine's clang-tidy 22 flags pre-existing `max_size()`/`operator[]`/`namespace std` sites that the pinned 18 does not).
- Mutation sweep of the diff (179 mutants): the survivors were the wrap-around paths, now covered by `probe_wrap.cpp`; a targeted rerun over those lines leaves only equivalent mutants (advance-by-fewer, and the guard for probe distances beyond 2^23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
