### PR TITLE
Score a table that only churns, which nothing measured

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Warnings are errors (`werror=true`, `warning_level=3`, plus `-Wconversion`, `-Wo
 
 ## Benchmarking
 
-The main performance metric is `bench_quick_overall_udm`. It runs eight nanobench benchmarks covering the most important primitives — iterate-while-modifying, random insert/erase, build-from-empty, and random find (50% hit rate) — each for both `map<uint64_t, size_t>` and `map<std::string, size_t>`, then prints the geometric mean of the median elapsed times:
+The main performance metric is `bench_quick_overall_udm`. It runs ten nanobench benchmarks covering the most important primitives — iterate-while-modifying, random insert/erase, build-from-empty, sustained churn at a fixed size, and random find (50% hit rate) — each for both `map<uint64_t, size_t>` and `map<std::string, size_t>`, then prints the geometric mean of the median elapsed times:
 
 ```sh
 # benchmarks are marked doctest::skip(), so -ns (no-skip) is required
@@ -80,6 +80,24 @@ rounding error in general: building a map of a million entries costs 52% more th
 same map after `reserve` for `uint64_t` keys and 31% more for strings, all of it rehashing, so a
 map that grew badly would have scored the same as one that grew well. `build` covers it, and it
 showed at once that this is where the map is weakest -- see `scripts/ab/README.md`.
+
+**Nothing measured a table that only churns.** Until 2026-09-03 every workload in the score
+either grew or was measured on a table that had just been built. Backward shift deletion leaves the
+table as it would have been had the erased element never been inserted, so a table that has churned
+for a long time is as good as a fresh one. A design that frees a slot without undoing what once
+probed past it cannot do that -- its probe sequences only grow, and it repairs them with a rehash.
+Nothing in the score could tell the two apart, because `build` and `insert_erase` both keep growing
+and a growth rehash resets the damage for free. `churn` grows once and then never again: fill to
+50000, reserve the room, then erase one and insert one with two lookups between, holding the size
+exactly there. Measured that way over two million operations at 200000 entries,
+`boost::unordered_flat_map`'s lookups degrade to **1.31x** of their fresh cost and snap back on an
+in-place rehash it pays for every third round -- its bucket count never changes, and the round that
+repairs costs +7ns per operation -- while this map's stay flat within the noise. With string keys
+both degrade, because what degrades there is the heap the key bodies live on rather than the table,
+and this map churns **1.28x faster** than boost throughout. Against boost the sustained gap is much
+smaller than the fresh-table one: 1.32x on `churn64` where `rhit64` on a fresh table is 1.71x, and
+1.03x on `churnstr`, the narrowest of any string workload it does not already win. Scores from
+before this workload are not comparable with scores after it.
 
 **Lookup benchmarks must not replay.** Until 2026-09 the find workload of
 `bench_quick_overall_udm` reset its search rng to the insertion rng's seed, so its sequence of hits

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -6,8 +6,9 @@ Builds the working-tree header against `REV`'s (default `HEAD`) in one binary --
 renamed into a second namespace -- and runs nanobench's `compare()`: the alternatives run
 interleaved in the same slice of time, so drift cancels out of the ratios, and the interval it
 prints is about the ratio. `-b` adds `boost::unordered_flat_map` (needs its headers). The
-workloads are `test/bench/workloads.h`, the ones `bench_quick_overall_udm` scores, plus all-hits
-and no-hits lookups. Its string keys run from 8 to 135 bytes, skewed towards short; a fixed length
+workloads are `test/bench/workloads.h`, the ones `bench_quick_overall_udm` scores -- including
+`churn64`/`churnstr`, a table that grows once and then only erases and inserts -- plus all-hits and
+no-hits lookups. Its string keys run from 8 to 135 bytes, skewed towards short; a fixed length
 would leave the length dispatch of the hash perfectly predicted. Believe a change when the interval excludes 100%.
 
 ## What the hot paths are bound by (Ryzen 9 7950X, clang 22, default `-march`, 2026-09)
@@ -47,6 +48,31 @@ Numbers from that session, paired against main (ms; boost for scale). The string
 | iestr (200 byte keys) | 226 | 212 | 188 |
 | rhit64 | 145 | 80 | 50 |
 | rmiss64 | 48 | 35 | 28 |
+
+## Where a table that only churns stands (2026-09-03)
+
+Every workload above measures a table that has just been built. `churn` measures one that never
+grows again: filled to a fixed size, reserved, then erase-one/insert-one forever. Paired against
+`boost::unordered_flat_map` with the same hash:
+
+| workload | udm | boost | |
+|---|---|---|---|
+| churn64 | 12.10 ms | 9.16 ms | boost ahead 32% |
+| churnstr | 30.50 ms | 29.48 ms | boost ahead 3% |
+
+Both gaps are much narrower than the fresh-table ones (`rhit64` is 1.71x, `findstr` 1.07x), and the
+reason is visible when the run is broken into rounds at 200000 entries. boost's lookups degrade to
+1.31x of their fresh cost over three rounds and then snap back, and the round that repairs them
+costs +7ns per operation while its bucket count does not change -- an in-place rehash. This map does
+not degrade at all: 0.91-1.00x across two million operations, flat churn cost. That is backward
+shift deletion doing what it claims.
+
+With string keys both degrade, to 1.41x and 1.71x, and that part is not the table -- the u64 run
+proves this map's table does not degrade. It is the heap the key bodies live on. This map churns
+strings 1.28x faster than boost at every round.
+
+A run that measures only a fresh table is therefore systematically flattering to a design that
+trades erase quality for lookup speed.
 
 ## Where inserting and erasing stand (2026-09-02)
 

--- a/scripts/ab/ab.cpp
+++ b/scripts/ab/ab.cpp
@@ -83,6 +83,12 @@ struct build {
     }
 };
 template <typename Map>
+struct churn {
+    static auto run() {
+        return workloads::churn<Map>();
+    }
+};
+template <typename Map>
 struct find_50 {
     static auto run() {
         return workloads::find_50<Map>();
@@ -112,7 +118,7 @@ struct find_misses {
 auto main(int argc, char** argv) -> int {
     if (argc < 2) {
         std::printf("usage: %s <workload|all> [epochs=12] [boost=0]\n"
-                    "workloads: it64 ie64 build64 find64 itstr iestr buildstr findstr\n"
+                    "workloads: it64 ie64 build64 churn64 find64 itstr iestr buildstr churnstr findstr\n"
                     "           (bench_quick_overall_udm)\n"
                     "           rhit64 rmiss64 rhitstr rmissstr (all hits / no hits)\n"
                     "           hashstr (the string hash on its own)\n",
@@ -140,10 +146,12 @@ auto main(int argc, char** argv) -> int {
     U64("it64", iterate);
     U64("ie64", insert_erase);
     U64("build64", build);
+    U64("churn64", churn);
     U64("find64", find_50);
     STR("itstr", iterate);
     STR("iestr", insert_erase);
     STR("buildstr", build);
+    STR("churnstr", churn);
     STR("findstr", find_50);
     U64("rhit64", find_hits);
     U64("rmiss64", find_misses);

--- a/test/bench/quick_overall_map.cpp
+++ b/test/bench/quick_overall_map.cpp
@@ -2,7 +2,7 @@
 
 #include <app/doctest.h>           // for TestCase, skip, ResultBuilder
 #include <app/geomean.h>           // for geomean
-#include <bench/workloads.h>       // for insert_erase, iterate, build, find_50, find_all, hash_strings
+#include <bench/workloads.h>       // for insert_erase, iterate, build, churn, find_50, find_all, hash_strings
 #include <third-party/nanobench.h> // for Bench
 
 #include <fmt/format.h> // for print, format
@@ -43,6 +43,13 @@ void bench_build(ankerl::nanobench::Bench* bench, std::string_view name) {
 }
 
 template <typename Map>
+void bench_churn(ankerl::nanobench::Bench* bench, std::string_view name) {
+    bench->run(fmt::format("{} churn at a fixed size", name), [&] {
+        CHECK(workloads::churn<Map>() == 13688565634U);
+    });
+}
+
+template <typename Map>
 void bench_random_find(ankerl::nanobench::Bench* bench, std::string_view name) {
     bench->run(fmt::format("{} 50% probability to find", name), [&] {
         CHECK(workloads::find_50<Map>() == 124865472559U);
@@ -56,6 +63,7 @@ void bench_all(ankerl::nanobench::Bench* bench, std::string_view name) {
     bench_iterate<Map>(bench, name);
     bench_random_insert_erase<Map>(bench, name);
     bench_build<Map>(bench, name);
+    bench_churn<Map>(bench, name);
     bench_random_find<Map>(bench, name);
 }
 

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -247,6 +247,66 @@ auto build() -> size_t {
     return map.size();
 }
 
+// Sustained churn at a fixed size, which every other workload here resets before it accumulates.
+//
+// Backward shift deletion leaves the table as it would have been had the erased element never
+// been inserted, so a table that has churned is as good as a fresh one. A design that frees a slot
+// without undoing what once probed past it cannot do that: its probe sequences only grow, and it
+// repairs them with a rehash. Nothing in the score could tell the two apart, because build and
+// insert_erase both keep growing and a growth rehash resets the damage for free.
+//
+// So this one grows once and then never again: fill to 50000, reserve the room, and from there
+// erase one and insert one, holding the size exactly there. Measured this way over two million
+// operations, boost::unordered_flat_map's lookups degrade to 1.31x of their fresh cost and snap
+// back on a rehash it pays for every third round -- its bucket count never changes -- while this
+// map's stay flat within the noise. With string keys both degrade, because what degrades there is
+// the heap the key bodies live on rather than the table, and this map churns 1.28x faster than
+// boost throughout.
+//
+// The lookups are interleaved rather than left to the end so that a table which has degraded pays
+// for it while it is degraded, which is what a real churning cache does.
+template <typename Map>
+auto churn() -> size_t {
+    constexpr size_t num_elements = 50000;
+    constexpr size_t num_rounds = 4;
+    constexpr auto never_inserted = uint64_t{1} << 63U;
+
+    ankerl::nanobench::Rng rng(31337);
+    Map map;
+    map.reserve(num_elements);
+
+    // The keys are a counter, so every insert below brings one the map has never held and every
+    // erase names one it holds. live[] is the set of those, and stays exactly num_elements long.
+    std::vector<uint64_t> live;
+    live.reserve(num_elements);
+    uint64_t next = 0;
+    while (live.size() < num_elements) {
+        map[key_for<Map>(next)] = live.size();
+        live.push_back(next);
+        ++next;
+    }
+
+    size_t checksum = 0;
+    for (size_t i = 0; i < num_rounds * num_elements; ++i) {
+        auto const slot = static_cast<size_t>(((rng() >> 32U) * live.size()) >> 32U);
+        map.erase(key_for<Map>(live[slot]));
+        map[key_for<Map>(next)] = i;
+        live[slot] = next;
+        ++next;
+
+        for (size_t search = 0; search < 2; ++search) {
+            auto const r = rng();
+            auto const& key =
+                (r & 1U) != 0 ? key_for<Map>(live[((r >> 32U) * live.size()) >> 32U]) : key_for<Map>(r | never_inserted);
+            auto it = map.find(key);
+            if (it != map.end()) {
+                checksum += it->second;
+            }
+        }
+    }
+    return checksum + map.size();
+}
+
 // Hashing alone, over the keys the string workloads use.
 //
 // A whole lookup is ~167 instructions and only ~59 of them are the hash, and a hash change that


### PR DESCRIPTION
Adds `churn64` and `churnstr` to `bench_quick_overall_udm`. Benchmark honesty, not an optimization — the same pattern as the string-key lengths, the scrambled integer keys and the build workload.

## The hole

Backward shift deletion leaves the table as it would have been had the erased element never been inserted, so a table that has churned for a long time is as good as a fresh one. A design that frees a slot without undoing what once probed past it cannot do that; it repairs itself with a rehash instead.

Nothing in the score could tell those apart. `build` and `insert_erase` both keep growing, and a growth rehash resets the damage for free — so **the one property backward shift deletion exists for was worth nothing in the score**, and a change that gave it up would have measured the same.

## The workload

Fill to 50000, `reserve` the room, then erase one and insert one with two lookups between, holding the size exactly there for four rounds. Nothing ever grows, so anything that changes is degradation. The lookups are interleaved rather than left to the end, so a table that has degraded pays for it while it is degraded — which is what a real churning cache does.

## What it shows

Broken into rounds at 200000 entries, against `boost::unordered_flat_map` with the same hash:

| churn ops | udm lookup | udm churn ns/op | boost lookup | boost churn ns/op |
|---|---|---|---|---|
| 0 | 9.50 ns (1.00x) | — | 5.89 ns (1.00x) | — |
| 400k | 9.31 (0.98x) | 47.6 | 7.16 (1.21x) | 36.9 |
| 600k | 9.13 (0.96x) | 48.4 | 7.63 (**1.29x**) | 32.4 |
| 800k | 8.68 (0.91x) | 44.3 | 6.58 (1.12x) | **38.9** |
| 1.2M | 8.76 (0.92x) | 45.3 | 7.70 (**1.31x**) | 32.0 |
| 1.4M | 8.74 (0.92x) | 45.2 | 6.73 (1.14x) | **39.0** |

boost degrades to 1.31x over three rounds and snaps back; the round that repairs costs +7 ns/op and its `bucket_count()` never changes — an in-place rehash. This map is flat, 0.91–1.00x across two million operations.

With string keys both degrade (1.41x and 1.71x), and that half is the heap the key bodies live on rather than the table — the u64 run proves the table doesn't degrade. This map churns strings **1.28x faster** than boost at every round.

In the score itself the sustained gaps are much narrower than the fresh-table ones:

| workload | udm | boost | |
|---|---|---|---|
| churn64 | 12.10 ms | 9.16 ms | boost ahead 32% (`rhit64` fresh is 71%) |
| churnstr | 30.50 ms | 29.48 ms | boost ahead 3% — narrowest string gap this map doesn't already win |

## Notes

- The checksum (`13688565634`) is identical for `uint64_t` keys, `std::string` keys and both boost instantiations, since it follows from the sequence of operations rather than the container.
- `reserve()` is already guarded by `if constexpr (has_reserve<value_container_type>)`, so the deque-backed configuration is fine; verified at runtime along with `segmented_vector` and `bucket_type::big`.
- Costs 12 ms / 30 ms per run, well under `ie64` (87 ms) and `findstr` (198 ms).
- **Scores from before this change are not comparable with scores after it.** The new score on this machine is 0.0267.

## Checks

601 tests pass under clang release, ASan, UBSan and gcc release; the unity leg compiles; `bench_quick_overall_udm`, `_deque`, `_segmented_vector` and `_bigbucket` all pass their checksums. `lint-clang-format`, `lint-version`, `lint-mutate-core` and `lint-stdint-types-modules` pass. `lint-clang-tidy` can't run on this machine (pinned clang-tidy-18 can't parse its GCC 16 libstdc++); it only inspects `unordered_dense.h`, which this PR doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)