### PR TITLE
Split the probe past the home group, for keys whose compare is a call

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -742,6 +742,11 @@ inline constexpr std::array<std::uint32_t, 256> fingerprint_words = make_fingerp
 // report `is_trivially_copyable_v<std::pair<std::uint64_t, std::uint64_t>>` as false. Keying on
 // that would have split one of the commonest key types after string and integer and cost it 40%.
 //
+// A pair and a tuple are asked about their elements rather than about themselves, because that is
+// what comparing one does -- and because the answer for the aggregate is not portable: MSVC's
+// `std::tuple<int, int>` is not trivially copy-constructible where libstdc++'s and libc++'s is, so
+// without this a tuple key would take a different probe on Windows than everywhere else.
+//
 // A user type that is trivially copy-constructible and still compares through a call (a large byte
 // array) is treated as cheap and does not get the split. Measured, that costs it about 2%, and the
 // heuristic never misfires in the expensive direction.
@@ -750,6 +755,13 @@ struct key_compare_is_call : std::bool_constant<!std::is_trivially_copy_construc
 
 template <typename CharT, typename Traits>
 struct key_compare_is_call<std::basic_string_view<CharT, Traits>> : std::true_type {};
+
+template <typename A, typename B>
+struct key_compare_is_call<std::pair<A, B>>
+    : std::bool_constant<key_compare_is_call<A>::value || key_compare_is_call<B>::value> {};
+
+template <typename... Ts>
+struct key_compare_is_call<std::tuple<Ts...>> : std::bool_constant<(key_compare_is_call<Ts>::value || ...)> {};
 
 template <typename Key>
 constexpr bool key_compare_is_call_v = key_compare_is_call<Key>::value;

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -721,6 +721,39 @@ namespace detail {
 }
 inline constexpr std::array<std::uint32_t, 256> fingerprint_words = make_fingerprint_words();
 
+// Whether comparing two keys of this type is a *call*, which decides how the probe is shaped.
+//
+// A probe that leaves its home group needs the delta and the group mask, and about 3% of lookups
+// leave it. When the key compare is a register compare, those two values live in registers and cost
+// nothing; when it is a call -- a `memcmp` for a string -- everything the loop keeps live has to
+// survive the call, and the compiler builds a frame and spills them before the *first* group is
+// even compared. Splitting the rare part out of line then removes the frame from the common path,
+// and that is worth 8-9% of a string lookup and costs an integer one 20-40% (measured 2026-09-10,
+// `notes/index-design.md`), so it has to be decided per key type.
+//
+// No trait separates the two cases -- `std::string_view` and `std::pair<std::uint64_t,
+// std::uint64_t>` are both sixteen bytes and both trivially copyable, and they want opposite
+// answers -- so this is a heuristic plus the one exception the standard library provides. A type
+// whose copy constructor is trivial holds no indirection, and so is compared field by field unless
+// it is a view; `basic_string_view` is the view the library knows about.
+//
+// **Trivially copy-constructible, not trivially copyable**, and the difference is not pedantry:
+// `std::pair` and `std::tuple` write their own copy *assignment*, so both libstdc++ and libc++
+// report `is_trivially_copyable_v<std::pair<std::uint64_t, std::uint64_t>>` as false. Keying on
+// that would have split one of the commonest key types after string and integer and cost it 40%.
+//
+// A user type that is trivially copy-constructible and still compares through a call (a large byte
+// array) is treated as cheap and does not get the split. Measured, that costs it about 2%, and the
+// heuristic never misfires in the expensive direction.
+template <typename Key>
+struct key_compare_is_call : std::bool_constant<!std::is_trivially_copy_constructible_v<Key>> {};
+
+template <typename CharT, typename Traits>
+struct key_compare_is_call<std::basic_string_view<CharT, Traits>> : std::true_type {};
+
+template <typename Key>
+constexpr bool key_compare_is_call_v = key_compare_is_call<Key>::value;
+
 template <typename T>
 using detect_is_transparent = typename T::is_transparent;
 
@@ -1625,13 +1658,15 @@ private:
     // measured 0.66 of the robin hood index, and forcing it took them to 1.23; with SSE2 the same
     // change was churn 1.32, string hits 1.22 and the integer build 1.42 against the commit before.
     // clang inlined it already and measures 1.00 everywhere.
+    // The probe's loop, from a group and the distance already walked. Written out rather than built
+    // from a per-group helper: returning a probe_result from an inner function costs gcc 26% of an
+    // integer hit even fully inlined, and this path must stay exactly what it was for a key whose
+    // compare is cheap.
     template <typename K>
-    ANKERL_UNORDERED_DENSE_FORCEINLINE auto probe(K const& key, std::uint64_t mh) const -> probe_result {
-        auto const word = fingerprint_word(mh);
-        auto const counter = word & 7U;
-        auto group_idx = group_idx_from_hash(mh);
+    ANKERL_UNORDERED_DENSE_FORCEINLINE auto
+    probe_from(K const& key, std::uint32_t word, unsigned counter, value_idx_type group_idx, value_idx_type delta) const
+        -> probe_result {
         auto const* groups = m_buckets.data();
-        value_idx_type delta = 0;
         while (true) {
             prefetch_index(groups, group_idx);
             auto const& group = groups[group_idx];
@@ -1651,6 +1686,52 @@ private:
                 return {0, 0, false};
             }
             group_idx = next_group(group_idx, delta);
+        }
+    }
+
+    // Everything past the home group, out of line, for a key whose compare is a call. See
+    // detail::key_compare_is_call for what that buys and what it would cost the other kind of key.
+    // Entered by a tail call, so the caller keeps nothing live across it.
+    template <typename K>
+    ANKERL_UNORDERED_DENSE_NOINLINE auto
+    probe_past_home(K const& key, std::uint32_t word, unsigned counter, value_idx_type group_idx, value_idx_type delta) const
+        -> probe_result {
+        return probe_from(key, word, counter, group_idx, delta);
+    }
+
+    template <typename K>
+    ANKERL_UNORDERED_DENSE_FORCEINLINE auto probe(K const& key, std::uint64_t mh) const -> probe_result {
+        auto const word = fingerprint_word(mh);
+        auto const counter = word & 7U;
+        auto const home_idx = group_idx_from_hash(mh);
+        if constexpr (!detail::key_compare_is_call_v<Key>) {
+            return probe_from(key, word, counter, home_idx, 0);
+        } else {
+            // The home group inline and the rest behind a call, which is where the frame goes.
+            auto const* groups = m_buckets.data();
+            prefetch_index(groups, home_idx);
+            auto const& home = groups[home_idx];
+            auto lanes = match_fingerprint(home, word);
+            while (lanes != 0) {
+                auto const lane = first_lane(lanes);
+                auto const slot = static_cast<value_idx_type>(std::size_t{home_idx} * slots_per_group + lane);
+                auto const value_idx = home.m_index[lane];
+                if (m_equal(key, get_key(m_values[value_idx]))) {
+                    return {slot, value_idx, true};
+                }
+                lanes &= lanes - 1;
+            }
+            // The loop's two stopping conditions at delta 0: nothing of this class ever overflowed
+            // past home, or there is nowhere else to look. The second is `delta == m_group_mask`
+            // with delta zero, and it cannot fire while the smallest array is four groups -- it is
+            // kept because it is what the loop tests, not because it is reachable, so a mutation
+            // survivor on it is expected rather than a hole.
+            if (home.m_overflows[counter] == 0 || m_group_mask == 0) {
+                return {0, 0, false};
+            }
+            value_idx_type delta = 0;
+            auto const next = next_group(home_idx, delta);
+            return probe_past_home(key, word, counter, next, delta);
         }
     }
 

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- Splitting the probe past the home group: kept, for keys whose compare is a call
 - The insert path's instructions, counted one by one: the clang/gcc gap is the call boundary
 - The F14Vector string miss, re-measured, and the old explanation of it is wrong
 - Where they are, from `perf annotate`
@@ -287,6 +288,77 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**Splitting the probe past the home group: kept, for keys whose compare is a call** (2026-09-10,
+issue #233). The entry below records this being tried on 2026-09-10 and reverted -- string miss
+138.3 to 126.5 instructions, integer miss 55.8 to 65.9 and integer hit 69.1 to 85.0, "it buys 8% of
+the one workload we lose and spends 20% of the ones we lead by most". Both halves of that reproduce
+exactly. What was missing is that the two halves are selected by the **key type**, and can be had
+separately.
+
+**Why the frame is there.** For a `std::string` key the probe builds a frame and spills the loop
+state -- the counter, `this`, the mask, the delta, the hash and the broadcast fingerprint -- before
+the first group is compared, because the key compare is a `memcmp` call and everything the loop
+keeps live has to survive it. Only about 3% of lookups leave the home group, and the delta and the
+mask are the only things the rest of the walk needs, so the frame is paid by every lookup for a path
+almost none of them take. Where the compare is a register compare there is no call, nothing has to
+survive anything, and splitting only adds a call.
+
+**Measured per key type**, one map per binary, instructions per lookup, clang 22 (miss):
+
+| key | shipped | split | |
+|---|---|---|---|
+| `std::string` | 140.6 | **128.8** | **-8.4%**, and 19.65 ns to 17.85 |
+| `std::string_view` | 134.2 | **122.4** | **-8.8%** |
+| `std::uint64_t` | 56.1 | 67.1 | +20% |
+| `std::pair<std::uint64_t, std::uint64_t>` | 50.2 | 70.2 | **+40%** |
+| 64 byte POD, `memcmp` compare | 111.4 | 109.4 | -1.8% |
+
+So the split is gated on `detail::key_compare_is_call<Key>`, and **integer codegen is byte-identical
+to the shipped header** on both compilers -- 56.1 / 59.9 / 70.0 under clang and 58.1 / 57.0 / 68.6
+under gcc, before and after, on miss, hit and half. The `map<uint64_t, big_value>` workloads are
+identical to the tenth as well. Strings gain everywhere: clang miss -8.2%, half -4.3%, hit -1.7%,
+insert -3.2%; gcc miss -4.0%, half -2.3%, hit -1.4%, insert -3.0%; churn and insert-erase -1 to
+-2%; the one loss is `++m[k]` on a present string key, +2.2% under clang and +0.3% under gcc.
+Timings, three runs each, medians: clang string miss **19.65 to 17.85 ns**, hit 25.00 to 24.55, half
+24.60 to 24.00; gcc 16.15 to 15.80, 22.95 to 22.65, 22.45 to 22.35. Every cell improves.
+
+**The trait is `is_trivially_copy_constructible`, and the difference from `is_trivially_copyable` is
+a 40% bug.** `std::pair` and `std::tuple` write their own copy *assignment*, so both libstdc++ and
+libc++ report `is_trivially_copyable_v<std::pair<std::uint64_t, std::uint64_t>>` as **false**. The
+first version of this keyed on that, and split one of the commonest key types after string and
+integer. `std::string_view` is the other way round -- trivially copyable and still a call -- and no
+trait separates it from `pair<uint64_t, uint64_t>`, since both are sixteen bytes and hold no
+indirection the language can see. It is named explicitly. A user type that is trivially
+copy-constructible and still compares through a call is treated as cheap and loses the ~2% in the
+last row, which is the harmless direction to be wrong in.
+
+**And the shape of the code is load-bearing.** Factoring the per-group compare into a helper
+returning a `probe_result`, so that the split and unsplit paths share it, is tidier and costs **gcc
+26% of an integer hit** (57.0 to 72.0) and clang 6.7%, fully inlined, purely from returning a
+twelve-byte struct through an inner function. The loop is written out instead, and the unsplit path
+is the shipped loop unchanged, which is what makes the integer columns identical rather than merely
+close.
+
+**Mutation swept, and the one hole it found is closed.** The split duplicates the probe's
+"did anything of this class overflow past me" test into an inline home-group check, and turning that
+`== 0` into `== 1` was **caught by nothing** -- it stops a probe at home whenever exactly one entry
+of the key's class went past, so that entry becomes unfindable. Reaching it by chance needs a string
+whose home counter happens to be one; `test/unit/probe_split.cpp` reaches it on purpose, with
+`fuzz_group_index`'s construction -- an identity hash and a key type whose copy constructor is user
+provided, so the key names its group and its fingerprint class *and* takes the split path. Fill
+group 0, send one key of class 3 past it, look that key up. Of the other survivors, all are
+performance-only (dropping the `!` on the gate, deleting a prefetch, `||` to `&&`, deleting an early
+return) or write to `slot` and `value_idx` in a result whose `found` is false, which the type
+documents as meaningless; and `m_group_mask == 0` is equivalent, since the smallest array is four
+groups and the disjunct never fires either way.
+
+**What this does not claim.** The scored benchmark's string workloads are a third of it, so the
+score moves by about 1%; that is not the argument. The argument is the instruction counts, which
+neither code layout nor drift can move, and the rule that a paired A/B cannot measure a change that
+moves an inlining boundary. Against F14VectorMap, the one lookup this map lost, the string miss goes
+from 140.6 instructions to 128.8 against its 131.4 -- ahead on instructions, still 2.3% behind on
+time.
+
 **The insert path's instructions, counted one by one: the clang/gcc gap is the call boundary, and
 PGO removes all of it** (2026-09-10, issue #234 step 1, asked as "with which issue would you
 start"). This file has said since 2026-09-08 that "a reserved `uint64_t` insert is 97.8

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -328,7 +328,13 @@ libc++ report `is_trivially_copyable_v<std::pair<std::uint64_t, std::uint64_t>>`
 first version of this keyed on that, and split one of the commonest key types after string and
 integer. `std::string_view` is the other way round -- trivially copyable and still a call -- and no
 trait separates it from `pair<uint64_t, uint64_t>`, since both are sixteen bytes and hold no
-indirection the language can see. It is named explicitly. A user type that is trivially
+indirection the language can see. It is named explicitly.
+
+A pair and a tuple are then asked about their *elements* rather than about themselves, which CI
+found rather than reasoning: **MSVC's `std::tuple<int, int>` is not trivially copy-constructible
+where libstdc++'s and libc++'s is**, so asking the aggregate gave a tuple key a different probe on
+Windows than everywhere else, and all four Windows legs went red on the `static_assert` that pins
+it. Recursing is also simply what comparing a pair does. A user type that is trivially
 copy-constructible and still compares through a call is treated as cheap and loses the ~2% in the
 last row, which is the harmless direction to be wrong in.
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -40,6 +40,7 @@ test_sources = [
     'unit/erase_if.cpp',
     'unit/erase_churn.cpp',
     'unit/move_home.cpp',
+    'unit/probe_split.cpp',
     'unit/erase_range.cpp',
     'unit/erase_throwing_move.cpp',
     'unit/erase_uncounts.cpp',

--- a/test/unit/probe_split.cpp
+++ b/test/unit/probe_split.cpp
@@ -45,16 +45,21 @@ using ankerl::unordered_dense::detail::key_compare_is_call_v;
 static_assert(!key_compare_is_call_v<std::uint64_t>);
 static_assert(!key_compare_is_call_v<int>);
 static_assert(!key_compare_is_call_v<pod_key>);
-// `std::pair` and `std::tuple` write their own copy *assignment*, so they are not trivially
-// copyable even when their members are. Keying the trait on `is_trivially_copyable` rather than on
-// `is_trivially_copy_constructible` split them and cost 40%; this is that bug, pinned.
+// A pair and a tuple are asked about their elements. Two bugs are pinned here at once: keying the
+// trait on `is_trivially_copyable` rather than on `is_trivially_copy_constructible` split both of
+// these and cost 40%, and asking either about *itself* splits a tuple on MSVC and not elsewhere,
+// because MSVC's std::tuple is not trivially copy-constructible where libstdc++'s and libc++'s is.
 static_assert(!key_compare_is_call_v<std::pair<std::uint64_t, std::uint64_t>>);
 static_assert(!key_compare_is_call_v<std::tuple<int, int>>);
+static_assert(!key_compare_is_call_v<std::tuple<>>);
+static_assert(!key_compare_is_call_v<std::pair<int, std::pair<int, char>>>);
 
 // Compared through a call: the probe splits.
 static_assert(key_compare_is_call_v<std::string>);
 static_assert(key_compare_is_call_v<owning_key>);
 static_assert(key_compare_is_call_v<std::pair<int, std::string>>);
+static_assert(key_compare_is_call_v<std::tuple<int, int, std::string>>);
+static_assert(key_compare_is_call_v<std::pair<int, std::pair<int, std::string>>>);
 // Trivially copyable, and still a call, which is why it is named rather than deduced.
 static_assert(key_compare_is_call_v<std::string_view>);
 static_assert(key_compare_is_call_v<std::wstring_view>);

--- a/test/unit/probe_split.cpp
+++ b/test/unit/probe_split.cpp
@@ -1,0 +1,219 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// Which shape of probe a key type gets, pinned.
+//
+// A key whose comparison is a call makes the probe build a frame and spill the loop state before
+// the first group is compared, because everything the loop keeps live has to survive that call.
+// Handing everything past the home group to an out-of-line function removes the frame from the
+// common path: measured 2026-09-10, a string miss goes from 140.6 instructions to 128.8 under
+// clang and 118.0 to 113.2 under gcc. Doing the same where the comparison is a register compare
+// costs an integer lookup 20% and a `pair<uint64_t, uint64_t>` one 40%.
+//
+// So the trait below decides a 40% question in both directions, and nothing else in the suite
+// would notice it flipping -- every one of these keys keeps working either way, just slower. That
+// is what these assertions are for.
+namespace {
+
+struct pod_key {
+    std::uint64_t a{};
+    std::uint64_t b{};
+    auto operator==(pod_key const& o) const -> bool {
+        return a == o.a && b == o.b;
+    }
+};
+
+struct owning_key {
+    std::string s{};
+    auto operator==(owning_key const& o) const -> bool {
+        return s == o.s;
+    }
+};
+
+using ankerl::unordered_dense::detail::key_compare_is_call_v;
+
+// Compared in registers: the probe stays one loop.
+static_assert(!key_compare_is_call_v<std::uint64_t>);
+static_assert(!key_compare_is_call_v<int>);
+static_assert(!key_compare_is_call_v<pod_key>);
+// `std::pair` and `std::tuple` write their own copy *assignment*, so they are not trivially
+// copyable even when their members are. Keying the trait on `is_trivially_copyable` rather than on
+// `is_trivially_copy_constructible` split them and cost 40%; this is that bug, pinned.
+static_assert(!key_compare_is_call_v<std::pair<std::uint64_t, std::uint64_t>>);
+static_assert(!key_compare_is_call_v<std::tuple<int, int>>);
+
+// Compared through a call: the probe splits.
+static_assert(key_compare_is_call_v<std::string>);
+static_assert(key_compare_is_call_v<owning_key>);
+static_assert(key_compare_is_call_v<std::pair<int, std::string>>);
+// Trivially copyable, and still a call, which is why it is named rather than deduced.
+static_assert(key_compare_is_call_v<std::string_view>);
+static_assert(key_compare_is_call_v<std::wstring_view>);
+
+} // namespace
+
+// The split path, exercised where it actually differs: keys that do not stop in their home group.
+// Both shapes have to agree with a reference map over inserts, lookups, misses and erases -- the
+// out-of-line continuation carries the probe's termination test, so a mistake in it either loops
+// forever or stops early, and stopping early is silent.
+TEST_CASE("probe_split_agrees_with_a_reference_for_both_key_shapes") {
+    auto strings = ankerl::unordered_dense::map<std::string, size_t>();
+    auto integers = ankerl::unordered_dense::map<uint64_t, size_t>();
+    auto ref = std::unordered_map<uint64_t, size_t>();
+
+    // Enough entries at a high load that a good fraction of them sit past their home group.
+    for (size_t i = 0; i < 20000; ++i) {
+        auto const v = static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15);
+        strings[std::to_string(v)] = i;
+        integers[v] = i;
+        ref[v] = i;
+    }
+    REQUIRE(strings.size() == ref.size());
+    REQUIRE(integers.size() == ref.size());
+
+    for (auto const& [v, i] : ref) {
+        REQUIRE(strings.at(std::to_string(v)) == i);
+        REQUIRE(integers.at(v) == i);
+    }
+    // misses, which are what the counters and the continuation's bound decide
+    for (size_t i = 0; i < 20000; ++i) {
+        auto const v = (static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15)) | (uint64_t{1} << 63U);
+        REQUIRE(strings.count(std::to_string(v)) == ref.count(v));
+        REQUIRE(integers.count(v) == ref.count(v));
+    }
+    // erase every second one, then look for all of them again: an erase decrements the counters the
+    // continuation stops on.
+    for (size_t i = 0; i < 20000; i += 2) {
+        auto const v = static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15);
+        REQUIRE(strings.erase(std::to_string(v)) == 1U);
+        REQUIRE(integers.erase(v) == 1U);
+        ref.erase(v);
+    }
+    REQUIRE(strings.size() == ref.size());
+    for (size_t i = 0; i < 20000; ++i) {
+        auto const v = static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15);
+        REQUIRE(strings.count(std::to_string(v)) == ref.count(v));
+        REQUIRE(integers.count(v) == ref.count(v));
+    }
+}
+
+// A string_view key is trivially copyable and still splits, so it exercises the specialization
+// rather than the default. Its bodies outlive the map, which is what makes the view valid.
+TEST_CASE("probe_split_string_view_key") {
+    auto bodies = std::vector<std::string>();
+    bodies.reserve(5000);
+    for (size_t i = 0; i < 5000; ++i) {
+        bodies.push_back("key-" + std::to_string(i * 7919));
+    }
+    auto map = ankerl::unordered_dense::map<std::string_view, size_t>();
+    for (size_t i = 0; i < bodies.size(); ++i) {
+        map[bodies[i]] = i;
+    }
+    REQUIRE(map.size() == bodies.size());
+    for (size_t i = 0; i < bodies.size(); ++i) {
+        REQUIRE(map.at(bodies[i]) == i);
+    }
+    REQUIRE(map.count("not in it") == 0U);
+}
+
+// The split path's own early-out, steered rather than hoped for.
+//
+// `probe` now tests "did anything of this class overflow past my home group" in two places: inside
+// the shared loop, and again in the split path's inline home-group check. A mutation sweep on
+// 2026-09-10 turned the second one from `== 0` into `== 1` and **no test noticed** -- that stops a
+// probe at home whenever exactly one entry of the key's class went past it, so the entry that went
+// past becomes unfindable. Reaching it by chance needs a string whose home counter happens to be
+// exactly one; reaching it on purpose needs a hash the test chooses, which is what
+// fuzz_group_index does for the unsplit path and what this does for the split one.
+//
+// The key type is what selects the shape: a user-provided copy constructor makes it not trivially
+// copy-constructible, so detail::key_compare_is_call is true and the probe splits.
+namespace {
+
+struct call_key {
+    std::uint64_t v{};
+
+    call_key() = default;
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions) -- terser test
+    call_key(std::uint64_t x)
+        : v(x) {}
+    // user-provided on purpose: it is what makes this key take the split probe
+    call_key(call_key const& o)
+        : v(o.v) {}
+    auto operator=(call_key const& o) -> call_key& {
+        v = o.v;
+        return *this;
+    }
+    ~call_key() = default;
+    call_key(call_key&&) = default;
+    auto operator=(call_key&&) -> call_key& = default;
+
+    auto operator==(call_key const& o) const -> bool {
+        return v == o.v;
+    }
+};
+
+struct steered_call_hash {
+    using is_avalanching = void;
+    auto operator()(call_key const& k) const noexcept -> std::uint64_t {
+        return k.v;
+    }
+};
+
+static_assert(key_compare_is_call_v<call_key>, "this test is about the split probe; this key must take it");
+
+// The top byte picks the group, the low byte the fingerprint, the middle keeps keys distinct --
+// exactly fuzz_group_index's construction.
+auto steered(std::uint8_t group, std::uint8_t id, std::uint8_t fingerprint) -> call_key {
+    return call_key{(static_cast<std::uint64_t>(group) << 56U) | (static_cast<std::uint64_t>(id) << 8U) | fingerprint};
+}
+
+} // namespace
+
+TEST_CASE("probe_split_home_group_counter_must_be_exact") {
+    auto map = ankerl::unordered_dense::map<call_key, size_t, steered_call_hash>();
+    map.reserve(17); // two groups, and 17 entries do not grow them
+    auto const groups = map.bucket_count() / 16U;
+    REQUIRE(map.bucket_count() >= 32U);
+
+    // Sixteen keys that all call group 0 home, filling it exactly.
+    for (std::uint8_t i = 0; i < 16U; ++i) {
+        REQUIRE(map.try_emplace(steered(0, i, static_cast<std::uint8_t>(0x10U + i)), i).second);
+    }
+    REQUIRE(map.size() == 16U);
+
+    // One more, of fingerprint class 3, which finds group 0 full: it lands in a later group and
+    // leaves group 0's counter for class 3 at exactly one. That "one" is the number the mutation
+    // stopped on.
+    auto const overflowed = steered(0, 200, 0x03U);
+    REQUIRE(map.try_emplace(overflowed, 999U).second);
+    REQUIRE(map.size() == 17U);
+    REQUIRE(map.bucket_count() / 16U == groups); // nothing grew, so the layout is still the one built above
+
+    // The lookup that only succeeds if the home group's counter is compared against zero.
+    REQUIRE(map.count(overflowed) == 1U);
+    REQUIRE(map.find(overflowed) != map.end());
+    REQUIRE(map.at(overflowed) == 999U);
+
+    // Everything still there, and a miss of the same class still stops correctly.
+    for (std::uint8_t i = 0; i < 16U; ++i) {
+        REQUIRE(map.count(steered(0, i, static_cast<std::uint8_t>(0x10U + i))) == 1U);
+    }
+    REQUIRE(map.count(steered(0, 201, 0x03U)) == 0U);
+
+    // Erasing the overflowed entry takes that counter back down; the fillers stay findable.
+    REQUIRE(map.erase(overflowed) == 1U);
+    REQUIRE(map.count(overflowed) == 0U);
+    for (std::uint8_t i = 0; i < 16U; ++i) {
+        REQUIRE(map.count(steered(0, i, static_cast<std::uint8_t>(0x10U + i))) == 1U);
+    }
+}


### PR DESCRIPTION
Issue #233. Replaces #236, which GitHub closed when #235's base branch was deleted on merge; same
two commits, rebased onto `main`.

## Why the frame is there

For a `std::string` key the probe builds a frame and spills the loop state — the counter, `this`,
the mask, the delta, the hash and the broadcast fingerprint — **before the first group is
compared**, because the key compare is a `memcmp` call and everything the loop keeps live has to
survive it. Only ~3% of lookups leave the home group, and the delta and the mask are the only
things the rest of the walk needs. Where the compare is a register compare there is no call,
nothing has to survive anything, and splitting only adds one.

This was tried on 2026-09-10 and reverted, and **both halves reproduce exactly**. What was missing
is that the two halves are selected by the key type:

| key (clang, miss) | shipped | split | |
|---|---|---|---|
| `std::string` | 140.6 | **128.8** | **−8.4%**, 19.65 → 17.85 ns |
| `std::string_view` | 134.2 | **122.4** | **−8.8%** |
| `std::uint64_t` | 56.1 | 67.1 | +20% |
| `std::pair<std::uint64_t, std::uint64_t>` | 50.2 | 70.2 | **+40%** |
| 64 B POD, `memcmp` compare | 111.4 | 109.4 | −1.8% |

## What it does

Gated on `detail::key_compare_is_call<Key>`:

- **Integer codegen is byte-identical to the shipped header** on both compilers — 56.1/59.9/70.0
  under clang and 58.1/57.0/68.6 under gcc on miss, hit and half, and the whole
  `map<uint64_t, big_value>` too.
- **Strings gain everywhere**: clang miss −8.2%, half −4.3%, hit −1.7%, insert −3.2%; gcc −4.0%,
  −2.3%, −1.4%, −3.0%; churn and insert-erase −1 to −2%. Timings, three runs, medians: clang miss
  19.65 → 17.85 ns, hit 25.00 → 24.55, half 24.60 → 24.00; gcc 16.15 → 15.80, 22.95 → 22.65,
  22.45 → 22.35. Every cell improves. The one loss is `++m[k]` on a present string key, +2.2%
  clang and +0.3% gcc.
- Against F14VectorMap, the one lookup this map lost: 128.8 instructions against its 131.4 — ahead
  on instructions, still 2.3% behind on time.

## Three things that were nearly bugs

**The trait is `is_trivially_copy_constructible`, not `is_trivially_copyable`.** `std::pair` and
`std::tuple` write their own copy *assignment*, so both libstdc++ and libc++ report
`is_trivially_copyable_v<std::pair<std::uint64_t, std::uint64_t>>` as **false**. The first version
keyed on that and split one of the commonest key types after string and integer, at +40%.

**A pair and a tuple are asked about their elements, not about themselves.** CI found this, not
reasoning: **MSVC's `std::tuple<int, int>` is not trivially copy-constructible** where libstdc++'s
and libc++'s is, so asking the aggregate gave a tuple key a different probe shape on Windows than
everywhere else. All four Windows legs went red on the `static_assert` that pins it. Recursing is
also simply what comparing a pair does, and nested cases fall out.

**The unsplit path is the shipped loop unchanged, deliberately.** Factoring the per-group compare
into a helper returning a `probe_result`, so both shapes share it, costs **gcc 26% of an integer
hit** and clang 6.7%, fully inlined, purely from returning a twelve-byte struct through an inner
function.

## Verification

- 784 tests pass; clean under clang, gcc, `--unity=on --unity-size=16` on both, and ASan+UBSan.
- **Mutation sweep found a real hole and it is closed**: turning the split path's inline
  home-group `== 0` into `== 1` was caught by nothing — that makes any entry past its home group
  with exactly one same-class overflow unfindable. `test/unit/probe_split.cpp` reaches it on
  purpose with `fuzz_group_index`'s construction: identity hash, and a key whose copy constructor
  is user-provided so it takes the split path. Fill group 0, send one key of class 3 past it, look
  it up. Verified caught with `--replace`. Remaining survivors are performance-only, or write to
  fields a `probe_result` with `found == false` documents as meaningless, or are equivalent
  (`m_group_mask == 0` cannot fire while the smallest array is four groups) — noted in the header
  so the next sweep does not re-investigate.
- Instruction counts, not the paired harness: a paired A/B cannot measure a change that moves an
  inlining boundary and gets the sign wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)