### PR TITLE
Measure the insert path, and correct what the notes said about it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,8 +232,12 @@ key compare.
 
 *Compilers.* `always_inline` on `probe` and `do_place_element`: **both kept**, worth 1.244 vs 1.149
 under gcc and 17–20% of a build in a caller's translation unit. clang splits the insert path and
-gcc does not, which is most of the build difference between them; no source change has been found
-that steers it.
+gcc does not, which is most of the build difference between them: measured exactly with callgrind,
+the split costs **15 instructions of prologue and epilogue per insert** and clang pays the same 15
+on boost, so it is the call boundary and not this map's register allocation. **PGO removes all of
+it** (96.4 to 69.3 instructions, 34.0 to 17.5 cycles) on both maps. No source change steers it, and
+six have been tried; what is left against boost once the boundary is gone is eleven instructions,
+and at 4M entries the two are level.
 
 *Still open.* Huge pages (22% of a large lookup, nothing asks for them). ARM prefetch tuning.
 A built-in probe-length statistics facility like boost's. The string erase's ~50 ns second hash.

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- The insert path's instructions, counted one by one: the clang/gcc gap is the call boundary
 - The F14Vector string miss, re-measured, and the old explanation of it is wrong
 - Where they are, from `perf annotate`
 - Splitting the probe so the miss path stops paying for it
@@ -286,6 +287,113 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**The insert path's instructions, counted one by one: the clang/gcc gap is the call boundary, and
+PGO removes all of it** (2026-09-10, issue #234 step 1, asked as "with which issue would you
+start"). This file has said since 2026-09-08 that "a reserved `uint64_t` insert is 97.8
+instructions under clang and 65.9 under gcc, on identical source", and explained the difference as
+clang spilling the probe's loop state at function entry where gcc sinks it into a branch a miss
+never takes -- "a register allocator's choice and not something a source change has been found to
+steer". Nobody had ever listed the instructions. They are listed now and the explanation was wrong.
+
+**First, the tool.** The `/tmp/ins.cpp` that produced those numbers went with `/tmp`, so the
+measurement could not be repeated at all. It is now `insert` and `bump` in
+`scripts/ab/maps_one.{cpp,sh}`: a *reserved* build, so no growth and no rehash is in it, and
+`++m[k]` on a key already present, both counting `reps` in operations so every column is per
+operation, both with the round in a `noinline` function so `objdump` has a symbol.
+
+**Reproduction, n = 50000, per insert, three runs agreeing on instructions to 0.1%:**
+
+| | this map | boost | notes' 2026-09-08 figure |
+|---|---|---|---|
+| clang 22.1.8 | **96.4** instr, 33.8 cyc, 6.4 ns | 82.9, 21.3, 4.1 | this map 97.8 -- reproduces |
+| gcc 16.2.1 | **67.5**, 25.0, 4.7 | 57.0, 16.9, 3.2 | this map 65.9 -- reproduces |
+
+Both of this map's figures reproduce. **Boost's does not**: this file records boost at 64
+instructions under clang and it is 82.9. That figure comes from the 2026-09-05 table, taken with
+the lost tool and before the merged block; the 2026-09-08 entry that restates this map's numbers
+never restated boost's. So the headline "39% behind boost under clang on the insert path" was
+comparing two different measurements. It is **16%** on instructions.
+
+**Second, exact instruction counts, by category.** Sampling cannot answer this -- `perf record -e
+instructions` skids, and attributed 8.4 prefetches per insert to a path that issues 2. What can is
+`valgrind --tool=callgrind --dump-instr=yes`, which counts every instruction exactly. It agrees
+with `perf stat` to 0.5% once the once-per-process key generation is subtracted. Per insert, in
+each binary's own code:
+
+| category | gcc, this map | clang, this map | gcc, boost | clang, boost |
+|---|---|---|---|---|
+| **prologue/epilogue** | **1.00** | **15.00** | **0.00** | **15.00** |
+| call | 0.00 | 1.00 | 0.00 | 1.00 |
+| move/load/store | 16.94 | 30.56 | 14.77 | 26.50 |
+| arithmetic/address | 16.21 | 20.15 | 19.51 | 19.43 |
+| compare/branch | 13.57 | 18.19 | 9.42 | 9.15 |
+| fingerprint compare (SSE2) | 10.89 | 9.92 | 9.24 | 9.19 |
+| spill + reload + frame | 11.53 | 4.20 | 8.69 | 7.29 |
+| prefetch | 2.01 | 2.01 | 0.00 | 0.00 |
+| **total** | **67.1** | **96.0** | **56.5** | **82.5** |
+
+Read the first row. Clang pays **fifteen instructions of prologue and epilogue per insert** -- six
+pushes, six pops, a frame adjust either side, a `ret` -- plus the call. gcc pays one. And **clang
+pays the same fifteen on boost**, which is what settles what this is: not a register allocator
+mishandling this map's probe, but *the function-call boundary*, paid because clang leaves the
+operation out of line and gcc inlines it into the caller. The spill and reload columns, which the
+old diagnosis named, go the other way: gcc spills more than clang does, 11.53 against 4.20.
+
+**Third, PGO, and it is decisive.** Hot/cold outlining and inlining are profile decisions, so the
+question was whether clang can do it when told. Instrument, run, rebuild:
+
+| | instructions | cycles |
+|---|---|---|
+| clang, this map, plain | 96.4 | 34.0 |
+| clang, this map, **PGO** | **69.3** | **17.5** |
+| clang, boost, plain | 82.9 | 23.7 |
+| clang, boost, **PGO** | **57.8** | **14.2** |
+| gcc, this map, plain | 67.6 | 31.2 |
+| gcc, this map, PGO | 69.5 | 25.8 |
+
+**PGO removes 27 instructions from clang and halves its cycles, on both maps.** After it, clang and
+gcc retire the same work on this map (69.3 against 67.6) and clang's code is much the faster of the
+two. gcc gains nothing on instructions because it had already inlined. So the clang/gcc instruction
+gap is a missing profile and nothing else, and no source shuffle was ever going to close it -- which
+is why the six that were tried did not.
+
+**What is left, once the boundary is out of the way, is about eleven instructions.** This map
+against boost, PGO to PGO under clang, 69.3 against 57.8; under gcc 67.6 against 57.0. By category
+under gcc the difference is +4.2 compare/branch, +3.8 frame accesses, +2.2 move, +2.0 prefetch (the
+probe's two `prefetch_index`, which boost does not issue on an insert), +1.7 on the vector compare
+and -3.3 arithmetic. That is the real design difference and it is roughly the second walk: this map
+probes to find the key absent and then walks again in `place_group`, where boost's probe returns the
+position it will insert at. Eleven instructions, not thirty-four.
+
+**And it is an in-cache statement only.** The same measurement at four million entries:
+
+| n | clang, this map | clang, boost | gcc, this map | gcc, boost |
+|---|---|---|---|---|
+| 50000 | 6.4 ns | 4.1 | 4.7 | 3.2 |
+| 200000 | 6.9 | 5.6 | 6.3 | 3.9 |
+| **4000000** | **35.6** | **34.6** | **28.7** | **28.3** |
+
+At four million they are level -- within 3% on both compilers -- and this map takes **0.80 dTLB
+misses per insert against boost's 1.37** and 1.07 branch misses against 1.26. Whatever the insert
+path costs, it stops mattering exactly where the table stops fitting in cache.
+
+**The other two workloads, for the record.** `++m[k]` on a key already present, n = 50000: this map
+84.7 instructions under clang and 90.9 under gcc, boost 80.9 and 57.1. Here *both* compilers leave
+this map's `do_try_emplace` out of line (15.4 instructions of prologue in both) while gcc inlines
+boost's, which is 15 of the 34 that separate them under gcc. That path is also where
+`always_inline` on `do_place_element` is paid without being used, and the callgrind table says what
+it costs: the placement code makes `do_try_emplace` too big for the caller, so every `operator[]`
+buys a call boundary. That is the trade the entry below on `always_inline` describes from the other
+side, now with a number on it. A **string** insert reverses the whole picture: 491 instructions
+under clang against boost's 454, and **27.3 ns against 34.9** -- 21% *faster* on 8% more
+instructions, on 7.2 L1 misses against 11.2 and 1.45 branch misses against 2.16.
+
+**So the standing sentence in `CLAUDE.md`, "clang splits the insert path and gcc does not, which is
+most of the build difference between them; no source change has been found that steers it", is
+right about the mechanism and wrong about the remedy.** A profile steers it completely. Nothing
+here recommends shipping a PGO build -- a header library cannot -- but it does say where the next
+attempt should not go: not at the probe's register allocation, which was never the problem.
+
 **The F14Vector string miss, re-measured, and the old explanation of it is wrong** (2026-09-10,
 asked as "is my map the fastest dense map"). The paired octave still has F14VectorMap ahead on
 string lookups -- miss 1.06 at the 1000 octave and 1.09 at 32000, hit 1.02-1.03, half 1.04-1.06 --

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -394,6 +394,33 @@ right about the mechanism and wrong about the remedy.** A profile steers it comp
 here recommends shipping a PGO build -- a header library cannot -- but it does say where the next
 attempt should not go: not at the probe's register allocation, which was never the problem.
 
+**And the one candidate the list suggested is dead too, which is the useful half of it.** The table
+above says `always_inline` on `do_place_element` makes `do_try_emplace` too big for its caller, so
+every writing lookup buys a call boundary; the obvious answer is to move the attribute. Five
+variants, one map per binary, instructions per operation (per element for `build`), both compilers:
+
+| | clang insert | clang bump | clang build | gcc insert | gcc bump | gcc build |
+|---|---|---|---|---|---|---|
+| **A, shipped** (placement `always_inline`) | **96.4** | 84.7 | **140.4** | **67.6** | 90.9 | **123.3** |
+| B, placement plain | 124.4 | 83.7 | 168.5 | 65.5 | 90.9 | 125.2 |
+| C, placement `noinline` | 124.4 | 83.7 | 168.5 | 144.4 | **72.8** | 198.0 |
+| D, placement **and** `do_try_emplace` `always_inline` | **96.4** | 84.7 | **140.4** | **67.6** | 90.9 | **123.3** |
+| E, C plus `do_try_emplace` `always_inline` | 124.4 | 83.8 | 168.5 | 144.4 | **72.8** | 198.0 |
+
+**D is identical to A in every column** -- not close, identical -- and the binaries differ. In A the
+out-of-line symbol is `do_try_emplace`; in D that symbol is gone and **`try_emplace` is out of line
+instead**. Forcing the inner function into its caller moves the boundary outward by one level and
+changes nothing at all, because the outermost function that does not carry the attribute is the one
+that pays, and there is always one. You cannot inline your way to the caller's loop from inside a
+header. That is why PGO was the only thing that removed it: it inlines the whole chain into the loop
+that calls it.
+
+**C is the trade named out loud and it is a bad one**: 20% off a gcc `++m[k]` (90.9 to 72.8) for
+**61% onto a gcc build** (123.3 to 198.0) and 20% onto a clang one. B reproduces this file's own
+17-20% build regression exactly, now as an instruction count rather than a time: clang build 140.4
+to 168.5. So `always_inline` on `do_place_element` stays, for the third time, and the call boundary
+on `operator[]` is its price, which nothing in the source can refuse.
+
 **The F14Vector string miss, re-measured, and the old explanation of it is wrong** (2026-09-10,
 asked as "is my map the fastest dense map"). The paired octave still has F14VectorMap ahead on
 string lookups -- miss 1.06 at the 1000 octave and 1.09 at 32000, hit 1.02-1.03, half 1.04-1.06 --

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -80,6 +80,18 @@ hides completely.
 `maps_one.sh` builds **one map per binary** and runs it under `perf stat`, because a binary holding
 several maps has a code layout that moves by more than a 3% question every time any of them
 changes. Anything under about 10% is decided there, with counters, and not by the paired harness.
+Its third argument is a count of operations and its default is 30000000; passing a small number
+measures the machine's noise floor rather than the map. `AB_CORE` pins the measured binary to one
+core, which the cycle columns want and the instruction counts do not need.
+
+Two of its workloads are the insert path taken apart, because that is where this map is furthest
+behind a flat one and nothing measured it on its own. `insert` builds a map that was told its size
+first, so growth and the rehash are out of it and what is left is a probe that misses, a value
+appended and a slot pointed at it; `bump` is `++m[k]` on a key that is already there, which places
+nothing and is the commonest map operation there is. Both count `reps` in operations, so every
+column is per insert and per bump, and both put their round in a `noinline` function so that
+`objdump -d` has a symbol -- which is the whole point of them, since the question is which
+instructions are in it.
 
 `scripts/ab/hash_others.sh` is the same idea for the *hash* rather than the index: this library's
 wyhash, its own older version, `boost::hash`, `absl::Hash` and `folly::hasher` over six key lengths

--- a/scripts/ab/maps.h
+++ b/scripts/ab/maps.h
@@ -103,7 +103,14 @@ namespace udm_maps {
 
 template <typename Map>
 struct stl_like {
+    // Whether reserve() below really reserves. A map that cannot be told its size in advance would
+    // otherwise measure its own growth in a workload whose whole point is that growth is out of it.
+    static constexpr bool reserves = true;
+
     Map m{};
+    void reserve(std::size_t n) {
+        m.reserve(n);
+    }
     template <typename K>
     void insert(K const& k, std::size_t v) {
         m.try_emplace(k, v);
@@ -188,6 +195,11 @@ struct a_verstable {
     a_verstable(a_verstable const&) = delete;
     auto operator=(a_verstable const&) -> a_verstable& = delete;
 
+    static constexpr bool reserves = true;
+    void reserve(std::size_t n) {
+        vtab_reserve(&t, n);
+    }
+
     // _insert replaces an existing value, like insert_or_assign; the honest counterpart of
     // try_emplace is _get_or_insert.
     void insert(std::uint64_t k, std::size_t v) {
@@ -239,6 +251,11 @@ struct a_ihtab {
                   "fixed by the macro template it wraps: only the uint64_t key and the 8 byte value");
     static constexpr char const* name = "ihtab";
     iht::ihtab<iht_entry, iht_hash, iht_eq> t{8};
+
+    // Sized at construction and never afterwards, so this cannot honour the request. Said out loud
+    // rather than silently ignored: `reserves` is what makes the harness print the difference.
+    static constexpr bool reserves = false;
+    void reserve(std::size_t /*n*/) {}
 
     void insert(std::uint64_t k, std::size_t v) {
         auto e = iht_entry{k, v};
@@ -410,6 +427,21 @@ auto build(pools<Key> const& p) -> std::size_t {
     return m.size();
 }
 
+// The same build with the size known in advance, which takes growth and the rehash out of it and
+// leaves the pure insert path: a probe that misses, a value appended, a slot pointed at it. That is
+// the thing this map is slowest at relative to a flat one -- 97.8 instructions under clang against
+// boost's 64 on 2026-09-08 -- and there was no tool in the repository that measured it on its own.
+//
+// A map that cannot reserve (Map::reserves is false) measures its own growth here instead, which is
+// a different quantity; maps_one.cpp prints which it was.
+template <typename Map, typename Key>
+auto build_reserved(pools<Key> const& p) -> std::size_t {
+    auto m = Map();
+    m.reserve(p.present.size());
+    fill(m, p);
+    return m.size();
+}
+
 // The rngs outlive the epochs on purpose. A benchmark whose per-epoch batch is small enough to
 // memorise must advance its own randomness, or a TAGE-style predictor learns the sequence of hits
 // and misses and flatters whichever probe has the most branches in it -- measured at 2.7x once.
@@ -427,6 +459,23 @@ auto lookups(Map& m, pools<Key> const& p, lookup_state& st, asking what, std::si
         auto const at = static_cast<std::size_t>(((st.rng() >> 32U) * p.present.size()) >> 32U);
         auto const hit = what == asking::hits || (what == asking::half && (st.coin() & 1U) != 0);
         acc += m.count(hit ? p.present[at] : p.absent[at]);
+    }
+    return acc;
+}
+
+// ++m[k] on a key that is already there: the writing lookup, which finds the key, does not place
+// anything, and on this map also gets move_home(). It is the commonest map operation there is and
+// it is where an always_inline placement path is paid for without being used (clang 73.2
+// instructions against 48.4 without it), so it is measured on its own rather than inside churn.
+//
+// Draws its keys the way lookups() does, from a state that outlives the epoch: a batch small enough
+// to memorise, replayed, is learned by the branch predictor.
+template <typename Map, typename Key>
+auto bump_present(Map& m, pools<Key> const& p, lookup_state& st, std::size_t n) -> std::size_t {
+    auto acc = std::size_t{0};
+    for (std::size_t i = 0; i < n; ++i) {
+        auto const at = static_cast<std::size_t>(((st.rng() >> 32U) * p.present.size()) >> 32U);
+        acc += m.bump(p.present[at]);
     }
     return acc;
 }

--- a/scripts/ab/maps_one.cpp
+++ b/scripts/ab/maps_one.cpp
@@ -6,10 +6,16 @@
 // smaller than 10% is decided here instead, with counters.
 //
 //   -DUDM_ONE_MAP=<index into maps_for<Key>::type>   -DUDM_ONE_STR   to use string keys
-//   argv: <hit|miss|half|build|churn|ie|iterate|none> [entries] [reps]
+//   argv: <hit|miss|half|insert|bump|build|churn|ie|iterate|none> [entries] [reps]
 //
 // `none` runs the workload's loop with no map in it at all, which is what the other numbers are
 // netted against.
+//
+// `insert` and `bump` are the two halves of the insert path, and `reps` counts operations for both,
+// so every column comes out per insert and per bump. `insert` builds a *reserved* map, so what it
+// measures has no growth and no rehash in it; `bump` is ++m[k] on a key already present. Their
+// bodies sit in noinline functions on purpose -- `objdump -d` then has a symbol to disassemble, and
+// the question these two modes exist for is which instructions are in that symbol.
 
 #include "maps.h"
 
@@ -37,6 +43,19 @@ using one_val = std::size_t;
 #endif
 using map_t = std::tuple_element_t<UDM_ONE_MAP, typename maps_for<one_key, one_val>::type>;
 
+// One round of each, out of line so that the disassembly has a name to look for. The map itself
+// still inlines into these exactly as it does into any caller; the counts are the check that it
+// does.
+template <typename Key>
+[[gnu::noinline]] auto insert_round(pools<Key> const& p) -> std::size_t {
+    return build_reserved<map_t>(p);
+}
+
+template <typename Key>
+[[gnu::noinline]] auto bump_round(map_t& m, pools<Key> const& p, lookup_state& st, std::size_t n) -> std::size_t {
+    return bump_present(m, p, st, n);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -52,6 +71,19 @@ int main(int argc, char** argv) {
         for (std::size_t i = 0; i < reps; ++i) {
             acc += build<map_t>(p);
         }
+    } else if (what == "insert") {
+        // reps counts inserts, not rounds, so the per-op columns are per insert. What is left in
+        // them besides the insert is one allocate-and-free pair per n of them -- under a tenth of an
+        // instruction per insert at n = 50000, and the same for every map -- so it is not netted out.
+        auto const rounds = reps < n ? std::size_t{1} : static_cast<std::size_t>(reps / n);
+        for (std::size_t i = 0; i < rounds; ++i) {
+            acc += insert_round(p);
+        }
+    } else if (what == "bump") {
+        auto m = map_t();
+        fill(m, p);
+        auto st = lookup_state();
+        acc += bump_round(m, p, st, reps);
     } else if (what == "none") {
         // the lookup loop's own cost: the rng, the index arithmetic and the key selection
         auto st = lookup_state();
@@ -83,5 +115,11 @@ int main(int argc, char** argv) {
             acc += lookups(m, p, st, ask, reps);
         }
     }
-    std::printf("%s %s n=%zu reps=%zu acc=%zu\n", map_t::name, what.c_str(), n, reps, acc);
+    std::printf("%s %s n=%zu reps=%zu acc=%zu%s\n",
+                map_t::name,
+                what.c_str(),
+                n,
+                reps,
+                acc,
+                what == "insert" && !map_t::reserves ? " (cannot reserve: this is a growing build)" : "");
 }

--- a/scripts/ab/maps_one.sh
+++ b/scripts/ab/maps_one.sh
@@ -5,6 +5,11 @@
 #   scripts/ab/maps_one.sh [-c COMPILER] [-k u64|str|big] <workload> <entries> <reps> [map...]
 #
 # With no map named it does all of them. Netting out the loop is what the `none` workload is for.
+# `reps` is a count of operations and its default in the binary is 30000000; a small value measures
+# noise rather than the map.
+#
+# AB_CORE pins the measured binary to one core. Unset it and nothing is pinned, which is what this
+# always did -- instruction counts do not need it and cycles do.
 set -euo pipefail
 export LC_ALL=C # a German locale prints 1,23 and every awk over perf output then reads 1
 cxx=clang++ keys=u64
@@ -56,8 +61,10 @@ for i in "${!names[@]}"; do
     "$cxx" "${flags[@]}" -DUDM_ONE_MAP="$i" "$root/scripts/ab/maps_one.cpp" "$nbo" "${srcs[@]}" "${libs[@]}" -o "$bin"
     # task-clock rather than an external timer: `/usr/bin/time -f %e` has 10 ms of resolution,
     # which over a run of a fifth of a second quantises ns/op into visible steps.
+    pin=()
+    [ -n "${AB_CORE:-}" ] && pin=(taskset -c "$AB_CORE")
     out=$(perf stat -x, -e task-clock,cycles,instructions,branch-misses,L1-dcache-load-misses,dTLB-load-misses \
-              "$bin" "$work" "$n" "$reps" 2>&1)
+              "${pin[@]}" "$bin" "$work" "$n" "$reps" 2>&1)
     get() { echo "$out" | awk -F, -v e="$1" '$3==e {print $1}'; }
     awk -v name="$name" -v reps="$reps" -v ms="$(get task-clock)" -v c="$(get cycles)" \
         -v ins="$(get instructions)" -v bm="$(get branch-misses)" \


### PR DESCRIPTION
Issue #234, step 1: list the instructions clang's insert path has and gcc's does not, before
changing anything. The header is untouched.

## The tool, because there was none

The `/tmp/ins.cpp` that produced "97.8 instructions under clang and 65.9 under gcc" is gone with
`/tmp`, so the number could not be re-taken. `scripts/ab/maps_one.{cpp,sh}` gain two workloads:

- `insert` — a **reserved** build, so growth and the rehash are out of it and what is left is the
  pure insert path.
- `bump` — `++m[k]` on a key already present, which places nothing.

Both count `reps` in operations, so every column is per operation, and both put their round in a
`noinline` function so `objdump` has a symbol. Adapters gain `reserve()`; ihtab, which is sized at
construction only, says so through `reserves` instead of quietly measuring its own growth.
`AB_CORE` optionally pins the measured binary.

## What it found

**This map's figures reproduce; boost's do not.** clang 96.4 against the recorded 97.8, gcc 67.5
against 65.9 — but boost is **82.9**, not the 64 this repository has been quoting. That 64 came
from the 2026-09-05 table and the lost tool; the gap is 16%, not 39%.

**The clang/gcc difference is the call boundary.** Counted exactly with `callgrind --dump-instr`
(sampling skids badly enough to attribute 8.4 prefetches to a path that issues 2), per insert:

| category | gcc, this map | clang, this map | gcc, boost | clang, boost |
|---|---|---|---|---|
| **prologue/epilogue** | **1.00** | **15.00** | **0.00** | **15.00** |
| spill + reload + frame | 11.53 | 4.20 | 8.69 | 7.29 |
| total | 67.1 | 96.0 | 56.5 | 82.5 |

Clang pays fifteen instructions of prologue and epilogue per insert and **pays the same fifteen on
boost**. The spill columns, which the old diagnosis named, go the other way: gcc spills more.

**PGO removes 27 instructions and halves the cycles, on both maps** (this map 96.4 → 69.3 and
34.0 → 17.5). So the gap is a missing profile, which is why none of the six source changes tried
against it worked.

**What is left against boost is about eleven instructions** — roughly the second walk in
`place_group` — and **at four million entries the two maps are level** (35.6 ns against 34.6), with
0.80 dTLB misses per insert here against boost's 1.37.

A string insert reverses it outright: 21% faster on 8% more instructions.

## Verification

- `scripts/ab/maps.sh check u64` and `check str` green: 18 and 16 maps agree over 400000 operations.
- Instruction counts stable to 0.1% over three runs; callgrind and `perf stat` agree to 0.5%.
- No diff under `include/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)