### PR TITLE
Measure whether a value address the hash predicts is worth prefetching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,12 @@ misses at 4M. Splitting fingerprints from counters: a tie. Cache-line-aligning t
 A second fingerprint in the index's spare bits: 0.975. 16-bit indices for small maps: 0.986. A
 12-slot 64 byte block: 0.9888.
 
-*The values.* A slot back-pointer per value: pays only for string erase-by-iterator, loses the
+*The values.* A narrower value index, tiny pointers included: bounded at ~9% of memory and no speed
+by insertion order itself -- the referrer does not choose the position, so the index carries
+log2(n) - 1.44 bits per entry. The one speed idea behind it, a value address the group predicts and
+can prefetch, was measured on a layout built to make the prediction exact: 0.82 of a hit at 12M
+entries, **0.99 for a string**, and misses 13-24% worse at every size. Closed, #229.
+A slot back-pointer per value: pays only for string erase-by-iterator, loses the
 score. Distance nibbles with it: 0.959. `realloc` growth: available today via
 `AllocatorOrContainer`. A growth factor below 2: 7–13% of steady memory for 9–19% of a build —
 a knob, not a default. Not zeroing the index: 1.7% of a large build, and undefined behaviour in the

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- Tiny pointers, and the bound insertion order puts on the value index
 - Splitting the probe past the home group: kept, for keys whose compare is a call
 - The insert path's instructions, counted one by one: the clang/gcc gap is the call boundary
 - The F14Vector string miss, re-measured, and the old explanation of it is wrong
@@ -288,6 +289,84 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**Tiny pointers, and the bound insertion order puts on the value index** (2026-09-10/11, issue
+#229). Asked whether a tiny pointer (Bender et al., SODA '23; Flattened-TPHT, VLDB '26) could shrink
+the four of five and a half bytes per slot that are the `uint32_t` value index. **Half of it is
+settled without building anything, and the half that needed a measurement is now measured and lost.**
+
+**A tiny pointer needs the referrer to choose where the referent goes.** This map's value vector is
+insertion-ordered and that order is public contract -- `values()`, iteration, `extract()`,
+`replace()`. The user chooses every position, so the map from slot to vector position is an
+arbitrary permutation of n things and the index has to encode it: **log2(n) - 1.44 bits per entry**
+however the bits are arranged, at home or away from it. The issue's premise, a narrow index into a
+range the group implies, has nothing to stand on -- the group implies nothing about where the value
+sits. That bound caps every width reduction, tiny or otherwise:
+
+| value index | index B/entry (4 x 1/load, octave geomean 1.77) | total B/entry, 8 byte value |
+|---|---|---|
+| `uint32_t`, shipped | 7.1 | 32.6 |
+| 24 bit, built and measured, score 0.995 clang / 0.983 gcc, capped at 2^24 | 5.3 | ~30.8 |
+| the information-theoretic floor at n = 2^20 | 4.1 | ~29.6 |
+
+So the whole axis is worth **at most ~9% of memory and no speed** inside the contract, and the entry
+below ("Why none of them could have won") already says the L1 fills a narrower block saves are not on
+the critical path. It should not be prototyped.
+
+**What that leaves is a different container**, values in a hash-addressed table so the *map* chooses
+each value's slot. Its one possible speed win is that the value's line becomes a function of the
+group, so it can be fetched in parallel with the fingerprints instead of after them -- this map pays
+two dependent memory accesses on a hit where a flat map pays one, which is most of the 10-13% boost
+leads by on a fresh hit. Whether a software prefetch actually recovers that latency is the one thing
+argument cannot settle, so it was measured, by making the prediction true inside the *shipped* map:
+`scripts/ab/value_prefetch.{cpp,sh}` inserts keys in home-group order, exactly twelve per group, so
+the values of group g are twelve contiguous entries at `values + g * 12`, and a patched `probe()`
+prefetches that address before touching the group. Perfect packing and no holes, so it is an upper
+bound on what the container could get.
+
+Four variants: **A** random fill and no prefetch (today), **B** grouped fill and no prefetch
+(locality alone), **C** grouped and prefetching one to three lines (the question), **D** random and
+prefetching (the tax on a wrong address). ns per lookup, `uint64_t` key, n = 12 x 2^p:
+
+| | p=16, hit | p=18, hit | p=20, hit | p=16, miss | p=18, miss | p=20, miss |
+|---|---|---|---|---|---|---|
+| A random, no prefetch | 14.74 | 52.17 | 64.69 | 6.87 | 25.58 | 38.06 |
+| B grouped, no prefetch | 14.95 | 51.65 | 65.53 | 6.68 | 26.26 | 38.30 |
+| C grouped, 1 line | 13.75 | 48.06 | 58.87 | 8.30 | 30.40 | 38.65 |
+| C grouped, 3 lines | 15.28 | 46.60 | **53.98** | 11.21 | 36.33 | 41.38 |
+| D random, 1 line | 15.15 | 54.91 | 65.70 | 8.18 | 30.55 | 38.66 |
+
+**Three things kill it.**
+
+*The gain does not clear the bar, and the bar was set before the run.* The rule was hit(C) at or
+below 0.75 x hit(B) at both DRAM sizes, for integer and string keys. Best case is 0.824 at p=20 with
+an integer key, and **strings are 0.99** -- 148.74 to 147.11 ns at p=18, which is noise. For a string
+the value load was never the bottleneck: the key compare is a second dependent load into the string
+body and it happens either way.
+
+*The miss gets worse everywhere.* Integer +24% at p=16, +16% at p=18; string +13% and +18%. A miss
+never reads a value, so every one of those prefetches is wasted work on the critical path, and a
+50/50 workload is a **net loss** at p=18 and about 8% ahead only at p=20 with an integer key.
+
+*Locality alone is worth nothing.* B is A to within half a percent at every size and both key types,
+so the container gets nothing for free from owning placement -- its entire case is the prefetch.
+And even the ceiling is modest: hit(B) minus miss(B) at p=20 is 27.2 ns, the whole value load, and
+three lines of prefetch recover 11.6 of it, 42%, for six instructions and 2.8 extra L1 fills.
+
+So the container would give up insertion order, `values()` and vector-speed iteration, land at an
+estimated 28-30 bytes per entry (between boost and absl, not below them), lose on misses, pay a
+14-19% tax in cache, and win at most 17.6% on an integer hit at twelve million entries. **Closed.**
+
+**And a measurement trap worth more than the result.** The first run of this said the grouped layout
+alone was worth 18-25% at p=20 -- which is impossible, since a miss never reads a value and the
+index is structurally identical either way. The tell was in the instruction counts: **300 per lookup
+for a probe that stops in its home group**. `perf stat` counts the whole process, and building a
+table of twelve million entries by rejection sampling is most of the run at that size, so what the
+"locality" column actually measured was that a random-order fill is slower than a grouped one. The
+harness now reports every figure as the **slope of two rep counts**, which subtracts any fixed cost
+exactly, whatever it is; A and B then agree on instructions to the tenth, which is the physical
+check that the subtraction worked. Any harness that builds its own table and measures the process
+has this bug available to it.
+
 **Splitting the probe past the home group: kept, for keys whose compare is a call** (2026-09-10,
 issue #233). The entry below records this being tried on 2026-09-10 and reverted -- string miss
 138.3 to 126.5 instructions, integer miss 55.8 to 65.9 and integer hit 69.1 to 85.0, "it buys 8% of

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -110,6 +110,16 @@ with an argument for how many writing lookups each churn round does -- which is 
 `scripts/ab/placement.cpp` simulates bucketized placement against sliding-window placement with no
 map involved, which is how the ungrouped-window idea was priced without building it.
 
+`scripts/ab/value_prefetch.sh` answers a question about a container this library does not have. A
+hit here pays two dependent memory accesses, the group block and then the value, where a flat map
+pays one; a container that owned placement could predict the value's address from the group and
+fetch both at once. It makes that prediction true inside the shipped map -- keys inserted in
+home-group order, twelve per group, so the values of group g are twelve contiguous entries -- and a
+patched `probe()` prefetches them. It reports every figure as the **slope of two rep counts** rather
+than a total, because building a twelve-million-entry table is most of what `perf stat` sees at that
+size: measured as totals, a miss came out at 300 instructions and the fill order appeared to change
+the cost of a workload that never reads a value.
+
 `scripts/ab/mapsplot.py` draws the CSVs (`bars`, `memory`, `octave`) and prints them
 (`table`, `swing`); `scripts/ab/diagrams.py` draws the byte-level layout figures of every index in
 one house style. Both are stdlib only.

--- a/scripts/ab/value_prefetch.cpp
+++ b/scripts/ab/value_prefetch.cpp
@@ -1,0 +1,182 @@
+// Can a hash-predictable value address be prefetched in time to matter?
+//
+// This map pays two dependent memory accesses on a hit: the group block, and then the value the
+// slot's index points at. A flat map pays one, which is most of the 10-13% boost leads by on a
+// fresh hit. The value's address cannot be predicted here, because the value vector is ordered by
+// *insertion* and the map does not choose where a value goes -- that is the whole content of issue
+// #229, and it is why a tiny pointer cannot shrink the index while that contract holds.
+//
+// A container that *did* own placement (TPHT-style: values in a hash-addressed table, the index
+// holding a small offset from a base the group implies) would know the value's line before the
+// group arrived, and could fetch both at once. Whether that actually recovers a memory latency on
+// real hardware is the one thing about such a container that argument cannot settle: a software
+// prefetch that misses the dTLB may be dropped, and at DRAM sizes the access may already be bound
+// by bandwidth or translation rather than by latency.
+//
+// So this makes the prediction true by construction inside the *shipped* map, without building the
+// container. Keys are inserted in home-group order, exactly twelve per group, so the value of slot
+// j of group g sits at m_values[g * 12 + j] and the values of a group are twelve contiguous
+// entries. The patched probe (see value_prefetch.sh) then prefetches `values + g * 12` before it
+// touches the group. That is an upper bound on what the container could get -- perfect packing, no
+// holes, no second choice -- which is what a kill experiment wants: if the bound does not clear the
+// bar, the container cannot either.
+//
+//   argv: <hit|miss|half|none> <grouped|random> <p> [reps]     n = 12 * 2^p entries
+//
+// Built by scripts/ab/value_prefetch.sh, which is where the header patch and the variants live.
+#include <ankerl/unordered_dense.h>
+
+#include <bench/workloads.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifndef UDM_VP_PER_GROUP
+#    define UDM_VP_PER_GROUP 12
+#endif
+
+namespace {
+
+// Its own, so that the harness needs no nanobench object to link against -- probe_length.cpp does
+// the same. Any full-period generator does; nothing here is measuring the generator.
+struct rng {
+    std::uint64_t s;
+    explicit rng(std::uint64_t seed)
+        : s(seed * UINT64_C(0x9E3779B97F4A7C15) | 1U) {}
+    auto operator()() -> std::uint64_t {
+        s ^= s << 13U;
+        s ^= s >> 7U;
+        s ^= s << 17U;
+        return s;
+    }
+    auto bounded(std::size_t n) -> std::size_t {
+        return static_cast<std::size_t>((((*this)() >> 32U) * n) >> 32U);
+    }
+};
+
+#if defined(UDM_VP_STR)
+using key_type = std::string;
+#elif defined(UDM_VP_BIG)
+using key_type = std::uint64_t;
+#else
+using key_type = std::uint64_t;
+#endif
+
+#if defined(UDM_VP_BIG)
+using mapped_type = workloads::big_value;
+#else
+using mapped_type = std::size_t;
+#endif
+
+using map_t = ankerl::unordered_dense::map<key_type, mapped_type>;
+
+// The group a key would call home, computed the way the table does: the map's own hash finalized,
+// then its top `p` bits. Both hashes this harness uses are avalanching, so mixed_hash is the hash
+// itself and this is exactly group_idx_from_hash.
+auto home_group(std::uint64_t v, unsigned p) -> std::size_t {
+    auto const h = ankerl::unordered_dense::hash<key_type>{}(workloads::key_for<map_t>(v));
+    return static_cast<std::size_t>(h >> (64U - p));
+}
+
+// `per_group` keys for each of the 2^p groups, laid out [g * per_group + j], drawn from `range`.
+auto keys_by_group(unsigned p, std::size_t per_group, std::uint64_t range) -> std::vector<std::uint64_t> {
+    auto const groups = std::size_t{1} << p;
+    auto out = std::vector<std::uint64_t>(groups * per_group);
+    auto filled = std::vector<std::uint8_t>(groups, 0);
+    auto remaining = groups;
+    auto r = rng(range == 0 ? 1 : 2);
+    while (remaining != 0) {
+        auto const v = (r() >> 2U) | range;
+        auto const g = home_group(v, p);
+        if (filled[g] == per_group) {
+            continue;
+        }
+        out[g * per_group + filled[g]] = v;
+        if (++filled[g] == per_group) {
+            --remaining;
+        }
+    }
+    return out;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    workloads::tame_allocator();
+    auto const what = std::string(argc > 1 ? argv[1] : "hit");
+    auto const order = std::string(argc > 2 ? argv[2] : "grouped");
+    auto const p = static_cast<unsigned>(argc > 3 ? std::strtoul(argv[3], nullptr, 10) : 14);
+    auto const reps = argc > 4 ? std::strtoull(argv[4], nullptr, 10) : 30000000;
+
+    constexpr auto per_group = std::size_t{UDM_VP_PER_GROUP};
+    auto const groups = std::size_t{1} << p;
+    auto const n = groups * per_group;
+
+    auto present = keys_by_group(p, per_group, 0);
+    auto absent = keys_by_group(p, per_group, std::uint64_t{1} << 63U);
+
+    auto map = map_t();
+    map.reserve(n);
+    // reserve must give exactly the group count the layout was computed for, or the home group of
+    // every key is a different number than the one the prefetch address is built from.
+    if (map.bucket_count() / 16U != groups) {
+        std::fprintf(stderr, "reserve(%zu) gave %zu groups, expected %zu\n", n, map.bucket_count() / 16U, groups);
+        return 1;
+    }
+
+    if (order == "grouped") {
+        for (auto const v : present) {
+            map.try_emplace(workloads::key_for<map_t>(v), mapped_type{});
+        }
+    } else {
+        // the same keys and the same table, in an order that puts no value where its group implies
+        auto shuffled = present;
+        auto r = rng(77);
+        for (std::size_t i = shuffled.size(); i > 1; --i) {
+            std::swap(shuffled[i - 1], shuffled[r.bounded(i)]);
+        }
+        for (auto const v : shuffled) {
+            map.try_emplace(workloads::key_for<map_t>(v), mapped_type{});
+        }
+    }
+    if (map.size() != n || map.bucket_count() / 16U != groups) {
+        std::fprintf(stderr, "filling changed the table: size %zu of %zu, %zu groups\n", map.size(), n, map.bucket_count() / 16U);
+        return 1;
+    }
+
+    // The invariant the whole experiment rests on: in grouped order the value of a key is exactly
+    // where its home group says it is. Checked on a sample rather than asserted in a comment.
+    if (order == "grouped") {
+        auto r = rng(4);
+        for (auto i = 0; i < 1000; ++i) {
+            auto const at = r.bounded(n);
+            auto const it = map.find(workloads::key_for<map_t>(present[at]));
+            if (it == map.end() || static_cast<std::size_t>(it - map.begin()) != at) {
+                std::fprintf(stderr, "grouped layout is not exact at %zu\n", at);
+                return 1;
+            }
+        }
+    }
+
+    auto acc = std::size_t{0};
+    // The rngs outlive the loop: a small batch replayed is learned by the branch predictor, which
+    // has flattered the branchiest probe by 2.7x once already.
+    auto r = rng(5);
+    auto coin = rng(99);
+    if (what == "none") {
+        for (std::size_t i = 0; i < reps; ++i) {
+            auto const at = r.bounded(n);
+            acc += present[at] & 1U;
+        }
+    } else {
+        for (std::size_t i = 0; i < reps; ++i) {
+            auto const at = r.bounded(n);
+            auto const hit = what == "hit" || (what == "half" && (coin() & 1U) != 0);
+            acc += map.count(workloads::key_for<map_t>(hit ? present[at] : absent[at]));
+        }
+    }
+    std::printf("%s %s p=%u n=%zu reps=%zu acc=%zu\n", what.c_str(), order.c_str(), p, n, reps, acc);
+}

--- a/scripts/ab/value_prefetch.sh
+++ b/scripts/ab/value_prefetch.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Is a value address that the hash predicts worth prefetching? (issue #229)
+#
+#   scripts/ab/value_prefetch.sh [-c COMPILER] [-k u64|str|big] [-p "12 14 16"] [-r REPS]
+#
+# This map pays two dependent memory accesses on a hit -- the group block, then the value -- where a
+# flat map pays one. The value's address cannot be predicted, because the value vector is ordered by
+# insertion and the map does not choose where a value goes. A container that owned placement could
+# predict it, and this asks whether predicting it is worth anything, by making the prediction true
+# inside the shipped map: keys are inserted in home-group order, twelve per group, so the values of
+# group g are twelve contiguous entries at `values + g * 12`.
+#
+# Four variants, and the comparison that answers the question is C against B:
+#
+#   A  random fill,  no prefetch   the shipped map, as it behaves today
+#   B  grouped fill, no prefetch   locality alone -- what the container gets for free
+#   C  grouped fill, prefetch      the value prefetch, 1/2/3 lines
+#   D  random fill,  prefetch      a prefetch of the wrong line: the tax on every miss
+#
+# The header is patched in a copy, exactly the way probe_length.sh does it; the working tree is
+# never touched. It refuses to run if probe() no longer looks the way the patch expects.
+set -euo pipefail
+export LC_ALL=C
+root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+build=${AB_BUILD:-$(mktemp -d)}
+mkdir -p "$build"
+cxx=clang++ keys=u64 points="14 16 18 20" reps=30000000
+while getopts "c:k:p:r:" opt; do
+    case $opt in
+        c) cxx=$OPTARG ;;
+        k) keys=$OPTARG ;;
+        p) points=$OPTARG ;;
+        r) reps=$OPTARG ;;
+        *) exit 1 ;;
+    esac
+done
+
+# the probe, with a prefetch of the value line the group implies
+python3 - "$root/include/ankerl/unordered_dense.h" "$build/vp.h" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+s = open(src).read()
+old = """        auto const word = fingerprint_word(mh);
+        auto const counter = word & 7U;
+        auto const home_idx = group_idx_from_hash(mh);
+        if constexpr (!detail::key_compare_is_call_v<Key>) {"""
+new = """        auto const word = fingerprint_word(mh);
+        auto const counter = word & 7U;
+        auto const home_idx = group_idx_from_hash(mh);
+        udm_prefetch_values(m_values.data() + std::size_t{home_idx} * UDM_VP_PER_GROUP);
+        if constexpr (!detail::key_compare_is_call_v<Key>) {"""
+if old not in s:
+    sys.exit("probe() no longer looks the way this patch expects; update scripts/ab/value_prefetch.sh")
+s = s.replace(old, new, 1)
+s = s.replace("namespace ankerl::unordered_dense {", """#ifndef UDM_VP_PER_GROUP
+#    define UDM_VP_PER_GROUP 12
+#endif
+#ifndef UDM_VP_LINES
+#    define UDM_VP_LINES 0
+#endif
+// With UDM_VP_LINES 0 the loop is empty and the address arithmetic is dead, so the baseline is
+// built from this same patched header and the two binaries differ only in the prefetch.
+template <typename P>
+inline void udm_prefetch_values(P const* p) {
+    auto const* c = reinterpret_cast<char const*>(p);
+    for (int i = 0; i < UDM_VP_LINES; ++i) {
+        ANKERL_UNORDERED_DENSE_PREFETCH(c + 64 * i);
+    }
+}
+namespace ankerl::unordered_dense {""", 1)
+open(dst, "w").write(s)
+PY
+mkdir -p "$build/vpinc/ankerl"
+cp "$build/vp.h" "$build/vpinc/ankerl/unordered_dense.h"
+[ -f "$root/include/ankerl/stl.h" ] && cp "$root/include/ankerl/stl.h" "$build/vpinc/ankerl/stl.h"
+
+kf=""
+[ "$keys" = str ] && kf="-DUDM_VP_STR"
+[ "$keys" = big ] && kf="-DUDM_VP_BIG"
+flags=(-O3 -DNDEBUG -std=c++17 -w -I"$build/vpinc" -I"$root/include" -I"$root/test" ${kf:+"$kf"})
+
+# Per lookup, as the *slope* of two rep counts rather than the total over one.
+#
+# perf counts the whole process, and building a table of twelve million entries -- plus generating
+# its keys by rejection sampling -- is not free. At p=20 that setup is most of the run: measured as
+# a total, a miss came out at 300 instructions, which is impossible for a probe that stops in its
+# home group, and the random and grouped fills differed on a workload that never reads a value.
+# Subtracting a quarter-length run removes every fixed cost exactly, whatever it was.
+measure() { # binary work order p reps -> "task-clock cycles instructions L1 dTLB"
+    local out
+    out=$(perf stat -x, -e task-clock,cycles,instructions,L1-dcache-load-misses,dTLB-load-misses \
+              ${AB_CORE:+taskset -c "$AB_CORE"} "$1" "$2" "$3" "$4" "$5" 2>&1)
+    echo "$out" | awk -F, '$3=="task-clock"{a=$1} $3=="cycles"{b=$1} $3=="instructions"{c=$1}
+                           $3=="L1-dcache-load-misses"{d=$1} $3=="dTLB-load-misses"{e=$1}
+                           END{print a, b, c, d, e}'
+}
+
+run() { # binary work order p -> ns, instructions, cycles, L1, dTLB per lookup
+    local lo=$((reps / 4))
+    local full short
+    full=$(measure "$1" "$2" "$3" "$4" "$reps")
+    short=$(measure "$1" "$2" "$3" "$4" "$lo")
+    awk -v d=$((reps - lo)) -v f="$full" -v s="$short" \
+        'BEGIN { split(f, F, " "); split(s, S, " ");
+                 printf "%9.2f %9.1f %9.1f %8.3f %8.3f",
+                        (F[1]-S[1])*1e6/d, (F[3]-S[3])/d, (F[2]-S[2])/d, (F[4]-S[4])/d, (F[5]-S[5])/d }'
+}
+
+for lines in 0 1 2 3; do
+    "$cxx" "${flags[@]}" -DUDM_VP_LINES=$lines "$root/scripts/ab/value_prefetch.cpp" -o "$build/vp_$lines"
+done
+
+echo "keys=$keys  $cxx  reps=$reps  (ns, instructions, cycles, L1-miss, dTLB-miss per lookup)"
+printf "%-4s %-6s %-9s %-8s %9s %9s %9s %8s %8s\n" p work variant lines ns instr cycles L1 dTLB
+for p in $points; do
+    for work in hit miss; do
+        for spec in "A random 0" "B grouped 0" "C grouped 1" "C grouped 2" "C grouped 3" "D random 1"; do
+            set -- $spec
+            printf "%-4s %-6s %-9s %-8s %s\n" "$p" "$work" "$1 $2" "$3" "$(run "$build/vp_$3" "$work" "$2" "$p")"
+        done
+    done
+done


### PR DESCRIPTION
Closes #229 with a measurement rather than a prototype. No change to the header.

## Half of it needed no experiment

**A tiny pointer needs the referrer to choose where the referent goes.** This map's value vector is
insertion-ordered and that order is public contract — `values()`, iteration, `extract()`,
`replace()`. The user chooses every position, so the map from slot to vector position is an
arbitrary permutation of n things and the index must encode it: **log₂(n) − 1.44 bits per entry**
however the bits are arranged, at home or away from it. The issue's premise — a narrow index into a
range the group implies — has nothing to stand on, because the group implies nothing about where the
value sits.

| value index | index B/entry | total B/entry, 8 B value |
|---|---|---|
| `uint32_t`, shipped | 7.1 | 32.6 |
| 24 bit (already built, score 0.995/0.983, capped at 2²⁴) | 5.3 | ~30.8 |
| information-theoretic floor at n = 2²⁰ | 4.1 | ~29.6 |

So the axis is worth **≤9% of memory and no speed** inside the contract.

## The half that needed one

What's left is a *different container*, one that owns placement, whose single possible speed win is
that the value's line becomes a function of the group and can be fetched alongside the fingerprints
— this map pays two dependent memory accesses on a hit where a flat map pays one.

`scripts/ab/value_prefetch.{cpp,sh}` makes that prediction true inside the **shipped** map: keys
inserted in home-group order, twelve per group, so the values of group g are twelve contiguous
entries, and a patched `probe()` prefetches that address. Perfect packing and no holes — an upper
bound on the container. ns per lookup, `uint64_t` key, n = 12·2^p:

| | p=16 hit | p=18 hit | p=20 hit | p=16 miss | p=18 miss | p=20 miss |
|---|---|---|---|---|---|---|
| A random, no prefetch | 14.74 | 52.17 | 64.69 | 6.87 | 25.58 | 38.06 |
| B grouped, no prefetch | 14.95 | 51.65 | 65.53 | 6.68 | 26.26 | 38.30 |
| C grouped, 1 line | 13.75 | 48.06 | 58.87 | 8.30 | 30.40 | 38.65 |
| C grouped, 3 lines | 15.28 | 46.60 | **53.98** | 11.21 | 36.33 | 41.38 |
| D random, 1 line | 15.15 | 54.91 | 65.70 | 8.18 | 30.55 | 38.66 |

**Three things kill it:**

1. **It misses the bar, which was set before the run.** Required hit(C) ≤ 0.75·hit(B) at both DRAM
   sizes for integer *and* string keys. Best case 0.824 (u64, p=20); **strings are 0.99** — 148.74
   → 147.11 ns, noise. For a string the value load was never the bottleneck: the key compare is a
   second dependent load into the string body and happens either way.
2. **The miss gets worse everywhere** — u64 +24% at p=16 and +16% at p=18, string +13% and +18% — because a miss reads no value, so every prefetch is wasted work on the critical path. A 50/50
   workload is a **net loss** at p=18.
3. **Locality alone is worth nothing.** B equals A to within half a percent at every size and both
   key types, so the container gets nothing free from owning placement. Even the ceiling is modest:
   hit(B) − miss(B) at p=20 is 27.2 ns and three lines recover 11.6 of it, 42%, for 6 instructions
   and 2.8 extra L1 fills.

The container would give up insertion order, `values()` and vector-speed iteration, land at ~28–30
B/entry (between boost and absl, not below), lose on misses, pay a 14–19% in-cache tax, and win at
most 17.6% on an integer hit at twelve million entries.

## A measurement trap worth more than the result

The first run said the grouped layout *alone* was worth 18–25% at p=20 — impossible, since a miss
never reads a value and the index is structurally identical. The tell was **300 instructions per
lookup for a probe that stops in its home group**: `perf stat` counts the whole process, and
building a twelve-million-entry table by rejection sampling is most of the run at that size, so the
"locality" column was measuring that a random-order fill is slower than a grouped one.

The harness now reports every figure as the **slope of two rep counts**, which subtracts any fixed
cost exactly. A and B then agree on instructions to the tenth — the physical check that the
subtraction worked. Any harness that builds its own table and measures the process has this bug
available to it, which is why it is in the README and the notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)