### PR TITLE
Time the prefetch benchmark's loop directly, and say which machine the depth advice came from

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ What it is worth, `map<uint64_t, size_t>`, clang 22 on a 7950X, ns per lookup. T
 
 With `std::string` keys at four million entries it is 158 ns to 115 ns, 1.37x — and there the hash matters too, which is why the hash comes back rather than being thrown away: pipelining it alone is worth 6% and the prefetch adds the other 29%.
 
-Two things to know. **Depth is not free to increase**: eight was the best of 4, 8, 16 and 32 here, and 32 was *slower* than 8 at four million entries, because only so many misses can be outstanding at once. And **it only pays past the cache** — at 200 000 entries it is worth a quarter, at 4 million half, and on a table that fits in L2 it is a wasted instruction.
+Two things to know. **Depth is not free to increase**: eight was the best of 4, 8, 16 and 32 *on the machine above*, and 32 was *slower* than 8 at four million entries, because a core can only keep so many misses outstanding at once — a Zen 4 about two dozen. That ceiling is a property of the core, not of the map, so the best depth on a different one will differ and is worth a minute of measuring; `scripts/ab/prefetch_api.sh` sweeps it. And **it only pays past the cache** — at 200 000 entries it is worth a quarter, at 4 million half, and on a table that fits in L2 it is a wasted instruction.
 
 The returned hash is not `[[nodiscard]]`: dropping it is the ordinary use of the plain form.
 

--- a/scripts/ab/prefetch_api.cpp
+++ b/scripts/ab/prefetch_api.cpp
@@ -10,9 +10,10 @@
 // past L3. depth 0 is the baseline, so both sides run the identical loop and the only difference is
 // the prefetch.
 //
-// Every figure is the *slope* of two repetition counts. Building a table of millions of entries is
-// not free, and perf counts the whole process; measured as totals, the setup is most of the run at
-// the sizes that matter here.
+// The loop times itself and prints ns per lookup, so nothing outside it is counted and the harness
+// needs no perf -- which matters because the machines worth asking this on include macOS, where
+// there is none. An earlier version measured the whole process under `perf stat` and subtracted a
+// shorter run to cancel the setup; timing the loop directly is both simpler and exact.
 //
 // Pipelining the loop moves three things earlier at once: the key's own fetch, its hash, and the
 // block prefetch. Only the third is what prefetch() adds, so `mode` separates them -- `hash` fills
@@ -25,6 +26,7 @@
 
 #include <bench/workloads.h>
 
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
@@ -104,6 +106,7 @@ int main(int argc, char** argv) {
     };
 
     auto acc = std::size_t{0};
+    auto const started = std::chrono::steady_clock::now();
     if (depth == 0) {
         for (std::size_t i = 0; i < reps; ++i) {
             acc += map.count(workloads::key_for<map_t>(next_key()));
@@ -127,5 +130,8 @@ int main(int argc, char** argv) {
             acc += map.count(workloads::key_for<map_t>(v), ph);
         }
     }
-    std::printf("%s depth=%zu n=%zu reps=%zu mode=%s acc=%zu\n", what.c_str(), depth, n, reps, mode.c_str(), acc);
+    auto const elapsed = std::chrono::steady_clock::now() - started;
+    auto const ns = std::chrono::duration<double, std::nano>(elapsed).count() / static_cast<double>(reps);
+    std::printf("%.3f ns/lookup  %s depth=%zu n=%zu reps=%zu mode=%s acc=%zu\n",
+                ns, what.c_str(), depth, n, reps, mode.c_str(), acc);
 }

--- a/scripts/ab/prefetch_api.cpp
+++ b/scripts/ab/prefetch_api.cpp
@@ -21,6 +21,12 @@
 // fills it with prefetch(). The difference between those two columns is the prefetch and nothing
 // else.
 //
+// The `hash` column is **not** a speedup to compare against depth 0; read it as the price of the
+// pipeline itself. Deferring a lookup costs a ring slot and a second key_for(), and buys nothing
+// unless something is fetched early -- so on an all-hits run it comes out *slower* than no
+// pipelining at all, by 7% here and considerably more on a Neoverse. That is the bar the prefetch
+// has to clear, which is why it is the column the prefetch is measured against.
+//
 //   argv: <hit|half> <depth> <n> [reps] [prefetch|hash]
 #include <ankerl/unordered_dense.h>
 
@@ -98,7 +104,12 @@ int main(int argc, char** argv) {
     // a branch predictor learns.
     // What goes into the ring: hash_for pipelines the key fetch and the hash and touches no map
     // memory, prefetch also fetches the block. The difference between the two is the prefetch.
-    auto const ahead = [&](key_type const& k) -> hash_t { return mode == "hash" ? map.hash_for(k) : map.prefetch(k); };
+    //
+    // Decided once rather than compared per iteration. A std::string compare in the inner loop is
+    // worth under a percent here and is not necessarily the same price on another core, which
+    // matters for a harness whose whole job is comparing cores.
+    auto const hash_only = mode == "hash";
+    auto const ahead = [&](key_type const& k) -> hash_t { return hash_only ? map.hash_for(k) : map.prefetch(k); };
 
     auto pick = rng(5);
     auto coin = rng(99);

--- a/scripts/ab/prefetch_api.cpp
+++ b/scripts/ab/prefetch_api.cpp
@@ -57,7 +57,10 @@ struct rng {
     }
 };
 
-constexpr std::size_t max_depth = 32;
+// The deepest pipeline the ring allows. Eight is best on a Zen 4, which holds about two dozen
+// misses outstanding; a core with more memory parallelism can want considerably more, so the sweep
+// has to be able to ask for more than the answer on one machine.
+constexpr std::size_t max_depth = 128;
 
 } // namespace
 

--- a/scripts/ab/prefetch_api.sh
+++ b/scripts/ab/prefetch_api.sh
@@ -19,17 +19,15 @@ while getopts "c:k:n:d:r:" opt; do
     esac
 done
 kf=""; [ "$keys" = str ] && kf="-DUDM_PF_STR"
-"$cxx" -O3 -DNDEBUG -std=c++17 -w -I"$root/include" -I"$root/test" ${kf:+"$kf"} \
+# shellcheck disable=SC2086 -- PF_EXTRA_FLAGS is meant to split
+"$cxx" -O3 -DNDEBUG -std=c++17 -w ${PF_EXTRA_FLAGS:-} -I"$root/include" -I"$root/test" ${kf:+"$kf"} \
     "$root/scripts/ab/prefetch_api.cpp" -o "$build/prefetch_api"
 
-measure() {
-    perf stat -x, -e task-clock ${AB_CORE:+taskset -c "$AB_CORE"} \
-        "$build/prefetch_api" "$1" "$2" "$3" "$4" "$5" 2>&1 | awk -F, '$3=="task-clock"{print $1}'
-}
+# The binary times its own loop, so nothing here needs perf -- which is what lets this run on
+# macOS, and macOS is where the answer is most likely to differ.
 run() { # work depth n mode -> ns per lookup
-    local lo=$((reps / 4))
-    awk -v d=$((reps - lo)) -v f="$(measure "$1" "$2" "$3" "$reps" "$4")" -v s="$(measure "$1" "$2" "$3" "$lo" "$4")" \
-        'BEGIN { printf "%8.2f", (f - s) * 1e6 / d }'
+    ${AB_CORE:+taskset -c "$AB_CORE"} "$build/prefetch_api" "$1" "$2" "$3" "$reps" "$4" |
+        awk '{ printf "%8.2f", $1 }'
 }
 
 # `hash` pipelines the key fetch and the hash and touches no map memory; `prefetch` also fetches


### PR DESCRIPTION
Two small follow-ups to #239, prompted by asking whether the new API should behave differently on ARM.

**The README's depth advice was a Zen 4 number wearing the word "here".** The best depth depends on how many misses a core keeps outstanding — about two dozen on a 7950X, which is why 8 beat 32 there. That ceiling is a property of the core, not of the map, so the number does not travel. The text now names the machine, says why the limit exists, and points at `scripts/ab/prefetch_api.sh` for measuring it elsewhere.

**And the benchmark could not run on the machines most likely to differ.** It measured the whole process under `perf stat` and subtracted a quarter-length run to cancel the table build — which works, but needs `perf`, and macOS has none. The loop now times itself with `steady_clock` and prints ns per lookup, so nothing outside it is counted. That is exact rather than merely unbiased, and it deletes the slope machinery: half the script goes away.

Also `PF_EXTRA_FLAGS` reaches the compile line, so a variant of the header can be measured without editing the script.

Unchanged numbers on this machine after the rewrite (`map<uint64_t, size_t>`, clang):

| entries | work | d=0 | 8h | 8p |
|---|---|---|---|---|
| 200 000 | hit | 10.16 | 10.84 | 8.45 |
| 4 000 000 | hit | 58.38 | 63.37 | **39.51** |
| 4 000 000 | half | 54.48 | 49.12 | 38.30 |

No change under `include/` — 791 tests pass, and the header is not touched at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)