### PR TITLE
Record why four attempts at the rehash loop failed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,28 @@ The `bench_quick_overall_udm` hot paths are close to machine limits. Ideas that 
   (49.7 against 46.3 cycles per insert): its second slot is still a branch. Both vector shifts
   first read as ~1% *losses* on `ie64`, and that was the benchmark: its integer keys hashed to a
   lattice with no chains to shift (see "Where the time goes"). With honest keys they are 1.07x.
+- Four attempts at the rehash loop (2026-09-03), and the reason they all failed. The loop in
+  `clear_and_fill_buckets_from_values` costs **~21-26 cycles per element at every size from L1 to
+  L3** (4.4 ns at 1000 elements, 5.4 ns at 200000): memory latency is already hidden, and what
+  bounds it is an in-core chain through the bucket array -- each element's loads sit behind the
+  previous element's stores. Two experiments pin that down. Adding 11 cycles of artificial latency
+  between the probe load and the store address adds 17 cycles per element; reading four elements'
+  home buckets before storing any of them is 1.5x faster while the array is L1-resident and nothing
+  at 100000, where the score's rehashes run. Nothing that shortens the *data* side of the store
+  moves it at all. So for this loop: anything that puts a load result on the path to the store
+  address is a large loss, and anything that only saves instructions or mispredictions is
+  invisible -- which is also why the earlier prefetch-eight-ahead and memset attempts found
+  nothing. What was tried, against `HEAD` on the isolated loop and paired on `build64`:
+  vectorizing `next_while_less` with the probe's four-lane window (`build64` **1.41x slower**,
+  the rehash 2-3x per element even in L1: fewer mispredictions, 7% more instructions, and the
+  store address now waits for the window load); the four-element batch above (neutral at scored
+  sizes, worse at a million); refilling from the *old* bucket array in order so new homes arrive
+  nearly sorted (**2x slower** at 100000-200000, with or without prefetching the keys: sorted
+  arrival makes every element probe the bucket the previous one just wrote); and replacing the
+  `tzcnt`-indexed blend tables of both vector shifts with a vector prefix-or (rehash neutral,
+  erase 6% slower: the table loads were never on the chain). `perf stat` shows 1.5
+  `ls_bad_status2.stli_other` interlocks per *insert* too, so the insert path is likely bound the
+  same way; IBS could not attribute them to an instruction.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,9 +196,12 @@ The `bench_quick_overall_udm` hot paths are close to machine limits. Ideas that 
   nearly sorted (**2x slower** at 100000-200000, with or without prefetching the keys: sorted
   arrival makes every element probe the bucket the previous one just wrote); and replacing the
   `tzcnt`-indexed blend tables of both vector shifts with a vector prefix-or (rehash neutral,
-  erase 6% slower: the table loads were never on the chain). `perf stat` shows 1.5
-  `ls_bad_status2.stli_other` interlocks per *insert* too, so the insert path is likely bound the
-  same way; IBS could not attribute them to an instruction.
+  erase 6% slower: the table loads were never on the chain). Do not read
+  `ls_bad_status2.stli_other` as a cost here: `build` shows 1.5 of them per insert and `churn`
+  1.3, on bucket-window loads that cannot overlap the previous insert's stores (odds ~3e-5), and
+  shifting the stack of the same binary moves the count from 1.45 to 2.85 per insert while the
+  cycles stay at 98.0 +- 0.5. Placing the bucket before appending the value, to put distance
+  between those stores and the next probe's loads, cost 2-7 cycles per insert in every variant.
 
 ## Testing
 


### PR DESCRIPTION
Adds a dead-end entry to `CLAUDE.md` for the rehash loop in `clear_and_fill_buckets_from_values`, so it is not re-tried.

**The finding:** the loop costs ~21-26 cycles per element at every size from L1 to L3 (4.4 ns at 1000 elements, 5.4 ns at 200000). Memory latency is already hidden; what bounds it is an in-core chain through the bucket array — each element's loads sit behind the previous element's stores. Adding 11 cycles of latency between the probe load and the store address adds 17 cycles per element; reading four home buckets ahead of any store is 1.5x faster in L1 and nothing at scored sizes; shortening the data side of the store does nothing.

**What that killed, measured against `HEAD`:**
- vectorizing `next_while_less` with the probe's four-lane window: `build64` **1.41x slower** (paired, 16 rounds), the store address now waits for the window load
- batching four elements' loads ahead of their stores: neutral at 100k–200k, worse at 1M
- refilling from the old bucket array in order (nearly sorted homes): **2x slower** — every element probes the bucket the previous one just wrote
- blend masks by vector prefix-or instead of a `tzcnt`-indexed table: rehash neutral, erase 6% slower

It also explains why the earlier prefetch-eight-ahead and memset attempts in this loop found nothing.

No code change; the header is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
