### PR TITLE
Close four holes a full mutation sweep found

### DIFF
--- a/test/unit/erase_uncounts.cpp
+++ b/test/unit/erase_uncounts.cpp
@@ -7,6 +7,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 // An erase takes its entry back out of every overflow counter its insert put it into, and until
 // this test nothing checked that. Deleting the decrement outright leaves the whole suite green --
@@ -108,6 +110,47 @@ auto build(overflow mode) -> uncount_map_t {
 }
 
 } // namespace
+
+// The other half of the erase path: finish_erase() moves m_values.back() into the hole the erased
+// element left, and then has to find the slot that pointed at it, which slot_of_value() does by
+// walking that element's own quadratic sequence from its home group.
+//
+// Every erase elsewhere in the suite moves an element that is still sitting in its home group, so
+// the walk never takes a second step. This one arranges for the moved element to be one that
+// overflowed: the last key inserted is homed in a group that was already full, so it lives in the
+// next group and is at the back of the value vector, and erasing a different key moves it.
+//
+// What this does *not* do is pin the walk's step. Starting its delta at 1 instead of 0 leaves the
+// suite green, and a mutation sweep on 2026-09-10 said so -- correctly, because slot_of_value has
+// no stopping condition except finding the value, and the value is definitely there. A different
+// step reaches it in a different order and a few groups later, which is slower and never wrong. So
+// that mutant is equivalent rather than a hole, and this case is here for the path rather than for
+// the constant.
+TEST_CASE("finish_erase_finds_a_moved_element_outside_its_home_group") {
+    auto map = build(overflow::live);
+    auto const key = uncount_keys(map);
+
+    // The overflowers went in last, so the final one is m_values.back() -- which is what an erase
+    // of anything else will move.
+    auto const displaced = key(uncount_home, 200 + uncount_overflowers - 1, uncount_fp);
+    REQUIRE(map.values().back().first == displaced);
+
+    auto const before = std::vector<std::pair<std::uint64_t, std::uint64_t>>(map.values().begin(), map.values().end());
+    auto const victim = key(uncount_home, 0, uncount_fp);
+    REQUIRE(victim != displaced);
+    REQUIRE(map.erase(victim) == 1U);
+
+    REQUIRE(map.size() == before.size() - 1);
+    for (auto const& entry : before) {
+        auto it = map.find(entry.first);
+        if (entry.first == victim) {
+            REQUIRE(it == map.end());
+        } else {
+            REQUIRE(it != map.end());
+            REQUIRE(it->second == entry.second);
+        }
+    }
+}
 
 TEST_CASE("erase_takes_its_entry_back_out_of_the_overflow_counters") {
     auto const fresh = build(overflow::none);

--- a/test/unit/group_bucket.cpp
+++ b/test/unit/group_bucket.cpp
@@ -125,6 +125,39 @@ using u64_map = ankerl::unordered_dense::map<uint64_t,
 
 } // namespace
 
+// The bucket count reserve() picks is the *smallest* power of two that holds the request at the
+// maximum load factor, and where the boundary falls is decided by one comparison in
+// calc_shifts_for_size(). Nothing pinned it: turning that `<` into `<=` moves every exact boundary
+// by one element and doubles the array a step early, which costs memory on every table built with
+// reserve() and which a mutation sweep on 2026-09-10 found nothing noticed.
+//
+// So this checks both sides: the count is enough, and half of it would not have been. The listed
+// sizes are the exact boundaries at a load factor of 0.8 -- 64 slots hold 51, 128 hold 102, and so
+// on -- because a size in the middle of a range is satisfied by both answers.
+TEST_CASE("reserve_picks_the_smallest_array_that_holds_the_request") {
+    using sized_map_t = ankerl::unordered_dense::map<uint64_t, uint64_t>;
+
+    for (auto n : {size_t{1}, size_t{51}, size_t{52}, size_t{102}, size_t{103}, size_t{204}, size_t{205}, size_t{1000}}) {
+        auto map = sized_map_t();
+        map.reserve(n);
+        auto const count = map.bucket_count();
+        INFO("reserve(", n, ") gave ", count, " buckets");
+
+        // enough for the request ...
+        REQUIRE(static_cast<double>(count) * static_cast<double>(map.max_load_factor()) >= static_cast<double>(n));
+        // ... and the next size down would not have been, unless we are already at the smallest
+        if (count > 64) {
+            REQUIRE(static_cast<double>(count / 2) * static_cast<double>(map.max_load_factor()) < static_cast<double>(n));
+        }
+
+        // and it really is room rather than a number: filling to the request must not grow it
+        for (uint64_t i = 0; i < n; ++i) {
+            map[i] = i;
+        }
+        REQUIRE(map.bucket_count() == count);
+    }
+}
+
 TEST_CASE("group_index_against_reference") {
     run_against_reference<u64_map<ankerl::unordered_dense::bucket_type::group>>(1, 10, 20000, false);
     run_against_reference<u64_map<ankerl::unordered_dense::bucket_type::group>>(2, 3000, 200000, false);

--- a/test/unit/hash_golden.cpp
+++ b/test/unit/hash_golden.cpp
@@ -64,6 +64,12 @@ namespace {
 // the iteration where the counter lands exactly on the bound, so there are lengths here that leave
 // it at 17 after the 48-byte loop (65) and at 96 after the 96-byte one (288, 289).
 //
+// 161 and 209 are the same idea for the *long* path's 16-byte loop, and they were missing: past
+// 144 bytes the counter is reduced by 96 and then by 48, so `while (i > 16)` is only distinguished
+// from `> 17` where that leaves exactly 17. 161 gets there through the 48-byte loop (161 - 96 = 65,
+// then 65 - 48 = 17) and 209 through the 96-byte one twice (209 - 96 - 96 = 17). Without them the
+// bound could be moved with the whole suite green -- found by a mutation sweep on 2026-09-10.
+//
 // The values from 17 to 144 changed on 2026-09-06, when that range became independent blocks;
 // everything shorter and everything longer hashes exactly as it did.
 TEST_CASE("wyhash_golden_values_by_length") {
@@ -85,6 +91,7 @@ TEST_CASE("wyhash_golden_values_by_length") {
         {144, UINT64_C(0x05009220cd4747f6)}, {145, UINT64_C(0x9214c954a67e0c14)}, {192, UINT64_C(0xbc152e7c1f5e9c40)},
         {193, UINT64_C(0x11ff8ae436691f52)}, {200, UINT64_C(0xc0895d26f8d2d90f)}, {288, UINT64_C(0x17e4aa47a185f12c)},
         {289, UINT64_C(0xede2975ce774d7e7)}, {300, UINT64_C(0xb8446c7b09ba427b)}, {512, UINT64_C(0x2c274db7d27dc42b)},
+        {161, UINT64_C(0xc3b8477018e0a5dc)}, {209, UINT64_C(0x391a4915c98fd37c)},
     };
 
     auto const data = pattern(512);

--- a/test/unit/lazy_bucket_allocation.cpp
+++ b/test/unit/lazy_bucket_allocation.cpp
@@ -403,6 +403,28 @@ TEST_CASE_MAP("reserve_sizes_the_buckets_not_just_the_values", int, int) {
 // to carry that over -- the copy must also start from the smallest array, not from the source's
 // grown shift. Only visible when the copy already has buckets of its own, i.e. copy-assignment
 // into a grown target, since a fresh target is at the initial shift anyway.
+// rehash() and reserve() take the same decision -- "is the array I have already the right one" --
+// and answer it differently on a table that has no array at all. rehash() is allowed to leave it
+// that way, because a caller who rehashes an empty map has asked for nothing; reserve() is not,
+// because the whole point of it is to have the room before the inserts arrive. Both arms of that
+// were unasserted: a mutation sweep on 2026-09-10 could delete rehash()'s early return, and turn
+// reserve()'s `0 == bucket_count()` into `1 == bucket_count()` -- which is never true, since a
+// table has either no buckets or at least sixty-four -- with the whole suite green.
+TEST_CASE_MAP("rehash_on_an_empty_table_allocates_nothing_and_reserve_allocates", uint64_t, uint64_t) {
+    auto map = map_t();
+    REQUIRE(map.bucket_count() == 0);
+
+    map.rehash(0);
+    REQUIRE(map.bucket_count() == 0); // still nothing: an empty map has nothing to index
+
+    map.reserve(0);
+    REQUIRE(map.bucket_count() > 0); // but reserve() is a request for room, even for none of it
+
+    auto fresh = map_t();
+    fresh.rehash(100);
+    REQUIRE(fresh.bucket_count() >= 100);
+}
+
 TEST_CASE_MAP("copying_an_emptied_table_starts_from_the_smallest_array", uint64_t, uint64_t) {
     auto source = map_t();
     for (uint64_t i = 0; i < 1000; ++i) {

--- a/test/unit/tuple_hash.cpp
+++ b/test/unit/tuple_hash.cpp
@@ -40,7 +40,10 @@ TEST_CASE("tuple_hash_golden_values") {
     REQUIRE(hash<std::tuple<std::uint64_t>>{}({UINT64_MAX}) == UINT64_C(0xffffffffffffffff));
     REQUIRE(hash<std::pair<int, int>>{}({1, 2}) == UINT64_C(0x0008a6bc006f6e06));
     REQUIRE(hash<std::pair<int, int>>{}({2, 1}) == UINT64_C(0xa2312f5f36a55294));
-    REQUIRE(hash<std::tuple<std::uint8_t, std::uint8_t, std::uint8_t>>{}({1, 2, 3}) == UINT64_C(0xd34d2e086bbe0e77));
+    // Written out rather than braced from integer literals: MSVC warns C4244 for the int -> uint8_t
+    // narrowing from inside <tuple>, where gcc and clang keep quiet because it is a system header.
+    auto const bytes = std::tuple<std::uint8_t, std::uint8_t, std::uint8_t>{std::uint8_t{1}, std::uint8_t{2}, std::uint8_t{3}};
+    REQUIRE(hash<std::tuple<std::uint8_t, std::uint8_t, std::uint8_t>>{}(bytes) == UINT64_C(0xd34d2e086bbe0e77));
     REQUIRE(hash<std::tuple<int, std::string>>{}({7, "hello"}) == UINT64_C(0x1140b91276c83448));
     REQUIRE(hash<std::tuple<colour, int>>{}({colour::green, 5}) == UINT64_C(0xdab19772c384ecfa));
 }

--- a/test/unit/tuple_hash.cpp
+++ b/test/unit/tuple_hash.cpp
@@ -4,8 +4,11 @@
 
 #include <third-party/nanobench.h> // for Rng, doNotOptimizeAway, Bench
 
+#include <cstdint>
 #include <string>
 #include <string_view>
+#include <tuple>
+#include <utility>
 
 TEST_CASE("tuple_hash") {
     auto m = ankerl::unordered_dense::map<std::pair<int, std::string>, int>();
@@ -15,6 +18,31 @@ TEST_CASE("tuple_hash") {
     m.try_emplace({1, "a"}, 23);
     m.try_emplace({1, "b"}, 42);
     REQUIRE(m.size() == 2U);
+}
+
+// What hashing a tuple actually computes, pinned.
+//
+// Every other case in this file asks whether *different* tuples hash differently, and they do
+// whatever `to64` does with each element -- so the one decision in it is invisible to all of them.
+// That decision is `if constexpr (is_integral_v<Arg> || is_enum_v<Arg>)`: an integral or an enum is
+// cast straight to 64 bits and the map's own mixing does the rest, anything else is hashed first.
+// Turning that `||` into `&&` sends every integer through `hash<Arg>{}` instead, changing the hash
+// of every tuple in every program -- and a mutation sweep on 2026-09-10 found nothing noticed.
+//
+// As with hash_golden.cpp this is not a promise the values never change. It is a promise that
+// changing them is a decision. The single-element rows are the sharpest: a one element tuple of an
+// integer is that integer, unmixed, which is exactly the property the `||` branch exists for.
+TEST_CASE("tuple_hash_golden_values") {
+    enum class colour : std::uint8_t { red = 1, green = 2 };
+    using ankerl::unordered_dense::hash;
+
+    REQUIRE(hash<std::tuple<>>{}({}) == UINT64_C(0x0000000000000000));
+    REQUIRE(hash<std::tuple<std::uint64_t>>{}({UINT64_MAX}) == UINT64_C(0xffffffffffffffff));
+    REQUIRE(hash<std::pair<int, int>>{}({1, 2}) == UINT64_C(0x0008a6bc006f6e06));
+    REQUIRE(hash<std::pair<int, int>>{}({2, 1}) == UINT64_C(0xa2312f5f36a55294));
+    REQUIRE(hash<std::tuple<std::uint8_t, std::uint8_t, std::uint8_t>>{}({1, 2, 3}) == UINT64_C(0xd34d2e086bbe0e77));
+    REQUIRE(hash<std::tuple<int, std::string>>{}({7, "hello"}) == UINT64_C(0x1140b91276c83448));
+    REQUIRE(hash<std::tuple<colour, int>>{}({colour::green, 5}) == UINT64_C(0xdab19772c384ecfa));
 }
 
 TEST_CASE("good_tuple_hash") {


### PR DESCRIPTION
A sweep of the whole header — **1810 mutants, 78 minutes, 132 survivors**. After triage nine were real; four are closed here.

| verdict | n |
|---|---|
| caught | 817 |
| compiler | 704 |
| hang | 146 |
| survived | 132 |
| oom | 11 |

Most survivors cannot be caught by any test: 22 prefetch hints, 20 moved-from fields never read again, 16 capacity hints that over-allocate at worst, 13 SFINAE relaxations, 4 in code this build does not compile (`_BitScanForward`, and `/ lane_stride` which is `/ 1` under SSE2).

## What the tests pin

- **`hash_golden`: lengths 161 and 209.** Past 144 bytes the counter is reduced by 96 then 48, so the long path's `while (i > 16)` differs from `> 17` only where that leaves exactly **17** — 161 through the 48-byte loop, 209 through the 96-byte one twice. The file already had 65 and 288/289 for the other two loops.
- **`tuple_hash`: seven golden values.** Every other case there asks whether *different* tuples hash differently, which they do whatever `to64` does. Turning `is_integral_v || is_enum_v` into `&&` sends every integer through `hash<Arg>{}` — changing the hash of every tuple in every program — and nothing noticed.
- **`group_bucket`: `reserve()` picks the smallest sufficient array**, at the exact boundaries (51/52, 102/103, 204/205), from both sides: enough for the request, and half of it would not have been.
- **`lazy_bucket_allocation`: `rehash()` on an empty table allocates nothing, `reserve()` allocates.** `0 == bucket_count()` could become `1 == bucket_count()` — never true, since a table has either no buckets or at least 64 — unnoticed.
- **`erase_uncounts`: `finish_erase()` moving an element that is not in its home group**, which no other erase in the suite does. **It kills no mutant and the comment says so** — `slot_of_value()` stops only when it finds the value, so a different probe step reaches it later and never wrongly. It is there for the path, not the constant.

## Verified, not assumed

Re-running the same mutants: `427`, `603`, `1807` and two at `3198` go **survived → caught**.

Still surviving, and equivalent rather than uncovered — recorded so the next sweep doesn't re-litigate them: `1260` is a leak that **ASan does catch** (30 MB in 10010 allocations) and nothing else can; `2613` self-move-assigns a value that is popped immediately after; `2591` and `3198`'s `<=` reallocate more often and rebuild correctly either way; `1806`'s arm only binds at sizes no test can build; `1762` and `3178` as above.

**781 cases green** under clang and under gcc with `--unity=on` — which is where `-Wshadow=global` caught a local `map_t` alias colliding with a file-level one, a failure the clang build could not see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)