### PR TITLE
bump version to 4.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 cmake_minimum_required(VERSION ${CMAKEVER})
 project("unordered_dense"
-    VERSION 4.9.2
+    VERSION 4.10.0
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense"
     LANGUAGES CXX)

--- a/include/ankerl/stl.h
+++ b/include/ankerl/stl.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 4.9.2
+// Version 4.10.0
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 4.9.2
+// Version 4.10.0
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
@@ -30,9 +30,9 @@
 #define ANKERL_UNORDERED_DENSE_H
 
 // see https://semver.org/spec/v2.0.0.html
-#define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 4 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
-#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 9 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
-#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 2 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
+#define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 4  // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
+#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 10 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
+#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 0  // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
 
 // API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '4.9.2',
+    version: '4.10.0',
     license: 'MIT',
     default_options : [
         'cpp_std=c++17', 

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -1,7 +1,7 @@
 #include <ankerl/unordered_dense.h>
 #include <app/doctest.h>
 
-namespace versioned_namespace = ankerl::unordered_dense::v4_9_2;
+namespace versioned_namespace = ankerl::unordered_dense::v4_10_0;
 
 static_assert(std::is_same_v<versioned_namespace::map<int, int>, ankerl::unordered_dense::map<int, int>>);
 static_assert(std::is_same_v<versioned_namespace::hash<int>, ankerl::unordered_dense::hash<int>>);


### PR DESCRIPTION
The SSE2 probe from #211: integer lookups 1.6 to 1.8x faster, one data-dependent branch per lookup instead of one per bucket.

Minor rather than major because nothing in the public API changed. Two behavioural notes for the release text: every map costs 24 bytes more (three sentinel buckets past the end of the array), and the find workload of `bench_quick_overall_udm` no longer replays its insertion sequence, so its score is not comparable with 4.9.2's.

Touches the five places `scripts/lint/lint-version.py` checks: the three version macros, the version comment in both headers, CMakeLists.txt, meson.build, and the namespace test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)