### PR TITLE
Make the benchmark honest, then make insert and erase faster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,10 +49,18 @@ Benchmarking practices:
 ## Where the time goes
 
 The u64 workloads are bound by branch mispredictions, the string workloads by the latency of a
-~250 instruction lookup of which the 200 byte hash is ~150, and a model of 16 cycles per
-misprediction plus instructions at ~3.5 per cycle predicts changes within a cycle or two. The
-measurements behind that, and the per-workload numbers, are in `scripts/ab/README.md` with the
-paired A/B harness that produced them.
+~224 instruction lookup of which the hash is ~60, and a model of 16 cycles per misprediction plus
+instructions at ~3.5 per cycle predicts changes within a cycle or two. The measurements behind
+that, and the per-workload numbers, are in `scripts/ab/README.md` with the paired A/B harness that
+produced them.
+
+**String keys must not all be the same length.** Until 2026-09-02 every string key of
+`bench_quick_overall_udm` was exactly 200 bytes. A hash dispatches on length, and one length makes
+that dispatch perfectly predictable: wyhash costs 0.31 branch mispredictions per hash on lengths
+spread over 4 to 200 bytes and 0.01 on a fixed length, so the benchmark could not see the
+difference. 200 bytes also put every key on the heap, where a real workload keeps a good share of
+them inside the `std::string`. The keys now run from 8 to 135 bytes, skewed towards short. Scores
+from before that change are not comparable with scores after it.
 
 **Lookup benchmarks must not replay.** Until 2026-09 the find workload of
 `bench_quick_overall_udm` reset its search rng to the insertion rng's seed, so its sequence of hits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,17 @@ difference. 200 bytes also put every key on the heap, where a real workload keep
 them inside the `std::string`. The keys now run from 8 to 135 bytes, skewed towards short. Scores
 from before that change are not comparable with scores after it.
 
+**Integer keys must not be small sequential values.** `insert_erase` and `iterate` draw their
+values from a range that grows to 20000, and until 2026-09-02 the value was the key. The hash of a
+`uint64_t` is one multiply, and the top bits of a multiple of a small integer walk a lattice: 10000
+such keys in 16384 buckets landed at most one to a bucket, with 39% of the buckets empty where a
+uniform hash leaves 54%. Nothing collided, so the probe never probed and the shifts never shifted
+-- 82% of erases moved nothing against 58% for the same values as strings -- and two changes to
+the shift loops read as losses on `ie64` that were wins on every honest table. The value is now
+scrambled through a 64 bit bijection before it becomes a key, so every checksum is as it was and
+`ie64` sees the same table `iestr` does. A benchmark that rewards a hash for the one input it is
+perfect on is measuring the input.
+
 **Inserting has to grow the table somewhere.** Until 2026-09-02 no workload in the score did.
 `insert_erase` draws its keys from a range that grows to 20000, so the map hovers at ~10k entries
 and doubles its bucket array about a dozen times in eight million operations. Growth is not a
@@ -109,9 +120,11 @@ The `bench_quick_overall_udm` hot paths are close to machine limits. Ideas that 
   conditional moves and one combined test does not help: written as `a == 0 || b == 0` it is still
   two branches, written as a bitwise or it is one branch that mispredicts just as often
   (0.608 per insert, ten more instructions). What did work is the vector version now in the
-  header, which settles four buckets from one mask -- the same trade the probe made. A two bucket
-  vector version was also tried and lost to it (49.7 against 46.3 cycles per insert): its second
-  slot is still a branch.
+  header, which settles four buckets from one mask -- the same trade the probe made, and the same
+  again for the shift down on erase. A two bucket vector version was also tried and lost to it
+  (49.7 against 46.3 cycles per insert): its second slot is still a branch. Both vector shifts
+  first read as ~1% *losses* on `ie64`, and that was the benchmark: its integer keys hashed to a
+  lattice with no chains to shift (see "Where the time goes"). With honest keys they are 1.07x.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Benchmarking practices:
 ## Where the time goes
 
 The u64 workloads are bound by branch mispredictions, the string workloads by the latency of a
-~224 instruction lookup of which the hash is ~60, and a model of 16 cycles per misprediction plus
+~167 instruction lookup of which the hash is ~59, and a model of 16 cycles per misprediction plus
 instructions at ~3.5 per cycle predicts changes within a cycle or two. The measurements behind
 that, and the per-workload numbers, are in `scripts/ab/README.md` with the paired A/B harness that
 produced them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,13 +98,20 @@ The `bench_quick_overall_udm` hot paths are close to machine limits. Ideas that 
   successful half of the erases move one, so the bound is ~7% of `iestr`, and it measured 1.4%
   for 4 bytes per element and a second container to keep consistent.
 - Caching the bucket data pointer in the shift loops (the compiler already hoists it).
-- Three attempts at the insert path, all measured against `build64` and `buildstr` (2026-09-02):
-  skipping the `memset` in `clear_and_fill_buckets_from_values`, which is redundant because
+- Two attempts at the rehash, measured against `build64` and `buildstr` (2026-09-02): skipping the
+  `memset` in `clear_and_fill_buckets_from_values`, which is redundant because
   `allocate_buckets_from_shift` hands back a freshly zeroed vector (0.7% on `build64`, ~1% *worse*
-  on `iestr`); hashing eight elements ahead in the rehash loop and prefetching the bucket each will
-  land in (nothing on `build64`, ~1% worse on `buildstr`); and settling the first two buckets of
-  `place_and_shift_up` without a branch, since 73% of inserts shift nothing and 11% shift one
-  (mispredictions 0.611 to 0.606 per insert, instructions 101.5 to 111.3, so it lost).
+  on `iestr`); and hashing eight elements ahead in the rehash loop and prefetching the bucket each
+  will land in (nothing on `build64`, ~1% worse on `buildstr`).
+- Scalar attempts to take the branch out of `place_and_shift_up`. The robin hood shift asks "is this
+  bucket occupied" once per bucket and the answer is a coin flip (73% of inserts shift nothing, 11%
+  shift one), which cost 0.61 mispredictions per insert. Settling the first two buckets with
+  conditional moves and one combined test does not help: written as `a == 0 || b == 0` it is still
+  two branches, written as a bitwise or it is one branch that mispredicts just as often
+  (0.608 per insert, ten more instructions). What did work is the vector version now in the
+  header, which settles four buckets from one mask -- the same trade the probe made. A two bucket
+  vector version was also tried and lost to it (49.7 against 46.3 cycles per insert): its second
+  slot is still a branch.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Warnings are errors (`werror=true`, `warning_level=3`, plus `-Wconversion`, `-Wo
 
 ## Benchmarking
 
-The main performance metric is `bench_quick_overall_udm`. It runs six nanobench benchmarks covering the most important primitives — iterate-while-modifying, random insert/erase, and random find (50% hit rate) — each for both `map<uint64_t, size_t>` and `map<std::string, size_t>`, then prints the geometric mean of the median elapsed times:
+The main performance metric is `bench_quick_overall_udm`. It runs eight nanobench benchmarks covering the most important primitives — iterate-while-modifying, random insert/erase, build-from-empty, and random find (50% hit rate) — each for both `map<uint64_t, size_t>` and `map<std::string, size_t>`, then prints the geometric mean of the median elapsed times:
 
 ```sh
 # benchmarks are marked doctest::skip(), so -ns (no-skip) is required
@@ -62,6 +62,14 @@ difference. 200 bytes also put every key on the heap, where a real workload keep
 them inside the `std::string`. The keys now run from 8 to 135 bytes, skewed towards short. Scores
 from before that change are not comparable with scores after it.
 
+**Inserting has to grow the table somewhere.** Until 2026-09-02 no workload in the score did.
+`insert_erase` draws its keys from a range that grows to 20000, so the map hovers at ~10k entries
+and doubles its bucket array about a dozen times in eight million operations. Growth is not a
+rounding error in general: building a map of a million entries costs 52% more than building the
+same map after `reserve` for `uint64_t` keys and 31% more for strings, all of it rehashing, so a
+map that grew badly would have scored the same as one that grew well. `build` covers it, and it
+showed at once that this is where the map is weakest -- see `scripts/ab/README.md`.
+
 **Lookup benchmarks must not replay.** Until 2026-09 the find workload of
 `bench_quick_overall_udm` reset its search rng to the insertion rng's seed, so its sequence of hits
 and misses repeated and a TAGE-style predictor learned much of it: 0.6 mispredictions per lookup
@@ -90,6 +98,13 @@ The `bench_quick_overall_udm` hot paths are close to machine limits. Ideas that 
   successful half of the erases move one, so the bound is ~7% of `iestr`, and it measured 1.4%
   for 4 bytes per element and a second container to keep consistent.
 - Caching the bucket data pointer in the shift loops (the compiler already hoists it).
+- Three attempts at the insert path, all measured against `build64` and `buildstr` (2026-09-02):
+  skipping the `memset` in `clear_and_fill_buckets_from_values`, which is redundant because
+  `allocate_buckets_from_shift` hands back a freshly zeroed vector (0.7% on `build64`, ~1% *worse*
+  on `iestr`); hashing eight elements ahead in the rehash loop and prefetching the bucket each will
+  land in (nothing on `build64`, ~1% worse on `buildstr`); and settling the first two buckets of
+  `place_and_shift_up` without a branch, since 73% of inserts shift nothing and 11% shift one
+  (mispredictions 0.611 to 0.606 per insert, instructions 101.5 to 111.3, so it lost).
 
 ## Testing
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -292,7 +292,13 @@ inline void mum(std::uint64_t* a, std::uint64_t* b) {
         ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
             std::uint64_t see1 = seed;
             std::uint64_t see2 = seed;
-            if (i > 96) {
+            // Six lanes cost three more accumulators to set up and fold back in, so the block
+            // has to run more than once to pay for them. Entering it at 96 meant exactly one
+            // iteration for everything from 97 to 192 bytes, which never can: measured, 23.4
+            // cycles for a 100 byte key against 21.8 when it takes the 48 byte loop instead, and
+            // 29.3 against 28.2 at 150. Above 192 the block runs at least twice and wins again --
+            // 143.5 cycles against 147.1 at 1000 bytes -- so it keeps those.
+            if (i > 192) {
                 // 6 independent lanes: twice the instruction level parallelism of the 48 byte loop below
                 std::uint64_t see3 = seed;
                 std::uint64_t see4 = seed;

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -278,58 +278,64 @@ inline void mum(std::uint64_t* a, std::uint64_t* b) {
             // ... and an empty input needs no branch of its own: it hashes whatever a and b were
             // declared with, which is the zero it has to be. Assigning it again here is what a
             // deletion sweep of this file kept pointing at.
+
+            // Return, rather than falling through to the same expression at the end of the
+            // function. Falling through makes seed, a and b values of two paths at once, and then
+            // the compiler cannot fold the constant seed of this one into the mix: measured, the
+            // short path costs 36 instructions that way and 24 this way.
+            return mix(secret[1] ^ len, mix(a ^ secret[1], b ^ seed));
         }
-    else {
-        std::size_t i = len;
-        if (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 48))
-            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
-                std::uint64_t see1 = seed;
-                std::uint64_t see2 = seed;
-                if (i > 96) {
-                    // 6 independent lanes: twice the instruction level parallelism of the 48 byte loop below
-                    std::uint64_t see3 = seed;
-                    std::uint64_t see4 = seed;
-                    std::uint64_t see5 = seed;
-                    do {
-                        seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
-                        see1 = mix(r8(p + 16) ^ secret[2], r8(p + 24) ^ see1);
-                        see2 = mix(r8(p + 32) ^ secret[3], r8(p + 40) ^ see2);
-                        see3 = mix(r8(p + 48) ^ secret[4], r8(p + 56) ^ see3);
-                        see4 = mix(r8(p + 64) ^ secret[5], r8(p + 72) ^ see4);
-                        see5 = mix(r8(p + 80) ^ secret[6], r8(p + 88) ^ see5);
-                        p += 96;
-                        i -= 96;
-                    } while (ANKERL_UNORDERED_DENSE_LIKELY(i > 96));
-                    seed ^= see3 ^ see4 ^ see5;
-                }
-                while (i > 48) {
+
+    // Anything longer, in blocks of 16 bytes, ending on the same expression as above.
+    std::size_t i = len;
+    if (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 48))
+        ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+            std::uint64_t see1 = seed;
+            std::uint64_t see2 = seed;
+            if (i > 96) {
+                // 6 independent lanes: twice the instruction level parallelism of the 48 byte loop below
+                std::uint64_t see3 = seed;
+                std::uint64_t see4 = seed;
+                std::uint64_t see5 = seed;
+                do {
                     seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
                     see1 = mix(r8(p + 16) ^ secret[2], r8(p + 24) ^ see1);
                     see2 = mix(r8(p + 32) ^ secret[3], r8(p + 40) ^ see2);
-                    p += 48;
-                    i -= 48;
-                }
-                seed ^= see1 ^ see2;
-                while (i > 16) {
-                    seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
-                    i -= 16;
-                    p += 16;
-                }
-
-                // the tail lane only depends on the input, not on seed, so it can execute in parallel
-                // with the lane loops above, and a single dependent mix finishes the hash
-                auto tail = mix(r8(p + i - 16) ^ secret[2], r8(p + i - 8) ^ secret[3]);
-                return mix(secret[1] ^ len, seed ^ tail);
+                    see3 = mix(r8(p + 48) ^ secret[4], r8(p + 56) ^ see3);
+                    see4 = mix(r8(p + 64) ^ secret[5], r8(p + 72) ^ see4);
+                    see5 = mix(r8(p + 80) ^ secret[6], r8(p + 88) ^ see5);
+                    p += 96;
+                    i -= 96;
+                } while (ANKERL_UNORDERED_DENSE_LIKELY(i > 96));
+                seed ^= see3 ^ see4 ^ see5;
             }
-        while (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 16))
-            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+            while (i > 48) {
+                seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
+                see1 = mix(r8(p + 16) ^ secret[2], r8(p + 24) ^ see1);
+                see2 = mix(r8(p + 32) ^ secret[3], r8(p + 40) ^ see2);
+                p += 48;
+                i -= 48;
+            }
+            seed ^= see1 ^ see2;
+            while (i > 16) {
                 seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
                 i -= 16;
                 p += 16;
             }
-        a = r8(p + i - 16);
-        b = r8(p + i - 8);
-    }
+
+            // the tail lane only depends on the input, not on seed, so it can execute in parallel
+            // with the lane loops above, and a single dependent mix finishes the hash
+            auto tail = mix(r8(p + i - 16) ^ secret[2], r8(p + i - 8) ^ secret[3]);
+            return mix(secret[1] ^ len, seed ^ tail);
+        }
+    while (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 16))
+        ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+            seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
+            i -= 16;
+            p += 16;
+        }
+    a = r8(p + i - 16);
+    b = r8(p + i - 8);
 
     return mix(secret[1] ^ len, mix(a ^ secret[1], b ^ seed));
 }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1346,6 +1346,62 @@ private:
     void place_and_shift_up(Bucket bucket, value_idx_type place) {
         // cache mask in a local so the bucket stores can't alias it
         auto const mask = m_bucket_mask;
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+        // NOLINTBEGIN(portability-simd-intrinsics) -- this is the x86 path, on purpose
+        if constexpr (has_simd_scan) {
+            // Four buckets at once, the way the probe reads them.
+            //
+            // Whether a bucket is occupied is a coin flip -- measured over 8 million inserts into a
+            // table at its load factor, 73% shift nothing, 11% shift one, and the rest tail off --
+            // and the loop below asks it once per bucket, so it paid 0.61 mispredictions per
+            // insert. Here the four answers arrive as one mask: the contents are built as if every
+            // bucket moved one along, and a blend keeps that for the run of occupied buckets plus
+            // the empty one it ends in, and the old contents beyond. No decision per bucket; the
+            // one branch left is "did the run end inside these four", which it does 91% of the
+            // time. The loop takes the rest, and the last three buckets before the sentinels, so
+            // that the four wide store never touches a sentinel. That bound is hygiene rather than
+            // correctness, and a mutation sweep says so: with it wrong in every way, a sentinel in
+            // the window reads as occupied and is written back as it was, and the three of them
+            // are exactly enough padding for the window. Measured: 0.24 mispredictions and 46
+            // cycles per insert where the loop alone cost 52, and build64 10% faster.
+            if (ANKERL_UNORDERED_DENSE_LIKELY(std::size_t{place} + 3 <= mask)) {
+                auto* gp = m_buckets.data() + place;
+                auto lo = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp));     // NOLINT
+                auto hi = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 2)); // NOLINT
+                auto const dists = _mm_castps_si128(
+                    _mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(2, 0, 2, 0)));
+                auto const empty = static_cast<unsigned>(
+                    _mm_movemask_ps(_mm_castsi128_ps(_mm_cmpeq_epi32(dists, _mm_setzero_si128()))));
+                if (ANKERL_UNORDERED_DENSE_LIKELY(empty != 0)) {
+                    // how many occupied buckets come before the first empty one: 0 to 3
+                    auto const run = detail::countr_zero(empty);
+                    auto const inc = static_cast<int>(Bucket::dist_inc);
+                    static_assert(sizeof(Bucket) == 8);
+                    auto const fresh = _mm_loadl_epi64(reinterpret_cast<__m128i const*>(&bucket)); // NOLINT
+                    // [bucket, b0] and [b1, b2], each moved bucket one distance further from home
+                    auto const moved_lo =
+                        _mm_add_epi32(_mm_or_si128(_mm_slli_si128(lo, 8), fresh), _mm_setr_epi32(0, 0, inc, 0));
+                    auto const moved_hi = _mm_add_epi32(_mm_or_si128(_mm_slli_si128(hi, 8), _mm_srli_si128(lo, 8)),
+                                                        _mm_setr_epi32(inc, 0, inc, 0));
+                    // buckets 0..run take the moved contents, the rest keep theirs
+                    alignas(16) static constexpr std::int32_t keep[4][8] = {
+                        {-1, -1, 0, 0, 0, 0, 0, 0},
+                        {-1, -1, -1, -1, 0, 0, 0, 0},
+                        {-1, -1, -1, -1, -1, -1, 0, 0},
+                        {-1, -1, -1, -1, -1, -1, -1, -1},
+                    };
+                    auto const keep_lo = _mm_load_si128(reinterpret_cast<__m128i const*>(&keep[run][0])); // NOLINT
+                    auto const keep_hi = _mm_load_si128(reinterpret_cast<__m128i const*>(&keep[run][4])); // NOLINT
+                    lo = _mm_or_si128(_mm_and_si128(keep_lo, moved_lo), _mm_andnot_si128(keep_lo, lo));
+                    hi = _mm_or_si128(_mm_and_si128(keep_hi, moved_hi), _mm_andnot_si128(keep_hi, hi));
+                    _mm_storeu_si128(reinterpret_cast<__m128i*>(gp), lo);     // NOLINT
+                    _mm_storeu_si128(reinterpret_cast<__m128i*>(gp + 2), hi); // NOLINT
+                    return;
+                }
+            }
+        }
+        // NOLINTEND(portability-simd-intrinsics)
+#    endif
         while (0 != at(m_buckets, place).m_dist_and_fingerprint) {
             bucket = std::exchange(at(m_buckets, place), bucket);
             bucket.m_dist_and_fingerprint = dist_inc(bucket.m_dist_and_fingerprint);

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1414,6 +1414,59 @@ private:
     void erase_and_shift_down(value_idx_type bucket_idx) {
         // cache mask in a local so the bucket stores can't alias it
         auto const mask = m_bucket_mask;
+#    if ANKERL_UNORDERED_DENSE_HAS_SSE2
+        // NOLINTBEGIN(portability-simd-intrinsics) -- this is the x86 path, on purpose
+        if constexpr (has_simd_scan) {
+            // The mirror of place_and_shift_up: the four buckets after the one being erased, read
+            // at once. A bucket moves back one if it is displaced, that is at distance two or
+            // more; the run of displaced buckets after the victim all move back by one, and the
+            // slot where the run ends becomes the empty one. Measured, the run is empty 73% of
+            // the time and one long 11%, so asking per bucket was a coin flip per erase.
+            //
+            // The bound keeps the four wide store off the sentinels. As with the insert, a
+            // mutation sweep found it is hygiene and not correctness: a sentinel inside the
+            // window reads as displaced, which only ever sends the erase to the loop below.
+            if (ANKERL_UNORDERED_DENSE_LIKELY(std::size_t{bucket_idx} + 4 <= mask)) {
+                auto* gp = m_buckets.data() + bucket_idx;
+                auto const rlo = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 1)); // NOLINT  [b1, b2]
+                auto const rhi = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 3)); // NOLINT  [b3, b4]
+                auto const dists =
+                    _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(rlo), _mm_castsi128_ps(rhi), _MM_SHUFFLE(2, 0, 2, 0)));
+                // at home or empty: distance below two, which is the value below 2 * dist_inc
+                static_assert(Bucket::dist_inc == (1U << 8U));
+                auto const settled = static_cast<unsigned>(
+                    _mm_movemask_ps(_mm_castsi128_ps(_mm_cmpeq_epi32(_mm_srli_epi32(dists, 9), _mm_setzero_si128()))));
+                if (ANKERL_UNORDERED_DENSE_LIKELY(settled != 0)) {
+                    auto const run = detail::countr_zero(settled); // displaced buckets after the victim, 0..3
+                    auto const inc = static_cast<int>(Bucket::dist_inc);
+                    // every bucket one closer to home, in the victim's window
+                    auto const moved_lo = _mm_sub_epi32(rlo, _mm_setr_epi32(inc, 0, inc, 0));
+                    auto const moved_hi = _mm_sub_epi32(rhi, _mm_setr_epi32(inc, 0, inc, 0));
+                    // what the window holds now, for the buckets past the run: [victim, b1] and [b2, b3]
+                    auto const old_lo = _mm_slli_si128(rlo, 8);
+                    auto const old_hi = _mm_or_si128(_mm_slli_si128(rhi, 8), _mm_srli_si128(rlo, 8));
+                    // buckets below run move, the one at run empties, the ones above stay
+                    alignas(16) static constexpr std::array<std::array<std::int32_t, 8>, 5> below = {
+                        { {{0, 0, 0, 0, 0, 0, 0, 0}},
+                          {{-1, -1, 0, 0, 0, 0, 0, 0}},
+                          {{-1, -1, -1, -1, 0, 0, 0, 0}},
+                          {{-1, -1, -1, -1, -1, -1, 0, 0}},
+                          {{-1, -1, -1, -1, -1, -1, -1, -1}},
+                        }};
+                    auto const take_lo = _mm_load_si128(reinterpret_cast<__m128i const*>(below[run].data()));         // NOLINT
+                    auto const take_hi = _mm_load_si128(reinterpret_cast<__m128i const*>(below[run].data() + 4));     // NOLINT
+                    auto const gone_lo = _mm_load_si128(reinterpret_cast<__m128i const*>(below[run + 1].data()));     // NOLINT
+                    auto const gone_hi = _mm_load_si128(reinterpret_cast<__m128i const*>(below[run + 1].data() + 4)); // NOLINT
+                    auto const lo = _mm_or_si128(_mm_and_si128(take_lo, moved_lo), _mm_andnot_si128(gone_lo, old_lo));
+                    auto const hi = _mm_or_si128(_mm_and_si128(take_hi, moved_hi), _mm_andnot_si128(gone_hi, old_hi));
+                    _mm_storeu_si128(reinterpret_cast<__m128i*>(gp), lo);     // NOLINT
+                    _mm_storeu_si128(reinterpret_cast<__m128i*>(gp + 2), hi); // NOLINT
+                    return;
+                }
+            }
+        }
+        // NOLINTEND(portability-simd-intrinsics)
+#    endif
 
         // shift down until either empty or an element with correct spot is found
         auto next_bucket_idx = static_cast<value_idx_type>((bucket_idx + 1U) & mask);

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1368,10 +1368,10 @@ private:
                 auto* gp = m_buckets.data() + place;
                 auto lo = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp));     // NOLINT
                 auto hi = _mm_loadu_si128(reinterpret_cast<__m128i const*>(gp + 2)); // NOLINT
-                auto const dists = _mm_castps_si128(
-                    _mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(2, 0, 2, 0)));
-                auto const empty = static_cast<unsigned>(
-                    _mm_movemask_ps(_mm_castsi128_ps(_mm_cmpeq_epi32(dists, _mm_setzero_si128()))));
+                auto const dists =
+                    _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(2, 0, 2, 0)));
+                auto const empty =
+                    static_cast<unsigned>(_mm_movemask_ps(_mm_castsi128_ps(_mm_cmpeq_epi32(dists, _mm_setzero_si128()))));
                 if (ANKERL_UNORDERED_DENSE_LIKELY(empty != 0)) {
                     // how many occupied buckets come before the first empty one: 0 to 3
                     auto const run = detail::countr_zero(empty);
@@ -1384,14 +1384,15 @@ private:
                     auto const moved_hi = _mm_add_epi32(_mm_or_si128(_mm_slli_si128(hi, 8), _mm_srli_si128(lo, 8)),
                                                         _mm_setr_epi32(inc, 0, inc, 0));
                     // buckets 0..run take the moved contents, the rest keep theirs
-                    alignas(16) static constexpr std::int32_t keep[4][8] = {
-                        {-1, -1, 0, 0, 0, 0, 0, 0},
-                        {-1, -1, -1, -1, 0, 0, 0, 0},
-                        {-1, -1, -1, -1, -1, -1, 0, 0},
-                        {-1, -1, -1, -1, -1, -1, -1, -1},
-                    };
-                    auto const keep_lo = _mm_load_si128(reinterpret_cast<__m128i const*>(&keep[run][0])); // NOLINT
-                    auto const keep_hi = _mm_load_si128(reinterpret_cast<__m128i const*>(&keep[run][4])); // NOLINT
+                    // rows are 32 bytes, so with the table aligned both halves of every row are
+                    alignas(16) static constexpr std::array<std::array<std::int32_t, 8>, 4> keep = {
+                        { {{-1, -1, 0, 0, 0, 0, 0, 0}},
+                          {{-1, -1, -1, -1, 0, 0, 0, 0}},
+                          {{-1, -1, -1, -1, -1, -1, 0, 0}},
+                          {{-1, -1, -1, -1, -1, -1, -1, -1}},
+                        }};
+                    auto const keep_lo = _mm_load_si128(reinterpret_cast<__m128i const*>(keep[run].data()));     // NOLINT
+                    auto const keep_hi = _mm_load_si128(reinterpret_cast<__m128i const*>(keep[run].data() + 4)); // NOLINT
                     lo = _mm_or_si128(_mm_and_si128(keep_lo, moved_lo), _mm_andnot_si128(keep_lo, lo));
                     hi = _mm_or_si128(_mm_and_si128(keep_hi, moved_hi), _mm_andnot_si128(keep_hi, hi));
                     _mm_storeu_si128(reinterpret_cast<__m128i*>(gp), lo);     // NOLINT

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -51,23 +51,29 @@ Numbers from that session, paired against main (ms; boost for scale). The string
 ## Where inserting stands (2026-09-02)
 
 `build64` is the weakest workload the score has, and it was added because nothing in the score grew
-a table. Paired against `boost::unordered_flat_map` with the same hash:
+a table. Paired against `boost::unordered_flat_map` with the same hash, before and after the vector
+shift in `place_and_shift_up`:
 
-| workload | unordered_dense | boost |
-|---|---|---|
-| build64 | 6.65 ms | **4.70 ms** |
-| buildstr | **11.25 ms** | 13.91 ms |
-| ie64 | 15.46 M op/s | **17.76 M op/s** |
-| iestr | 4.52 M op/s | **5.17 M op/s** |
+| workload | before | after | boost |
+|---|---|---|---|
+| build64 | 6.62 ms | **6.02 ms** | 4.66 ms |
+| buildstr | 11.14 ms | **10.64 ms** | 13.24 ms |
+| ie64 | 15.14 M op/s | 15.14 M op/s | 17.90 M op/s |
+| iestr | 4.54 M op/s | 4.60 M op/s | 5.17 M op/s |
 
 Growth is not the whole of it. Inserting 200000 `uint64_t` keys into a table that already reserved
-the room costs 52.4 cycles and 101.5 instructions here against boost's 22.6 and 73.5, and the
-difference is **0.611 branch mispredictions per insert against 0.097**. They come from the robin
+the room cost 52.4 cycles and 101.5 instructions here against boost's 22.6 and 73.5, and the
+difference was **0.61 branch mispredictions per insert against 0.10**. They came from the robin
 hood shift: measured over 8 million inserts, 73% shift no bucket, 11% shift one, and the rest
-spread out, so "is this bucket occupied" is a coin flip the predictor cannot win. boost does not
-shift at all -- it never moves an element once placed -- so this is the price of the distance
-ordering rather than something to tune away. Settling the first two buckets without a branch was
-tried and lost; see the dead ends in CLAUDE.md.
+spread out, so "is this bucket occupied", asked once per bucket, is a coin flip the predictor
+cannot win. boost never moves an element once placed.
+
+The vector shift asks it once for four buckets and blends the answer, the same trade the probe
+made: 0.24 mispredictions and 46.3 cycles per insert, for 126 instructions. That is why `ie64`
+does not move -- its map is small and often under its load factor, so fewer inserts shift at all
+and the extra instructions cost what the mispredictions saved. What is left of the gap to boost is
+the second container and the shifting itself; see the dead ends in CLAUDE.md for what did not
+work on it.
 
 `perf stat -e cycles,instructions,branch-misses` on a single-workload runner is what separates
 "more instructions" from "more mispredictions"; `perf record -e cycles:pp` for annotate.

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -21,13 +21,19 @@ working set of the benchmark sits in L2.
   so the *position* of a hit leaked into the branch pattern; on random lookups that was 1.35
   mispredictions per lookup, against 0.42 for boost's grouped scan. The SSE2 probe makes the
   outcome one data-dependent branch regardless of position: 0.70, and 35-80% faster.
-- **String workloads are latency bound.** At ~224 instructions and ~116 cycles per lookup the
+- **String workloads are latency bound.** At ~167 instructions and ~110 cycles per lookup the
   reorder buffer holds barely one lookup, so anything on the dependency chain shows directly. The
   vector decision (`movmskps` → `tzcnt` → index load) adds ~10 cycles before the value load can
   issue where the scalar path's predicted branch let it issue at once.
-- **Hashing is 32-35% of the string workloads**, measured against an 8 byte hash of the same keys:
-  findstr 261 → 170 ms, iestr 252 → 172 ms. That is ~60 of the 224 instructions and ~41 of the
-  116 cycles, for keys averaging ~50 bytes.
+- **Hashing is 33-38% of the string workloads**, measured against an 8 byte hash of the same keys:
+  findstr 167 → 108 instructions and 110 → 68 cycles, iestr 187 → 121 and 120 → 80. Keys average
+  ~50 bytes.
+- **`hashstr` resolves a large change and not a small one.** It is a tight loop with nothing else
+  in it, so which of the two hashes the A/B builds gets the better code layout matters more than a
+  few percent of hashing. For the six-lane threshold it reported 1.01x *slower* twice, where the
+  same two headers in separate binaries came out 2.6% faster in five pairs of five and `findstr`
+  and `iestr` both resolved 1.01-1.02x faster. It resolved the short-path return, which was 5%,
+  cleanly. Check a small change against the map workloads.
 
 Numbers from that session, paired against main (ms; boost for scale). The string rows predate
 2026-09-02: they were measured when every string key was 200 bytes, and the keys now run from 8 to

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -48,32 +48,37 @@ Numbers from that session, paired against main (ms; boost for scale). The string
 | rhit64 | 145 | 80 | 50 |
 | rmiss64 | 48 | 35 | 28 |
 
-## Where inserting stands (2026-09-02)
+## Where inserting and erasing stand (2026-09-02)
 
 `build64` is the weakest workload the score has, and it was added because nothing in the score grew
-a table. Paired against `boost::unordered_flat_map` with the same hash, before and after the vector
-shift in `place_and_shift_up`:
+a table. Paired against `boost::unordered_flat_map` with the same hash, before the two vector
+shifts in `place_and_shift_up` and `erase_and_shift_down` and after, with the integer keys
+scrambled (see CLAUDE.md: the old ones hashed to a lattice and had nothing to shift):
 
 | workload | before | after | boost |
 |---|---|---|---|
-| build64 | 6.62 ms | **6.02 ms** | 4.66 ms |
-| buildstr | 11.14 ms | **10.64 ms** | 13.24 ms |
-| ie64 | 15.14 M op/s | 15.14 M op/s | 17.90 M op/s |
-| iestr | 4.54 M op/s | 4.60 M op/s | 5.17 M op/s |
+| build64 | 6.88 ms | **6.14 ms** | 4.83 ms |
+| buildstr | 11.26 ms | **10.66 ms** | 13.36 ms |
+| ie64 | 10.79 M op/s | **11.61 M op/s** | 13.89 M op/s |
+| iestr | 4.53 M op/s | **4.70 M op/s** | 5.19 M op/s |
 
 Growth is not the whole of it. Inserting 200000 `uint64_t` keys into a table that already reserved
 the room cost 52.4 cycles and 101.5 instructions here against boost's 22.6 and 73.5, and the
-difference was **0.61 branch mispredictions per insert against 0.10**. They came from the robin
-hood shift: measured over 8 million inserts, 73% shift no bucket, 11% shift one, and the rest
-spread out, so "is this bucket occupied", asked once per bucket, is a coin flip the predictor
-cannot win. boost never moves an element once placed.
+difference was **0.61 branch mispredictions per insert against 0.10**; erasing them again cost
+63.6 cycles and 0.60 mispredictions against boost's 25.0 and 0.10. Both came from the robin hood
+shift. Measured over 8 million of each, 73% shift no bucket, 11% shift one, and the rest spread
+out, so "is this bucket occupied", asked once per bucket, is a coin flip the predictor cannot win.
+boost never moves an element once placed.
 
-The vector shift asks it once for four buckets and blends the answer, the same trade the probe
-made: 0.24 mispredictions and 46.3 cycles per insert, for 126 instructions. That is why `ie64`
-does not move -- its map is small and often under its load factor, so fewer inserts shift at all
-and the extra instructions cost what the mispredictions saved. What is left of the gap to boost is
-the second container and the shifting itself; see the dead ends in CLAUDE.md for what did not
-work on it.
+The vector shifts ask it once for four buckets and blend the answer, the same trade the probe
+made: 0.24 mispredictions and 46.3 cycles per insert for 126 instructions, 0.26 and 54.5 per erase
+for 133. The gain grows as the table gets more chains to shift, and on a table erased from full to
+empty it is 27% at 10000 entries and 7% at 200000. What is left of the gap to boost is the second
+container and the shifting itself; see the dead ends in CLAUDE.md for what did not work on it.
+
+A harness that erases the same keys in the same order every repetition reports 0.003
+mispredictions per erase and no gain from any of this: the predictor learns the order. Shuffle per
+repetition.
 
 `perf stat -e cycles,instructions,branch-misses` on a single-workload runner is what separates
 "more instructions" from "more mispredictions"; `perf record -e cycles:pp` for annotate.

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -7,7 +7,8 @@ renamed into a second namespace -- and runs nanobench's `compare()`: the alterna
 interleaved in the same slice of time, so drift cancels out of the ratios, and the interval it
 prints is about the ratio. `-b` adds `boost::unordered_flat_map` (needs its headers). The
 workloads are `test/bench/workloads.h`, the ones `bench_quick_overall_udm` scores, plus all-hits
-and no-hits lookups. Believe a change when the interval excludes 100%.
+and no-hits lookups. Its string keys run from 8 to 135 bytes, skewed towards short; a fixed length
+would leave the length dispatch of the hash perfectly predicted. Believe a change when the interval excludes 100%.
 
 ## What the hot paths are bound by (Ryzen 9 7950X, clang 22, default `-march`, 2026-09)
 
@@ -20,23 +21,24 @@ working set of the benchmark sits in L2.
   so the *position* of a hit leaked into the branch pattern; on random lookups that was 1.35
   mispredictions per lookup, against 0.42 for boost's grouped scan. The SSE2 probe makes the
   outcome one data-dependent branch regardless of position: 0.70, and 35-80% faster.
-- **String workloads are latency bound.** At ~250 instructions per lookup -- ~150 of them the
-  200 byte wyhash -- the reorder buffer holds barely one lookup, so anything on the dependency
-  chain shows directly. The vector decision (`movmskps` → `tzcnt` → index load) adds ~10 cycles
-  before the value load can issue where the scalar path's predicted branch let it issue at once.
-- **Hashing is 42-45% of the string workloads**, at ~40 cycles per 200 byte key: 0.5 uops per
-  byte, nothing to do with multiply count. With a trivial 8 byte hash, insert/erase time equals
-  boost's exactly -- the rest of the gap there is that a robin hood erase hashes the moved last
-  element too (only the successful half of the erases, so at most ~7% of that workload).
+- **String workloads are latency bound.** At ~224 instructions and ~116 cycles per lookup the
+  reorder buffer holds barely one lookup, so anything on the dependency chain shows directly. The
+  vector decision (`movmskps` → `tzcnt` → index load) adds ~10 cycles before the value load can
+  issue where the scalar path's predicted branch let it issue at once.
+- **Hashing is 32-35% of the string workloads**, measured against an 8 byte hash of the same keys:
+  findstr 261 → 170 ms, iestr 252 → 172 ms. That is ~60 of the 224 instructions and ~41 of the
+  116 cycles, for keys averaging ~50 bytes.
 
-Numbers from that session, paired against main (ms; boost for scale):
+Numbers from that session, paired against main (ms; boost for scale). The string rows predate
+2026-09-02: they were measured when every string key was 200 bytes, and the keys now run from 8 to
+135. The u64 rows are unaffected.
 
 | workload | main | SSE2 probe | boost |
 |---|---|---|---|
 | find64 | 78.6 | 48.0 | 40.1 |
-| findstr | 218 | 210 | 182 |
+| findstr (200 byte keys) | 218 | 210 | 182 |
 | ie64 | 62.0 | 65.3 | 57.1 |
-| iestr | 226 | 212 | 188 |
+| iestr (200 byte keys) | 226 | 212 | 188 |
 | rhit64 | 145 | 80 | 50 |
 | rmiss64 | 48 | 35 | 28 |
 

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -48,5 +48,26 @@ Numbers from that session, paired against main (ms; boost for scale). The string
 | rhit64 | 145 | 80 | 50 |
 | rmiss64 | 48 | 35 | 28 |
 
+## Where inserting stands (2026-09-02)
+
+`build64` is the weakest workload the score has, and it was added because nothing in the score grew
+a table. Paired against `boost::unordered_flat_map` with the same hash:
+
+| workload | unordered_dense | boost |
+|---|---|---|
+| build64 | 6.65 ms | **4.70 ms** |
+| buildstr | **11.25 ms** | 13.91 ms |
+| ie64 | 15.46 M op/s | **17.76 M op/s** |
+| iestr | 4.52 M op/s | **5.17 M op/s** |
+
+Growth is not the whole of it. Inserting 200000 `uint64_t` keys into a table that already reserved
+the room costs 52.4 cycles and 101.5 instructions here against boost's 22.6 and 73.5, and the
+difference is **0.611 branch mispredictions per insert against 0.097**. They come from the robin
+hood shift: measured over 8 million inserts, 73% shift no bucket, 11% shift one, and the rest
+spread out, so "is this bucket occupied" is a coin flip the predictor cannot win. boost does not
+shift at all -- it never moves an element once placed -- so this is the price of the distance
+ordering rather than something to tune away. Settling the first two buckets without a branch was
+tried and lost; see the dead ends in CLAUDE.md.
+
 `perf stat -e cycles,instructions,branch-misses` on a single-workload runner is what separates
 "more instructions" from "more mispredictions"; `perf record -e cycles:pp` for annotate.

--- a/scripts/ab/ab.cpp
+++ b/scripts/ab/ab.cpp
@@ -83,6 +83,12 @@ struct find_50 {
     }
 };
 template <typename Map>
+struct hash_strings {
+    static auto run() {
+        return workloads::hash_strings<Map>();
+    }
+};
+template <typename Map>
 struct find_hits {
     static auto run() {
         return workloads::find_all<Map, true>();
@@ -101,7 +107,8 @@ auto main(int argc, char** argv) -> int {
     if (argc < 2) {
         std::printf("usage: %s <workload|all> [epochs=12] [boost=0]\n"
                     "workloads: it64 ie64 find64 itstr iestr findstr (bench_quick_overall_udm)\n"
-                    "           rhit64 rmiss64 rhitstr rmissstr (all hits / no hits)\n",
+                    "           rhit64 rmiss64 rhitstr rmissstr (all hits / no hits)\n"
+                    "           hashstr (the string hash on its own)\n",
                     argv[0]);
         return 1;
     }
@@ -133,5 +140,6 @@ auto main(int argc, char** argv) -> int {
     U64("rmiss64", find_misses);
     STR("rhitstr", find_hits);
     STR("rmissstr", find_misses);
+    STR("hashstr", hash_strings);
     return 0;
 }

--- a/scripts/ab/ab.cpp
+++ b/scripts/ab/ab.cpp
@@ -77,6 +77,12 @@ struct insert_erase {
     }
 };
 template <typename Map>
+struct build {
+    static auto run() {
+        return workloads::build<Map>();
+    }
+};
+template <typename Map>
 struct find_50 {
     static auto run() {
         return workloads::find_50<Map>();
@@ -106,7 +112,8 @@ struct find_misses {
 auto main(int argc, char** argv) -> int {
     if (argc < 2) {
         std::printf("usage: %s <workload|all> [epochs=12] [boost=0]\n"
-                    "workloads: it64 ie64 find64 itstr iestr findstr (bench_quick_overall_udm)\n"
+                    "workloads: it64 ie64 build64 find64 itstr iestr buildstr findstr\n"
+                    "           (bench_quick_overall_udm)\n"
                     "           rhit64 rmiss64 rhitstr rmissstr (all hits / no hits)\n"
                     "           hashstr (the string hash on its own)\n",
                     argv[0]);
@@ -132,9 +139,11 @@ auto main(int argc, char** argv) -> int {
     compare<workload, base_str, cand_str, boost_str>(name, epochs, boost)
     U64("it64", iterate);
     U64("ie64", insert_erase);
+    U64("build64", build);
     U64("find64", find_50);
     STR("itstr", iterate);
     STR("iestr", insert_erase);
+    STR("buildstr", build);
     STR("findstr", find_50);
     U64("rhit64", find_hits);
     U64("rmiss64", find_misses);

--- a/test/bench/quick_overall_map.cpp
+++ b/test/bench/quick_overall_map.cpp
@@ -2,7 +2,7 @@
 
 #include <app/doctest.h>           // for TestCase, skip, ResultBuilder
 #include <app/geomean.h>           // for geomean
-#include <bench/workloads.h>       // for insert_erase, iterate, find_50, find_all
+#include <bench/workloads.h>       // for insert_erase, iterate, find_50, find_all, hash_strings
 #include <third-party/nanobench.h> // for Bench
 
 #include <fmt/format.h> // for print, format
@@ -134,6 +134,17 @@ TEST_CASE("bench_find_all_hits_or_misses_udm" * doctest::test_suite("bench") * d
     });
     bench.run("map<std::string, size_t> no hits", [] {
         ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_str_t, false>());
+    });
+}
+
+// The string hash on its own; not part of the score. A lookup is ~224 instructions and only ~60
+// of them are the hash, so a change to the hash is easier to resolve here than in the score.
+TEST_CASE("bench_hash_string_udm" * doctest::test_suite("bench") * doctest::skip()) {
+    ankerl::nanobench::Bench bench;
+    bench.title("hash").minEpochTime(100ms).unit("hash").batch(workloads::hash_keys().size());
+    using map_str_t = ankerl::unordered_dense::map<std::string, size_t, hash_str_t>;
+    bench.run("map<std::string, size_t> hash only", [] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::hash_strings<map_str_t>());
     });
 }
 

--- a/test/bench/quick_overall_map.cpp
+++ b/test/bench/quick_overall_map.cpp
@@ -2,7 +2,7 @@
 
 #include <app/doctest.h>           // for TestCase, skip, ResultBuilder
 #include <app/geomean.h>           // for geomean
-#include <bench/workloads.h>       // for insert_erase, iterate, find_50, find_all, hash_strings
+#include <bench/workloads.h>       // for insert_erase, iterate, build, find_50, find_all, hash_strings
 #include <third-party/nanobench.h> // for Bench
 
 #include <fmt/format.h> // for print, format
@@ -36,6 +36,13 @@ void bench_iterate(ankerl::nanobench::Bench* bench, std::string_view name) {
 }
 
 template <typename Map>
+void bench_build(ankerl::nanobench::Bench* bench, std::string_view name) {
+    bench->run(fmt::format("{} build from empty", name), [&] {
+        CHECK(workloads::build<Map>() == 200000U);
+    });
+}
+
+template <typename Map>
 void bench_random_find(ankerl::nanobench::Bench* bench, std::string_view name) {
     bench->run(fmt::format("{} 50% probability to find", name), [&] {
         CHECK(workloads::find_50<Map>() == 124865472559U);
@@ -48,6 +55,7 @@ void bench_all(ankerl::nanobench::Bench* bench, std::string_view name) {
     bench->minEpochTime(100ms);
     bench_iterate<Map>(bench, name);
     bench_random_insert_erase<Map>(bench, name);
+    bench_build<Map>(bench, name);
     bench_random_find<Map>(bench, name);
 }
 

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -50,7 +50,18 @@ inline constexpr std::string_view key_filler =
 // workload here uses a key and is done with it.
 template <typename K>
 struct key_source {
+    // Not the value itself. insert_erase and iterate draw their values from a small range, and
+    // the hash of a small sequential integer is a multiply, whose top bits walk a lattice: 10000
+    // of them in 16384 buckets landed at most one to a bucket, with 39% of buckets empty where a
+    // uniform hash leaves 54%. In that table nothing ever collides, so the probe never probes and
+    // the shifts never shift -- 82% of erases moved nothing against 58% for the same values as
+    // strings -- and the cost of both was invisible. A real integer key is as often an id from
+    // somewhere else as a counter, so scramble it: xor-shift between two multiplies is a bijection
+    // on 64 bits, which keeps every value distinct and every checksum exactly what it was.
     [[nodiscard]] static auto get(uint64_t v) -> K {
+        v *= UINT64_C(0x9E3779B97F4A7C15);
+        v ^= v >> 29U;
+        v *= UINT64_C(0xBF58476D1CE4E5B9);
         return static_cast<K>(v);
     }
 };

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -59,7 +59,9 @@ inline void set_key(uint64_t v, std::string* key) {
     static_assert(key_filler.size() >= max_key_len);
     // Square a byte of a mixed value: uniform in, skewed towards short out.
     auto const spread = (v * UINT64_C(0x9E3779B97F4A7C15)) >> 56U;
-    auto const len = min_key_len + ((spread * spread) >> 9U);
+    // At most 8 + 127, so the cast to size_t cannot lose anything, and size_t is what a
+    // 32 bit std::string takes.
+    auto const len = min_key_len + static_cast<size_t>((spread * spread) >> 9U);
     key->assign(key_filler.data(), len);
     std::memcpy(key->data(), &v, sizeof(v));
 }

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -221,10 +221,14 @@ inline auto hash_keys() -> std::vector<std::string> const& {
 
 // Hashing alone, over the keys the string workloads use.
 //
-// A whole lookup is ~224 instructions and only ~60 of them are the hash, and a hash change that
+// A whole lookup is ~167 instructions and only ~59 of them are the hash, and a hash change that
 // touches one length range is diluted further by the share of keys in it. This makes the hash the
 // whole measurement instead. The keys are built before the loop, so what is timed is hashing and
 // not the making of a key.
+//
+// It resolves a large change and not a small one. A loop this tight with nothing else in it is
+// more sensitive to code layout than to a few percent of hashing, and the A/B harness builds two
+// of them. See the note in scripts/ab/README.md before believing a small result here.
 template <typename Map>
 auto hash_strings() -> uint64_t {
     typename Map::hasher const hash{};

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace workloads {
@@ -18,20 +19,48 @@ inline auto init_key() -> K {
     return {};
 }
 
+// How long a string key is.
+//
+// Real string keys are identifiers, field names or paths. Most of them are short, a few are long,
+// and no workload has them all the same length. Until 2026-09 every string key here was exactly
+// 200 bytes, and that hid two things at once: the length dispatch of the hash was perfectly
+// predicted, and every key went on the heap because none of them fit a std::string.
+//
+// The lengths below run from 8 to 135 bytes, skewed towards short: about a quarter are 16 bytes
+// or less, a third are 17 to 48, a quarter are 49 to 96 and a sixth are longer. That covers every
+// path the hash has, weighted the way a real workload weighs them, and a quarter of the keys are
+// short enough to live inside the std::string.
+inline constexpr size_t min_key_len = 8; // room for the whole value, so keys stay distinct
+inline constexpr size_t max_key_len = 135;
+
+// What a string key is made of.
+//
+// Only the length changes what a lookup costs. Neither the hash nor the comparison is faster or
+// slower for one byte value than another, so the filler is a fixed string and the value goes in
+// the first 8 bytes. Two different values give two different keys, which is what every workload
+// here relies on.
+inline constexpr std::string_view key_filler =
+    "service.name/attribute.count/http.status_code/db.query.duration_ms/net.peer.address.family/"
+    "process.runtime.description/log.record.uid/k8s.pod.namespace";
+
 template <>
 inline auto init_key<std::string>() -> std::string {
     std::string str;
-    str.resize(200);
+    str.reserve(max_key_len); // once, so that set_key never has to allocate again
     return str;
 }
 
-// the first 8 bytes of a string key carry the value; the rest stays zero
 template <typename T>
 inline void set_key(uint64_t v, T* key) {
     *key = static_cast<T>(v);
 }
 
 inline void set_key(uint64_t v, std::string* key) {
+    static_assert(key_filler.size() >= max_key_len);
+    // Square a byte of a mixed value: uniform in, skewed towards short out.
+    auto const spread = (v * UINT64_C(0x9E3779B97F4A7C15)) >> 56U;
+    auto const len = min_key_len + ((spread * spread) >> 9U);
+    key->assign(key_filler.data(), len);
     std::memcpy(key->data(), &v, sizeof(v));
 }
 

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -219,6 +219,23 @@ inline auto hash_keys() -> std::vector<std::string> const& {
     return keys;
 }
 
+// Build a map from empty, which is the half of inserting that insert_erase never shows.
+//
+// insert_erase draws its keys from a range that grows to 20000, so the map hovers at ~10k entries
+// and doubles its bucket array about a dozen times in eight million operations -- growth is a
+// rounding error there. It is not one in general: building a map of a million entries against one
+// that reserved the room first costs 52% more for uint64_t keys and 31% more for strings, all of
+// it rehashing. A map that grew badly would have scored the same as one that grew well.
+template <typename Map>
+auto build() -> size_t {
+    ankerl::nanobench::Rng rng(777);
+    Map map;
+    for (size_t i = 0; i < 200000; ++i) {
+        map[key_for<Map>(rng())] = i;
+    }
+    return map.size();
+}
+
 // Hashing alone, over the keys the string workloads use.
 //
 // A whole lookup is ~167 instructions and only ~59 of them are the hash, and a hash change that

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -226,9 +226,9 @@ inline auto hash_keys() -> std::vector<std::string> const& {
 // whole measurement instead. The keys are built before the loop, so what is timed is hashing and
 // not the making of a key.
 template <typename Map>
-auto hash_strings() -> size_t {
+auto hash_strings() -> uint64_t {
     typename Map::hasher const hash{};
-    size_t checksum = 0;
+    uint64_t checksum = 0; // the hash is 64 bits wide whatever size_t is here
     for (auto const& key : hash_keys()) {
         checksum += hash(key);
     }

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -197,4 +197,40 @@ auto find_all() -> size_t {
     return checksum;
 }
 
+// The keys the hash-only workload runs over, built once and shared by every caller.
+//
+// One set, not one per instantiation: the A/B harness runs two hashes interleaved, and giving each
+// of them its own megabytes of keys measures the cache and not the hash. Ten thousand of them is
+// more than a branch predictor can remember and still small enough to stay warm.
+inline auto hash_keys() -> std::vector<std::string> const& {
+    static auto const keys = [] {
+        std::vector<std::string> built;
+        built.reserve(10000);
+        ankerl::nanobench::Rng rng(4711);
+        auto key = init_key<std::string>();
+        for (size_t i = 0; i < 10000; ++i) {
+            set_key(rng(), &key);
+            built.push_back(key);
+        }
+        return built;
+    }();
+    return keys;
+}
+
+// Hashing alone, over the keys the string workloads use.
+//
+// A whole lookup is ~224 instructions and only ~60 of them are the hash, and a hash change that
+// touches one length range is diluted further by the share of keys in it. This makes the hash the
+// whole measurement instead. The keys are built before the loop, so what is timed is hashing and
+// not the making of a key.
+template <typename Map>
+auto hash_strings() -> size_t {
+    typename Map::hasher const hash{};
+    size_t checksum = 0;
+    for (auto const& key : hash_keys()) {
+        checksum += hash(key);
+    }
+    return checksum;
+}
+
 } // namespace workloads

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -14,11 +14,6 @@
 
 namespace workloads {
 
-template <typename K>
-inline auto init_key() -> K {
-    return {};
-}
-
 // How long a string key is.
 //
 // Real string keys are identifiers, field names or paths. Most of them are short, a few are long,
@@ -43,35 +38,55 @@ inline constexpr std::string_view key_filler =
     "service.name/attribute.count/http.status_code/db.query.duration_ms/net.peer.address.family/"
     "process.runtime.description/log.record.uid/k8s.pod.namespace";
 
+// The key that stands for the value v.
+//
+// For a string this is a reference to one of a set of buffers prepared once, one per length, and
+// making it costs the 8 bytes of the value. Building it with `std::string::assign` instead cost
+// far more than the map: `perf` put 17.9% of `findstr` in libstdc++'s `_M_replace` and another
+// 15.8% in the `memmove` under it, against 3.3% in the key comparison. What the score compares is
+// the map, so a workload must not spend a third of itself making keys.
+//
+// The buffers are shared, so a key is only valid until the next call for the same length. Every
+// workload here uses a key and is done with it.
+template <typename K>
+struct key_source {
+    [[nodiscard]] static auto get(uint64_t v) -> K {
+        return static_cast<K>(v);
+    }
+};
+
 template <>
-inline auto init_key<std::string>() -> std::string {
-    std::string str;
-    str.reserve(max_key_len); // once, so that set_key never has to allocate again
-    return str;
+struct key_source<std::string> {
+    [[nodiscard]] static auto get(uint64_t v) -> std::string const& {
+        static_assert(key_filler.size() >= max_key_len);
+        static auto buffers = [] {
+            std::vector<std::string> prepared;
+            prepared.reserve(max_key_len - min_key_len + 1);
+            for (size_t n = min_key_len; n <= max_key_len; ++n) {
+                prepared.emplace_back(key_filler.data(), n);
+            }
+            return prepared;
+        }();
+
+        // Square a byte of a mixed value: uniform in, skewed towards short out.
+        auto const spread = (v * UINT64_C(0x9E3779B97F4A7C15)) >> 56U;
+        auto& key = buffers[static_cast<size_t>((spread * spread) >> 9U)];
+        std::memcpy(key.data(), &v, sizeof(v));
+        return key;
+    }
+};
+
+template <typename Map>
+[[nodiscard]] auto key_for(uint64_t v) -> decltype(auto) {
+    return key_source<typename Map::key_type>::get(v);
 }
 
-template <typename T>
-inline void set_key(uint64_t v, T* key) {
-    *key = static_cast<T>(v);
-}
-
-inline void set_key(uint64_t v, std::string* key) {
-    static_assert(key_filler.size() >= max_key_len);
-    // Square a byte of a mixed value: uniform in, skewed towards short out.
-    auto const spread = (v * UINT64_C(0x9E3779B97F4A7C15)) >> 56U;
-    // At most 8 + 127, so the cast to size_t cannot lose anything, and size_t is what a
-    // 32 bit std::string takes.
-    auto const len = min_key_len + static_cast<size_t>((spread * spread) >> 9U);
-    key->assign(key_filler.data(), len);
-    std::memcpy(key->data(), &v, sizeof(v));
-}
-
-// a random key in [0, n)
-template <typename T>
-inline void randomize_key(ankerl::nanobench::Rng* rng, int n, T* key) {
+// the key for a random value in [0, n)
+template <typename Map>
+[[nodiscard]] auto random_key(ankerl::nanobench::Rng* rng, int n) -> decltype(auto) {
     // we limit ourselves to 32bit n
-    auto limited = (((*rng)() >> 32U) * static_cast<uint64_t>(n)) >> 32U;
-    set_key(limited, key);
+    auto const limited = (((*rng)() >> 32U) * static_cast<uint64_t>(n)) >> 32U;
+    return key_for<Map>(limited);
 }
 
 struct insert_erase_result {
@@ -85,13 +100,10 @@ auto insert_erase() -> insert_erase_result {
     ankerl::nanobench::Rng rng(123);
     size_t erased{};
     Map map;
-    auto key = init_key<typename Map::key_type>();
     for (int n = 1; n < 20000; ++n) {
         for (int i = 0; i < 200; ++i) {
-            randomize_key(&rng, n, &key);
-            map[key];
-            randomize_key(&rng, n, &key);
-            erased += map.erase(key);
+            map[random_key<Map>(&rng, n)];
+            erased += map.erase(random_key<Map>(&rng, n));
         }
     }
     return {erased, map.size()};
@@ -101,13 +113,11 @@ auto insert_erase() -> insert_erase_result {
 template <typename Map>
 auto iterate() -> size_t {
     size_t const num_elements = 5000;
-    auto key = init_key<typename Map::key_type>();
     ankerl::nanobench::Rng rng(555);
     Map map;
     size_t result = 0;
     for (size_t n = 0; n < num_elements; ++n) {
-        randomize_key(&rng, 1000000, &key);
-        map[key] = n;
+        map[random_key<Map>(&rng, 1000000)] = n;
         for (auto const& key_val : map) {
             result += key_val.second;
         }
@@ -115,8 +125,7 @@ auto iterate() -> size_t {
 
     rng = ankerl::nanobench::Rng(555);
     do {
-        randomize_key(&rng, 1000000, &key);
-        map.erase(key);
+        map.erase(random_key<Map>(&rng, 1000000));
         for (auto const& key_val : map) {
             result += key_val.second;
         }
@@ -141,13 +150,11 @@ auto find_50() -> size_t {
     inserted.reserve(100000);
     size_t checksum = 0;
     Map map;
-    auto key = init_key<typename Map::key_type>();
     for (size_t i = 0; i < 100000; ++i) {
         // half of the candidates go in; the first one always, so there is something to find
         auto candidate = insert_rng() & ~never_inserted;
         if (inserted.empty() || (insert_rng() & 1U) != 0) {
-            set_key(candidate, &key);
-            if (map.emplace(key, i).second) {
+            if (map.emplace(key_for<Map>(candidate), i).second) {
                 inserted.push_back(candidate);
             }
         }
@@ -155,11 +162,8 @@ auto find_50() -> size_t {
         // search 100 entries in the map
         for (size_t search = 0; search < 100; ++search) {
             auto r = search_rng();
-            if ((r & 1U) != 0) {
-                set_key(inserted[((r >> 32U) * inserted.size()) >> 32U], &key);
-            } else {
-                set_key(r | never_inserted, &key);
-            }
+            auto const& key = (r & 1U) != 0 ? key_for<Map>(inserted[((r >> 32U) * inserted.size()) >> 32U])
+                                            : key_for<Map>(r | never_inserted);
             auto it = map.find(key);
             if (it != map.end()) {
                 checksum += it->second;
@@ -178,11 +182,9 @@ auto find_all() -> size_t {
     Map map;
     std::vector<uint64_t> keys;
     keys.reserve(50000);
-    auto key = init_key<typename Map::key_type>();
     while (map.size() < 50000) {
         auto v = rng() & ~never_inserted;
-        set_key(v, &key);
-        if (map.emplace(key, keys.size()).second) {
+        if (map.emplace(key_for<Map>(v), keys.size()).second) {
             keys.push_back(v);
         }
     }
@@ -190,7 +192,7 @@ auto find_all() -> size_t {
     auto const num_keys = keys.size();
     for (size_t i = 0; i < 10000000; ++i) {
         auto r = rng();
-        set_key(Hits ? keys[((r >> 32U) * num_keys) >> 32U] : (r | never_inserted), &key);
+        auto const& key = key_for<Map>(Hits ? keys[((r >> 32U) * num_keys) >> 32U] : (r | never_inserted));
         auto it = map.find(key);
         if (it != map.end()) {
             checksum += it->second;
@@ -209,10 +211,8 @@ inline auto hash_keys() -> std::vector<std::string> const& {
         std::vector<std::string> built;
         built.reserve(10000);
         ankerl::nanobench::Rng rng(4711);
-        auto key = init_key<std::string>();
         for (size_t i = 0; i < 10000; ++i) {
-            set_key(rng(), &key);
-            built.push_back(key);
+            built.push_back(key_source<std::string>::get(rng()));
         }
         return built;
     }();

--- a/test/meson.build
+++ b/test/meson.build
@@ -39,6 +39,7 @@ test_sources = [
     'unit/empty.cpp',
     'unit/equal_range.cpp',
     'unit/erase_if.cpp',
+    'unit/erase_churn.cpp',
     'unit/erase_range.cpp',
     'unit/erase_throwing_move.cpp',
     'unit/erase.cpp',

--- a/test/unit/erase_churn.cpp
+++ b/test/unit/erase_churn.cpp
@@ -1,0 +1,79 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <cstddef> // for size_t
+#include <cstdint> // for uint64_t
+#include <vector>  // for vector
+
+// Insert and erase at a fixed size, for a long time, with the bucket array never rebuilt.
+//
+// Every other churn test grows its map, and growth rebuilds every bucket from the values, so a
+// bucket the shift loops leave behind -- pointing at a value that has moved, or neither empty nor
+// at a valid distance -- does not live long there. Here nothing rebuilds it. Such a bucket is
+// invisible to a find, which compares the key it reaches, and to iteration, which walks the
+// values; it shows when an erase searching for the bucket of the value it is moving reaches a
+// stale one first and repoints that, leaving a live value no bucket finds, or when no bucket is
+// empty and an insert cannot end.
+//
+// A mutation sweep of the vector shifts had already caught every mutant that does this, most of
+// them as a hang of the whole suite. Under this test the same mutants fail within 300 cycles,
+// by name, which is what a person fixing one needs. The sixteen that survived it as well are
+// equivalent: the sentinel guards, and table lanes the blend never reads.
+//
+// So: reserve, so the bucket count is fixed and asserted to stay so; fill to a load that shifts
+// often; then churn, and every so often ask for every live key.
+TEST_CASE("erase_churn_keeps_every_live_key_findable") {
+    using map_t = ankerl::unordered_dense::map<uint64_t, uint64_t>;
+
+    // splitmix64: random 64 bit keys, so the hash has real chains to shift
+    uint64_t state = 0x9E3779B97F4A7C15;
+    auto next = [&state] {
+        state += 0x9E3779B97F4A7C15;
+        auto z = state;
+        z = (z ^ (z >> 30U)) * 0xBF58476D1CE4E5B9;
+        z = (z ^ (z >> 27U)) * 0x94D049BB133111EB;
+        return z ^ (z >> 31U);
+    };
+
+    map_t map;
+    map.reserve(2800);
+    auto const buckets = map.bucket_count();
+    REQUIRE(buckets == 4096U);
+
+    std::vector<uint64_t> live;
+    while (live.size() < 2900) {
+        auto const key = next();
+        if (map.try_emplace(key, ~key).second) {
+            live.push_back(key);
+        }
+    }
+    REQUIRE(map.bucket_count() == buckets);
+
+    size_t constexpr cycles = 200000;
+    size_t constexpr check_every = 8192;
+    for (size_t cycle = 0; cycle < cycles; ++cycle) {
+        // erase one live key at random, then insert a new one, so size and load stay put
+        auto const victim = static_cast<size_t>(next() % live.size());
+        auto const gone = live[victim];
+        REQUIRE(map.erase(gone) == 1U);
+        live[victim] = live.back();
+        live.pop_back();
+
+        auto const fresh = next();
+        REQUIRE(map.try_emplace(fresh, ~fresh).second);
+        live.push_back(fresh);
+
+        if (cycle % check_every == check_every - 1) {
+            INFO("after ", cycle + 1, " cycles");
+            REQUIRE(map.size() == live.size());
+            REQUIRE(map.bucket_count() == buckets); // no growth, so nothing has cleaned the buckets
+            for (auto const key : live) {
+                auto it = map.find(key);
+                REQUIRE(it != map.end());
+                REQUIRE(it->second == ~key);
+            }
+            REQUIRE(map.find(gone) == map.end());
+        }
+    }
+}

--- a/test/unit/hash_golden.cpp
+++ b/test/unit/hash_golden.cpp
@@ -57,11 +57,14 @@ namespace {
 
 // One length per branch of wyhash::hash and both sides of every boundary it switches on: 3/4 (the
 // 3-byte read), 7/8 (the 4-byte pair), 16/17 (the 8-byte pair vs the loop), 48/49 (the three-lane
-// loop) and 96/97 (the six-lane one). A mutated bound moves one of these onto the wrong branch.
+// loop) and 192/193 (the six-lane one). A mutated bound moves one of these onto the wrong branch.
 //
 // The loops need more than their entry conditions, though: a `>` that became `>=` only differs on
 // the iteration where the counter lands exactly on the bound, so there are lengths here that leave
-// it at 17 after the 48-byte loop (65) and at 96 after the 96-byte one (192, 289).
+// it at 17 after the 48-byte loop (65) and at 96 after the 96-byte one (288, 289).
+//
+// 96 and 97 are still here even though they no longer straddle anything: they are where the
+// six-lane block used to begin, and a bound that moved back there has to be caught.
 TEST_CASE("wyhash_golden_values_by_length") {
     if (skip_on_big_endian()) {
         return;
@@ -75,9 +78,10 @@ TEST_CASE("wyhash_golden_values_by_length") {
         {15, UINT64_C(0xb4f9a728274096d7)},  {16, UINT64_C(0xce6a868a78a46c73)},  {17, UINT64_C(0xab9f0d72fd62acbb)},
         {24, UINT64_C(0xaf048c621425ee78)},  {32, UINT64_C(0x46f297d4bd07d149)},  {48, UINT64_C(0x9e97709342df6b56)},
         {49, UINT64_C(0x3b846738927f6274)},  {64, UINT64_C(0xd4a468aebbe74bfa)},  {65, UINT64_C(0x68624a1222e1898b)},
-        {96, UINT64_C(0x2d9d003ab847fe53)},  {97, UINT64_C(0x97ef6fc060548571)},  {128, UINT64_C(0x04c929c0de5c5ada)},
-        {192, UINT64_C(0x188b2a6bd5264944)}, {193, UINT64_C(0x11ff8ae436691f52)}, {200, UINT64_C(0xc0895d26f8d2d90f)},
-        {289, UINT64_C(0xede2975ce774d7e7)}, {300, UINT64_C(0xb8446c7b09ba427b)}, {512, UINT64_C(0x2c274db7d27dc42b)},
+        {96, UINT64_C(0x2d9d003ab847fe53)},  {97, UINT64_C(0x8c7242d7e4010ba0)},  {128, UINT64_C(0x90d38e952fc9b8a0)},
+        {192, UINT64_C(0xbc152e7c1f5e9c40)}, {193, UINT64_C(0x11ff8ae436691f52)}, {200, UINT64_C(0xc0895d26f8d2d90f)},
+        {288, UINT64_C(0x17e4aa47a185f12c)}, {289, UINT64_C(0xede2975ce774d7e7)}, {300, UINT64_C(0xb8446c7b09ba427b)},
+        {512, UINT64_C(0x2c274db7d27dc42b)},
     };
 
     auto const data = pattern(512);


### PR DESCRIPTION
Fourteen commits. Three fix the benchmark, and each of those uncovered a result the next ones act on.

## What the map gains

Paired with `scripts/ab/run.sh`, 20 epochs, honest keys, against `main`:

| workload | change | 95% CI |
|---|---|---|
| build64 | **1.11x faster** | [1.11 .. 1.12] |
| ie64 | **1.07x faster** | [1.07 .. 1.08] |
| iestr | **1.04x faster** | [1.04 .. 1.04] |
| buildstr | **1.02x faster** | [1.02 .. 1.03] |
| findstr | 1.01x faster | [1.01 .. 1.01] |
| find64, it64, itstr | unchanged | |

Against `boost::unordered_flat_map` with the same hash, `build64` goes from 1.42x behind to 1.27x
and `ie64` from 1.29x to 1.20x. `buildstr` is 1.25x ahead.

No hash value changes except for keys of 97 to 192 bytes (below). No API changes.

## The benchmark: three things it could not see

**String keys were all exactly 200 bytes** (`d3e5ee4`). Real string keys are short and vary. One
fixed length made the hash's length dispatch perfectly predictable -- 0.01 mispredictions per hash
against 0.31 on mixed lengths -- and put every key on the heap. Keys now run 8 to 135 bytes,
skewed short; the value stays in the first 8 bytes, so every checksum is unchanged.

**A third of the string workloads was `std::string::assign`** (`83f285f`). Giving keys varying
lengths meant building them through libstdc++ in the timed loop: `perf` put 17.9% of `findstr`
in `_M_replace` and 15.8% in the `memmove` under it, against 3.3% in the key comparison. Buffers
are prepared once, one per length; a key costs 8 bytes again. `findstr` loses 25% of its
instructions.

**Integer keys hashed to a lattice** (`801e4e5`). `insert_erase` and `iterate` used small
sequential values as keys, and the hash of one is a multiply whose top bits walk a lattice: 10000
keys in 16384 buckets landed at most **one to a bucket**, 39% of buckets empty where uniform is
54%. Nothing collided, so the probe never probed and the shifts never shifted -- 82% of erases
moved nothing, against 58% for the same values as strings -- and both vector shifts below first
read as 1% *losses* on `ie64`. The value now goes through a 64-bit bijection; checksums unchanged.

Plus **`build`** (`1a1a995`): nothing in the score grew a table, and growth is 31-52% of building
one. It joins the score, which is eight workloads now. Scores are not comparable with before.

## The hash

- **Short path returns instead of falling through** (`457c9d6`): `seed`, `a`, `b` were phi
  nodes at a shared tail, so the constant seed could not fold. 36 -> 24 instructions for keys of
  16 bytes or less, on both compilers. No value changes.
- **Six-lane block enters at `>192`, not `>96`** (`f6300d0`): it sets up three extra
  accumulators, so it has to run twice to pay, and 97-192 byte keys ran it exactly once. 23.4 ->
  21.8 cycles at 100 bytes, unchanged at 400 and 1000. This changes hash values for keys of 97 to
  192 bytes; `hash_golden.cpp` exists to make that a decision, and its values are regenerated.

## Insert and erase: one branch per bucket was a coin flip

Inserting into a reserved table cost 52 cycles and **0.61 mispredictions** against boost's 23 and
0.10. The hardware attributed them all to the robin-hood shift loop: measured over 8M inserts,
73% shift nothing, 11% shift one, the rest tail off. `place_and_shift_up` now reads four buckets,
gets the four answers as one mask, and blends -- the same trade the probe made (`c777625`).
Mispredictions 0.61 -> 0.24, cycles 52 -> 46. `erase_and_shift_down` is the mirror image, with
the same numbers (`e2171bd`): 0.60 -> 0.26, 64 -> 55.

Two other shapes lost: settling two slots with scalar cmovs (still a branch that mispredicts as
often), and a two-bucket vector version (its second slot is still a coin flip). They're under the
dead ends in CLAUDE.md, along with two rehash ideas that did nothing.

## Verification

- Every leg of CI, plus locally clang 22 / gcc 16 / unity / ASan+UBSan and both 32-bit flavours.
- **Two mutation sweeps** of the vector shifts: 138 and 167 mutants. Every survivor is triaged
  lane by lane in the commit messages; all are equivalent (the sentinel guards, and blend-table
  lanes the blend never reads). A wrong lane anywhere else fails the new `erase_churn` test within
  300 cycles by name -- that test churns a fixed-size table with no rehash, the one regime where a
  bucket the shift leaves behind survives long enough to matter.
- `hashstr` resolves a 5% change cleanly but reported a real 2.6% one the wrong way twice: a tight
  loop with nothing else in it is layout-sensitive. Documented in `scripts/ab/README.md`; check a
  small hash change against the map workloads.
