### PR TITLE
bump version to 4.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 cmake_minimum_required(VERSION ${CMAKEVER})
 project("unordered_dense"
-    VERSION 4.10.0
+    VERSION 4.11.0
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense"
     LANGUAGES CXX)

--- a/include/ankerl/stl.h
+++ b/include/ankerl/stl.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 4.10.0
+// Version 4.11.0
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 4.10.0
+// Version 4.11.0
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
@@ -31,7 +31,7 @@
 
 // see https://semver.org/spec/v2.0.0.html
 #define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 4  // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
-#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 10 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
+#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 11 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
 #define ANKERL_UNORDERED_DENSE_VERSION_PATCH 0  // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
 
 // API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '4.10.0',
+    version: '4.11.0',
     license: 'MIT',
     default_options : [
         'cpp_std=c++17', 

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -1,7 +1,7 @@
 #include <ankerl/unordered_dense.h>
 #include <app/doctest.h>
 
-namespace versioned_namespace = ankerl::unordered_dense::v4_10_0;
+namespace versioned_namespace = ankerl::unordered_dense::v4_11_0;
 
 static_assert(std::is_same_v<versioned_namespace::map<int, int>, ankerl::unordered_dense::map<int, int>>);
 static_assert(std::is_same_v<versioned_namespace::hash<int>, ankerl::unordered_dense::hash<int>>);


### PR DESCRIPTION
Releases the four-at-a-time robin hood shift that landed in #213.

## What is in it

- `place_and_shift_up` and `erase_and_shift_down` settle four buckets from one SSE2 mask instead of asking "is this bucket occupied" once per bucket. That question was a coin flip -- 73% of inserts shift nothing, 11% shift one -- and cost 0.61 branch mispredictions per insert; it is 0.24 now.
- wyhash returns from its short path instead of falling through, and enters the six lane block only when it can run twice.

Nothing in the public API changed and no type changed size, which is why this is a minor.

## Measurements

Paired A/B against **4.9.2**, twelve interleaved passes at 32 epochs, pinned to one physical core, and repeated with the two headers' roles swapped inside the binary so code layout could not be mistaken for the map. The two orientations agreed to 0.19%.

| workload | speedup |
|---|---|
| find64 | 1.59x |
| ie64 | 1.26x |
| build64 | 1.17x |
| iestr | 1.17x |
| findstr | 1.16x |
| buildstr | 1.10x |
| itstr | 1.01x |
| it64 | 0.98x |
| **geomean** | **1.17x** |

Against **4.10.0** alone, the shift work is 1.12x on `build64`, 1.08x on `ie64` and 1.04x on `iestr`, for a 1.036x geomean.

`it64` is 2.5% slower, reproducibly and in both orientations. Iteration touches none of the changed code, so this is the new vector code displacing the iteration loop in the instruction cache. It costs ~0.5% of the geomean against gains many times that.

## Note on the score

The keys of `bench_quick_overall_udm` changed in #213 -- string lengths run from 8 to 135 bytes instead of a fixed 200, integer keys are scrambled instead of small and sequential, and a build-from-empty workload was added -- so its score is not comparable with 4.10.0's.

## Checks run locally

601 tests pass under clang release, ASan, UBSan and gcc release. `lint-clang-format`, `lint-version --expect 4.11.0`, `lint-mutate-core` and `lint-stdint-types-modules` pass. `lint-clang-tidy` could not run here: the pinned clang-tidy-18 cannot parse this machine's GCC 16 libstdc++, and the unpinned clang-tidy 22 fires checks that did not exist in 18. CI is the gate for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)