### PR TITLE
Add prefetch(key), which hands back the hash it had to compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Additionally, there are `ankerl::unordered_dense::segmented_map` and `ankerl::un
     - [3.3.4. `[[nodiscard]] auto values() const noexcept -> value_container_type const&`](#334-nodiscard-auto-values-const-noexcept---value_container_type-const)
     - [3.3.5. `auto replace(value_container_type&& container)`](#335-auto-replacevalue_container_type-container)
     - [3.3.6. `auto hash_for(K const& key) const -> precomputed_hash`](#336-auto-hash_fork-const-key-const---precomputed_hash)
+    - [3.3.7. `auto prefetch(K const& key) const -> precomputed_hash`](#337-auto-prefetchk-const-key-const---precomputed_hash)
   - [3.4. Custom Container Types](#34-custom-container-types)
   - [3.5. Custom Bucket Types](#35-custom-bucket-types)
     - [3.5.1. `ankerl::unordered_dense::bucket_type::group`](#351-ankerlunordered_densebucket_typegroup)
@@ -390,6 +391,60 @@ auto it = map.find("status"s, h);
 ```
 
 Only lookups take a precomputed hash, and insertion never will: a lookup given the wrong hash merely misses, while an insertion given one files the element under a probe chain it is not on, losing it for good and letting a second copy of the same key in beside it. Erase is left out for a duller reason — it hashes the moved element as well as the key, so precomputing the key's hash would save it only half its hashing.
+
+#### 3.3.7. `auto prefetch(K const& key) const -> precomputed_hash`
+
+A lookup on a table larger than the cache is two dependent memory accesses — the group's block, and then the value it points at — and nothing inside one lookup can overlap them. A caller with *many* keys to look up can overlap them across lookups: ask for the block of a key you will want shortly, then do the lookup whose block you asked for a while ago. No lookup gets faster; several misses are simply in flight at once.
+
+`prefetch()` hashes the key, starts fetching the block its home group lives in, and hands the hash back, so the lookup that follows does not hash it a second time:
+
+```cpp
+constexpr size_t depth = 8;
+std::array<map_t::precomputed_hash, depth> ring;
+for (size_t i = 0; i < depth; ++i) {
+    ring[i] = map.prefetch(keys[i]);
+}
+
+for (size_t i = 0; i < keys.size(); ++i) {
+    // take this key's hash out before refilling the slot: the slot holding key i is
+    // the one key i + depth goes into
+    auto const h = ring[i % depth];
+    if (i + depth < keys.size()) {
+        ring[i % depth] = map.prefetch(keys[i + depth]);
+    }
+    if (auto it = map.find(keys[i], h); it != map.end()) {
+        use(it->second);
+    }
+}
+```
+
+What it is worth, `map<uint64_t, size_t>`, clang 22 on a 7950X, ns per lookup. The middle column pipelines the key and its hash with `hash_for()` but fetches nothing, so the difference between the two right-hand columns is the prefetch itself:
+
+| entries | | plain | `hash_for` ahead | `prefetch` ahead | |
+| ------: | :--- | ----: | ---------------: | ---------------: | ---: |
+| 200 000 | all hits | 10.3 ns | 10.4 ns | 8.2 ns | 1.25x |
+| 4 000 000 | all hits | 58.4 ns | 64.4 ns | 38.5 ns | **1.52x** |
+| 16 000 000 | all hits | 65.6 ns | 73.1 ns | 42.5 ns | **1.54x** |
+| 4 000 000 | half hits | 55.1 ns | 48.3 ns | 38.1 ns | 1.45x |
+
+With `std::string` keys at four million entries it is 158 ns to 115 ns, 1.37x — and there the hash matters too, which is why the hash comes back rather than being thrown away: pipelining it alone is worth 6% and the prefetch adds the other 29%.
+
+Two things to know. **Depth is not free to increase**: eight was the best of 4, 8, 16 and 32 here, and 32 was *slower* than 8 at four million entries, because only so many misses can be outstanding at once. And **it only pays past the cache** — at 200 000 entries it is worth a quarter, at 4 million half, and on a table that fits in L2 it is a wasted instruction.
+
+The returned hash is not `[[nodiscard]]`: dropping it is the ordinary use of the plain form.
+
+```cpp
+map.prefetch(key); // fine, if you have nowhere to keep the hash
+```
+
+There is also an overload taking a `precomputed_hash`, for a caller that already has one:
+
+```cpp
+auto const h = map.hash_for("status");
+map.prefetch(h);
+```
+
+On a table that has never allocated buckets, `prefetch()` fetches nothing and still returns the hash, exactly as `hash_for()` does.
 
 ### 3.4. Custom Container Types
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -3142,6 +3142,48 @@ public:
         return {mixed_hash(key)};
     }
 
+    // Starts the memory access a later lookup of this key will make, and hands back the hash it
+    // had to compute to do so.
+    //
+    // A lookup on a table past the cache is two dependent memory accesses -- the group block, then
+    // the value -- and nothing in a single lookup can overlap them. A caller with *independent*
+    // lookups can: ask for the block of the key it will want in a few iterations, then do the
+    // lookup whose block it asked for a few iterations ago. Nothing here is faster; what changes is
+    // that the misses of several lookups are outstanding at once.
+    //
+    // The hash comes back because it is the reason to return anything at all. The address prefetched
+    // is `hash >> m_shifts`, so the hash is computed either way, and a caller who dropped it would
+    // hash every key twice -- once here and once in the lookup -- which for a string key is the
+    // largest single item in such a loop. Kept in a small ring and handed to `find(key, ph)`, every
+    // key is hashed once. It is deliberately not [[nodiscard]], unlike hash_for: dropping the hash
+    // is the ordinary use of the one-argument form, not a mistake.
+    //
+    // On a table with no buckets this prefetches nothing and still returns the hash, which is what
+    // hash_for does on the same table. The guard is not decoration: data() is null in that state and
+    // the group index is not, so forming the address would be pointer arithmetic on null. As with
+    // clear_buckets, that rests on the language rule rather than on a diagnostic -- removing the
+    // guard is a mutant that survives both sanitizers.
+    auto prefetch(Key const& key) const -> precomputed_hash {
+        auto const ph = precomputed_hash{mixed_hash(key)};
+        prefetch(ph);
+        return ph;
+    }
+
+    template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
+    auto prefetch(K const& key) const -> precomputed_hash {
+        auto const ph = precomputed_hash{mixed_hash(key)};
+        prefetch(ph);
+        return ph;
+    }
+
+    void prefetch(precomputed_hash ph) const {
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(m_buckets.empty()))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                return;
+            }
+        prefetch_block(m_buckets.data(), std::size_t{group_idx_from_hash(ph.m_mixed_hash)});
+    }
+
     auto find(Key const& key, precomputed_hash ph) -> iterator {
         return do_find(key, ph);
     }

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- `prefetch(key)`, and why it returns the hash
 - Tiny pointers, and the bound insertion order puts on the value index
 - Splitting the probe past the home group: kept, for keys whose compare is a call
 - The insert path's instructions, counted one by one: the clang/gcc gap is the call boundary
@@ -289,6 +290,57 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**`prefetch(key)`, and why it returns the hash** (2026-09-11, issue #232). A lookup past the cache
+is two dependent memory accesses -- the group's block, then the value -- and nothing inside one
+lookup can overlap them. A caller with many keys can overlap them *across* lookups, which is what
+abseil's and F14's `prefetch` exist for; this map had `hash_for()` but nothing that touched memory
+early. The win is entirely in the caller's loop, which is why none of the scored workloads can show
+it and why the score does not move.
+
+`scripts/ab/prefetch_api.{cpp,sh}`, ns per lookup, `map<uint64_t, size_t>`, clang 22. The middle
+column pipelines the key fetch and the hash with `hash_for` and touches no map memory, so the gap
+between the two right-hand columns is the prefetch and nothing else:
+
+| entries | work | plain | `hash_for` ahead | `prefetch` ahead | |
+|---|---|---|---|---|---|
+| 200000 | hit | 10.27 | 10.42 | 8.21 | 1.25x |
+| 4000000 | hit | 58.44 | 64.40 | **38.46** | **1.52x** |
+| 16000000 | hit | 65.56 | 73.08 | **42.52** | **1.54x** |
+| 4000000 | half | 55.12 | 48.32 | 38.10 | 1.45x |
+| 16000000 | half | 61.16 | 55.07 | 39.90 | 1.53x |
+
+**The hash coming back is the part worth arguing about, and the string column settles it.** Without
+it the loop hashes every key twice, once in the prefetch and once in the lookup. For an integer key
+that is ~8 of ~60 instructions; for a string at four million entries, `hash_for` ahead is worth 6%
+(158.1 to 149.2 ns) and the prefetch the other 29% (149.2 to 115.2), so throwing the hash away would
+have given back a fifth of the gain. It is deliberately not `[[nodiscard]]`, unlike `hash_for`:
+dropping it is the ordinary use of the one-argument form.
+
+**Depth is not monotone.** Of 4, 8, 16 and 32, eight was best, and **32 was slower than 8** at four
+million entries (46.4 against 38.5 ns) -- only so many misses can be outstanding at once, and past
+that the ring is just extra work. The README says eight.
+
+**Two measurement notes, both of which changed the numbers.** The first version of the harness drew
+its key sequence into a vector sized by the repetition count; that vector's cost is *proportional*
+to reps and so survives the slope subtraction, which only removes what is fixed. Keys are drawn in
+the loop instead. And the first version had no `hash_for`-ahead column, which would have credited
+the prefetch with pipelining the key fetch and the hash as well -- at 200000 entries that is most of
+the apparent gain, and at four million on hits the hash-ahead column is *worse* than plain, so the
+prefetch is doing more than the headline ratio suggests rather than less.
+
+**Mutation swept, and all three survivors are of a kind that cannot be tested.** Deleting the
+`prefetch(ph)` call from either key overload leaves a function that returns the same hash and
+touches no memory -- a prefetch has no observable result, which is the whole point of it, so nothing
+can catch that and nothing should pretend to. The third deletes the empty-table guard, which would
+form an address from a null `data()` and a non-zero group index; that survives **both sanitizers**,
+the same way `clear_buckets`'s null guard does, so it rests on the language rule rather than on a
+diagnostic. Recorded in the header so the next sweep does not re-open it.
+
+**The ring is easy to get wrong and the test caught it.** The slot holding key `i` is the same slot
+key `i + depth` goes into, so refilling before reading overwrites the hash about to be used. The
+first version of `prefetch_hash_drives_the_lookup_overloads` did exactly that and the lookup missed
+-- which would have shipped in the README as the recommended loop.
+
 **Tiny pointers, and the bound insertion order puts on the value index** (2026-09-10/11, issue
 #229). Asked whether a tiny pointer (Bender et al., SODA '23; Flattened-TPHT, VLDB '26) could shrink
 the four of five and a half bytes per slot that are the `uint32_t` value index. **Half of it is

--- a/scripts/ab/prefetch_api.cpp
+++ b/scripts/ab/prefetch_api.cpp
@@ -1,0 +1,131 @@
+// What prefetch(key) is worth to a caller with independent lookups.
+//
+// A lookup on a table past the cache is two dependent memory accesses -- the group block, then the
+// value -- and nothing inside a single lookup can overlap them. A caller looking up *many* keys can
+// overlap them across lookups: ask for the block of the key wanted `depth` iterations from now,
+// then do the lookup whose block was asked for `depth` iterations ago. Nothing gets faster; several
+// misses are simply outstanding at once.
+//
+// This measures that, against the same loop with no prefetching, at sizes from inside L2 to well
+// past L3. depth 0 is the baseline, so both sides run the identical loop and the only difference is
+// the prefetch.
+//
+// Every figure is the *slope* of two repetition counts. Building a table of millions of entries is
+// not free, and perf counts the whole process; measured as totals, the setup is most of the run at
+// the sizes that matter here.
+//
+// Pipelining the loop moves three things earlier at once: the key's own fetch, its hash, and the
+// block prefetch. Only the third is what prefetch() adds, so `mode` separates them -- `hash` fills
+// the ring with hash_for(), which pipelines the first two and touches no map memory, and `prefetch`
+// fills it with prefetch(). The difference between those two columns is the prefetch and nothing
+// else.
+//
+//   argv: <hit|half> <depth> <n> [reps] [prefetch|hash]
+#include <ankerl/unordered_dense.h>
+
+#include <bench/workloads.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+#if defined(UDM_PF_STR)
+using key_type = std::string;
+#else
+using key_type = std::uint64_t;
+#endif
+using map_t = ankerl::unordered_dense::map<key_type, std::size_t>;
+using hash_t = map_t::precomputed_hash;
+
+struct rng {
+    std::uint64_t s;
+    explicit rng(std::uint64_t seed)
+        : s(seed * UINT64_C(0x9E3779B97F4A7C15) | 1U) {}
+    auto operator()() -> std::uint64_t {
+        s ^= s << 13U;
+        s ^= s >> 7U;
+        s ^= s << 17U;
+        return s;
+    }
+    auto bounded(std::size_t n) -> std::size_t {
+        return static_cast<std::size_t>((((*this)() >> 32U) * n) >> 32U);
+    }
+};
+
+constexpr std::size_t max_depth = 32;
+
+} // namespace
+
+int main(int argc, char** argv) {
+    workloads::tame_allocator();
+    auto const what = std::string(argc > 1 ? argv[1] : "hit");
+    auto const depth = static_cast<std::size_t>(argc > 2 ? std::strtoul(argv[2], nullptr, 10) : 0);
+    auto const n = static_cast<std::size_t>(argc > 3 ? std::strtoull(argv[3], nullptr, 10) : 1000000);
+    auto const reps = argc > 4 ? std::strtoull(argv[4], nullptr, 10) : 20000000;
+    auto const mode = std::string(argc > 5 ? argv[5] : "prefetch");
+    if (depth > max_depth) {
+        std::fprintf(stderr, "depth %zu above the ring's %zu\n", depth, max_depth);
+        return 1;
+    }
+
+    auto present = std::vector<std::uint64_t>();
+    auto absent = std::vector<std::uint64_t>();
+    auto r = rng(1);
+    for (std::size_t i = 0; i < n; ++i) {
+        present.push_back(r() >> 2U);
+    }
+    for (std::size_t i = 0; i < n; ++i) {
+        absent.push_back((r() >> 2U) | (std::uint64_t{1} << 62U));
+    }
+
+    auto map = map_t();
+    map.reserve(n);
+    for (auto v : present) {
+        map.try_emplace(workloads::key_for<map_t>(v), std::size_t{1});
+    }
+
+    // Keys are drawn inside the loop rather than into a vector sized by `reps`: such a vector's
+    // own cost is proportional to the repetition count and would survive the slope subtraction,
+    // which only removes what is fixed. Drawing also keeps the sequence from being replayed, which
+    // a branch predictor learns.
+    // What goes into the ring: hash_for pipelines the key fetch and the hash and touches no map
+    // memory, prefetch also fetches the block. The difference between the two is the prefetch.
+    auto const ahead = [&](key_type const& k) -> hash_t { return mode == "hash" ? map.hash_for(k) : map.prefetch(k); };
+
+    auto pick = rng(5);
+    auto coin = rng(99);
+    auto next_key = [&]() -> std::uint64_t {
+        auto const at = pick.bounded(n);
+        auto const hit = what == "hit" || (coin() & 1U) != 0;
+        return hit ? present[at] : absent[at];
+    };
+
+    auto acc = std::size_t{0};
+    if (depth == 0) {
+        for (std::size_t i = 0; i < reps; ++i) {
+            acc += map.count(workloads::key_for<map_t>(next_key()));
+        }
+    } else {
+        // Both the key and its hash: count() needs the key to compare and the hash to probe with.
+        auto keys = std::vector<std::uint64_t>(max_depth);
+        auto ring = std::vector<hash_t>(max_depth);
+        for (std::size_t i = 0; i < depth; ++i) {
+            keys[i] = next_key();
+            ring[i] = ahead(workloads::key_for<map_t>(keys[i]));
+        }
+        for (std::size_t i = 0; i < reps; ++i) {
+            // this lookup's key and hash first, then refill the slot they free: the slot holding
+            // key i is the one key i + depth goes into
+            auto const slot = i % depth;
+            auto const v = keys[slot];
+            auto const ph = ring[slot];
+            keys[slot] = next_key();
+            ring[slot] = ahead(workloads::key_for<map_t>(keys[slot]));
+            acc += map.count(workloads::key_for<map_t>(v), ph);
+        }
+    }
+    std::printf("%s depth=%zu n=%zu reps=%zu mode=%s acc=%zu\n", what.c_str(), depth, n, reps, mode.c_str(), acc);
+}

--- a/scripts/ab/prefetch_api.sh
+++ b/scripts/ab/prefetch_api.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# What prefetch(key) is worth, against depth and table size.
+#
+#   scripts/ab/prefetch_api.sh [-c COMPILER] [-k u64|str] [-n "200000 4000000"] [-d "0 4 8 16"] [-r REPS]
+#
+# depth 0 is the same loop with no prefetching, so the two sides differ only in the prefetch.
+# Figures are the slope of two repetition counts: building the table is not free and perf counts
+# the whole process.
+set -euo pipefail
+export LC_ALL=C
+root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+build=${AB_BUILD:-$(mktemp -d)}
+mkdir -p "$build"
+cxx=clang++ keys=u64 sizes="200000 1000000 4000000 16000000" depths="0 4 8 16 32" reps=8000000
+while getopts "c:k:n:d:r:" opt; do
+    case $opt in
+        c) cxx=$OPTARG ;; k) keys=$OPTARG ;; n) sizes=$OPTARG ;; d) depths=$OPTARG ;; r) reps=$OPTARG ;;
+        *) exit 1 ;;
+    esac
+done
+kf=""; [ "$keys" = str ] && kf="-DUDM_PF_STR"
+"$cxx" -O3 -DNDEBUG -std=c++17 -w -I"$root/include" -I"$root/test" ${kf:+"$kf"} \
+    "$root/scripts/ab/prefetch_api.cpp" -o "$build/prefetch_api"
+
+measure() {
+    perf stat -x, -e task-clock ${AB_CORE:+taskset -c "$AB_CORE"} \
+        "$build/prefetch_api" "$1" "$2" "$3" "$4" "$5" 2>&1 | awk -F, '$3=="task-clock"{print $1}'
+}
+run() { # work depth n mode -> ns per lookup
+    local lo=$((reps / 4))
+    awk -v d=$((reps - lo)) -v f="$(measure "$1" "$2" "$3" "$reps" "$4")" -v s="$(measure "$1" "$2" "$3" "$lo" "$4")" \
+        'BEGIN { printf "%8.2f", (f - s) * 1e6 / d }'
+}
+
+# `hash` pipelines the key fetch and the hash and touches no map memory; `prefetch` also fetches
+# the block. The gap between the two columns at one depth is what prefetch() itself is worth.
+echo "keys=$keys  $cxx  reps=$reps   ns per lookup   (h = hash_for ahead, p = prefetch ahead)"
+printf "%-10s %-6s %8s" n work "d=0"
+for d in $depths; do [ "$d" = 0 ] && continue; printf " %8s %8s" "${d}h" "${d}p"; done
+echo
+for n in $sizes; do
+    for work in hit half; do
+        base=$(run "$work" 0 "$n" prefetch)
+        printf "%-10s %-6s %8s" "$n" "$work" "$base"
+        for d in $depths; do
+            [ "$d" = 0 ] && continue
+            printf " %8s %8s" "$(run "$work" "$d" "$n" hash)" "$(run "$work" "$d" "$n" prefetch)"
+        done
+        echo
+    done
+done

--- a/test/meson.build
+++ b/test/meson.build
@@ -40,6 +40,7 @@ test_sources = [
     'unit/erase_if.cpp',
     'unit/erase_churn.cpp',
     'unit/move_home.cpp',
+    'unit/prefetch.cpp',
     'unit/probe_split.cpp',
     'unit/erase_range.cpp',
     'unit/erase_throwing_move.cpp',

--- a/test/unit/prefetch.cpp
+++ b/test/unit/prefetch.cpp
@@ -1,0 +1,136 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+// prefetch() starts the memory access a later lookup will make and hands back the hash it had to
+// compute. Nothing it does is observable by itself -- a prefetch has no result and a wrong address
+// is merely a wasted one -- so what is testable is the hash it returns, that it agrees with
+// hash_for, that it is safe on a table with no buckets, and that the overloads resolve the way they
+// are meant to. The last of those is the one that could break silently.
+
+TEST_CASE("prefetch_returns_the_same_hash_as_hash_for") {
+    auto map = ankerl::unordered_dense::map<std::string, int>();
+    map["alpha"] = 1;
+    map["beta"] = 2;
+
+    for (auto const& key : {std::string("alpha"), std::string("beta"), std::string("absent")}) {
+        REQUIRE(map.prefetch(key).m_mixed_hash == map.hash_for(key).m_mixed_hash);
+    }
+}
+
+// The point of the return value: a pipelined loop hashes each key once rather than twice.
+TEST_CASE("prefetch_hash_drives_the_lookup_overloads") {
+    auto map = ankerl::unordered_dense::map<uint64_t, size_t>();
+    auto keys = std::vector<uint64_t>();
+    for (size_t i = 0; i < 5000; ++i) {
+        auto const k = static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15);
+        keys.push_back(k);
+        map[k] = i;
+    }
+
+    constexpr size_t depth = 8;
+    auto ring = std::array<ankerl::unordered_dense::map<uint64_t, size_t>::precomputed_hash, depth>{};
+    for (size_t i = 0; i < depth && i < keys.size(); ++i) {
+        ring[i] = map.prefetch(keys[i]);
+    }
+    auto sum = size_t{0};
+    for (size_t i = 0; i < keys.size(); ++i) {
+        // Take this key's hash out of the ring *before* refilling its slot: the slot that holds
+        // key i is the same one key i + depth goes into, so refilling first overwrites the hash
+        // about to be used. The first version of this test did exactly that and the lookup missed.
+        auto const ph = ring[i % depth];
+        if (i + depth < keys.size()) {
+            ring[i % depth] = map.prefetch(keys[i + depth]);
+        }
+        auto it = map.find(keys[i], ph);
+        REQUIRE(it != map.end());
+        sum += it->second;
+    }
+    REQUIRE(sum == 5000U * 4999U / 2U);
+}
+
+// An empty table has no bucket array at all -- data() is null -- so the prefetch has to stand down,
+// and still answer with the hash, which is what hash_for does on the same table.
+TEST_CASE("prefetch_on_a_table_without_buckets") {
+    auto map = ankerl::unordered_dense::map<std::string, int>();
+    REQUIRE(map.bucket_count() == 0U);
+    REQUIRE(map.prefetch(std::string("anything")).m_mixed_hash == map.hash_for(std::string("anything")).m_mixed_hash);
+
+    // and after the buckets go away again
+    map["x"] = 1;
+    map.clear();
+    REQUIRE(map.prefetch(std::string("x")).m_mixed_hash == map.hash_for(std::string("x")).m_mixed_hash);
+}
+
+// The overload that takes a hash must win against the one that takes a key, or `prefetch(ph)` would
+// try to hash the hash. Both are exact matches and the non-template wins, which is a rule worth
+// pinning rather than trusting: the failure is silent if precomputed_hash ever grows a conversion.
+TEST_CASE("prefetch_overload_on_a_precomputed_hash_returns_nothing") {
+    auto map = ankerl::unordered_dense::map<std::string, int>();
+    map["k"] = 1;
+    auto const ph = map.hash_for(std::string("k"));
+    static_assert(std::is_void_v<decltype(map.prefetch(ph))>,
+                  "prefetch(precomputed_hash) is the overload that takes a hash, and it returns void");
+    static_assert(std::is_same_v<decltype(map.prefetch(std::string("k"))),
+                                 ankerl::unordered_dense::map<std::string, int>::precomputed_hash>,
+                  "prefetch(key) hands back the hash it computed");
+    map.prefetch(ph);
+    REQUIRE(map.find(std::string("k"), ph) != map.end());
+}
+
+// Dropping the returned hash is the ordinary use of the one-argument form, so it must not be
+// [[nodiscard]] -- a warning there would fire on correct code, and the suite is built with
+// warnings as errors, which is what makes this a test rather than a comment.
+TEST_CASE("prefetch_result_may_be_dropped") {
+    auto map = ankerl::unordered_dense::map<uint64_t, int>();
+    map[1] = 1;
+    map.prefetch(uint64_t{1});
+    map.prefetch(uint64_t{2});
+    REQUIRE(map.size() == 1U);
+}
+
+// A transparent map takes a lookup type that is not the key type, the same way find does.
+namespace {
+// At namespace scope, not inside the test: gcc rejects the `is_avalanching` typedef as an unused
+// local typedef when the struct is declared in a function body. Named for this file, because a
+// unity build puts several test files in one translation unit.
+struct prefetch_sv_hash {
+    using is_transparent = void;
+    using is_avalanching = void;
+    auto operator()(std::string_view s) const -> uint64_t {
+        return ankerl::unordered_dense::hash<std::string_view>{}(s);
+    }
+};
+struct prefetch_sv_eq {
+    using is_transparent = void;
+    auto operator()(std::string_view a, std::string_view b) const -> bool {
+        return a == b;
+    }
+};
+} // namespace
+
+TEST_CASE("prefetch_transparent") {
+    auto map = ankerl::unordered_dense::map<std::string, int, prefetch_sv_hash, prefetch_sv_eq>();
+    map["hello"] = 7;
+    auto const ph = map.prefetch(std::string_view("hello"));
+    REQUIRE(ph.m_mixed_hash == map.hash_for(std::string_view("hello")).m_mixed_hash);
+    auto it = map.find(std::string_view("hello"), ph);
+    REQUIRE(it != map.end());
+    REQUIRE(it->second == 7);
+}
+
+// A set has the same lookup surface as a map.
+TEST_CASE("prefetch_on_a_set") {
+    auto set = ankerl::unordered_dense::set<uint64_t>();
+    set.insert(42);
+    auto const ph = set.prefetch(uint64_t{42});
+    REQUIRE(ph.m_mixed_hash == set.hash_for(uint64_t{42}).m_mixed_hash);
+    REQUIRE(set.count(uint64_t{42}, ph) == 1U);
+}


### PR DESCRIPTION
Closes #232.

## What it is for

A lookup on a table past the cache is two dependent memory accesses — the group's block, then the
value — and nothing inside one lookup can overlap them. A caller with *many* keys can overlap them
across lookups: ask for the block of a key wanted a few iterations from now, then do the lookup
whose block was asked for a few iterations ago. `absl` and F14 both have this; we had `hash_for()`
but nothing that touched memory early.

```cpp
template <typename K> auto prefetch(K const& key) const -> precomputed_hash;  // hashes, fetches, returns the hash
void prefetch(precomputed_hash ph) const;                                      // for a hash you already have
```

## What it is worth

`scripts/ab/prefetch_api.{cpp,sh}`, ns per lookup, `map<uint64_t, size_t>`, clang 22. The middle
column pipelines the key fetch and the hash with `hash_for()` and touches no map memory, so the gap
between the two right-hand columns is **the prefetch and nothing else**:

| entries | work | plain | `hash_for` ahead | `prefetch` ahead | |
|---|---|---|---|---|---|
| 200 000 | hit | 10.27 | 10.42 | 8.21 | 1.25x |
| 4 000 000 | hit | 58.44 | 64.40 | **38.46** | **1.52x** |
| 16 000 000 | hit | 65.56 | 73.08 | **42.52** | **1.54x** |
| 4 000 000 | half | 55.12 | 48.32 | 38.10 | 1.45x |
| 16 000 000 | half | 61.16 | 55.07 | 39.90 | 1.53x |

String keys at four million entries: 158 → 115 ns, 1.37x.

**Depth is not monotone**: of 4, 8, 16 and 32, eight was best, and **32 was slower than 8** at four
million (46.4 vs 38.5 ns) — only so many misses can be outstanding at once. The README says eight.

## Why it returns the hash

Without it the loop hashes every key twice, once in the prefetch and once in the lookup — ~8 of ~60
instructions for an integer key. The string column settles it: `hash_for` ahead alone is worth 6%
(158.1 → 149.2) and the prefetch the other 29% (149.2 → 115.2), so throwing the hash away would give
back a fifth of the gain. Not `[[nodiscard]]`, unlike `hash_for`: dropping it is the ordinary use of
the one-argument form, and the attribute would warn on correct code.

## Verification

- 791 tests pass, clean under clang, gcc, `--unity=on --unity-size=16` on both, and ASan+UBSan.
- **Nothing else moves**: existing lookups retire the same instructions to the tenth on both
  compilers (56.8 / 60.6 / 70.7 clang, 58.8 / 57.7 / 69.3 gcc, before and after). The scored
  benchmark cannot see this feature by design — the win is in the caller's loop.
- Mutation swept. All three survivors are untestable by construction and are now documented in the
  header: deleting either `prefetch(ph)` call leaves a function that returns the same hash and
  touches no memory — a prefetch has no observable result — and deleting the empty-table guard
  survives **both sanitizers**, exactly as `clear_buckets`'s null guard does, so it rests on the
  language rule rather than on a diagnostic.

## Two things the work caught

The ring is easy to get wrong: the slot holding key `i` is the same slot key `i + depth` goes into,
so refilling before reading overwrites the hash about to be used. My first version of the test did
exactly that and the lookup missed — **that loop would otherwise have shipped in the README as the
recommended pattern**.

And the harness's first version drew its key sequence into a vector sized by the repetition count.
That cost is *proportional* to reps, so it survives the slope subtraction, which only removes what
is fixed. Keys are drawn in the loop instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)