### PR TITLE
Hash ahead in insert(first, last), the way the rehash already does

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -772,18 +772,23 @@ using detect_is_transparent = typename T::is_transparent;
 template <typename T>
 using detect_iterator = typename T::iterator;
 
+template <typename T>
+using detect_iterator_category = typename std::iterator_traits<T>::iterator_category;
+
 // Whether a range can be walked twice, which is what reading ahead of where you are writing needs.
-// Written as a trait rather than asked inline, because a type with no iterator_traits at all -- a
-// test's hand-rolled iterator, say -- has to answer "no" rather than fail to compile.
-template <typename T, typename = void>
-struct is_forward_iterator : std::false_type {};
+// A type with no iterator_traits at all -- a test's hand-rolled iterator, say -- has to answer no
+// rather than fail to compile, which is what is_detected_v is for.
+template <typename T>
+[[nodiscard]] constexpr auto is_forward_iterator() -> bool {
+    if constexpr (is_detected_v<detect_iterator_category, T>) {
+        return std::is_convertible_v<detect_iterator_category<T>, std::forward_iterator_tag>;
+    } else {
+        return false;
+    }
+}
 
 template <typename T>
-struct is_forward_iterator<T, std::void_t<typename std::iterator_traits<T>::iterator_category>>
-    : std::is_convertible<typename std::iterator_traits<T>::iterator_category, std::forward_iterator_tag> {};
-
-template <typename T>
-constexpr bool is_forward_iterator_v = is_forward_iterator<T>::value;
+constexpr bool is_forward_iterator_v = is_forward_iterator<T>();
 
 template <typename T>
 using detect_reserve = decltype(std::declval<T&>().reserve(std::size_t{}));
@@ -1448,6 +1453,12 @@ private:
                   "a group is sixteen fingerprints, matched as one vector or two words, and eight counters, picked by "
                   "the low three bits of the fingerprint");
 
+    // How far ahead the three loops that pipeline look: the rehash, the range insert and the bulk
+    // visit. It is a count of memory accesses that has to fit inside what the core keeps
+    // outstanding, which is about two dozen on a Zen 4 -- not a property of the map, and every size
+    // from 8 to 32 measured within 2% of this one. Boost's bulk visit uses the same number.
+    static constexpr std::size_t pipeline_depth = 16;
+
     static constexpr std::uint8_t initial_shifts = 64 - 2; // 2^(64-m_shifts) groups
     static constexpr float default_max_load_factor = 0.8F;
 
@@ -1669,11 +1680,19 @@ private:
     // skips the first line because the probe is about to read it anyway; a rehash is about to
     // write a group it has never read, so it wants that line too.
     template <typename Block>
-    static void prefetch_block(Block const* blocks, std::size_t group_idx) {
+    static void prefetch_block(Block const* block) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- byte arithmetic on the block
-        auto const* p = reinterpret_cast<char const*>(blocks + group_idx);
+        auto const* p = reinterpret_cast<char const*>(block);
         ANKERL_UNORDERED_DENSE_PREFETCH(p);
         ANKERL_UNORDERED_DENSE_PREFETCH(p + sizeof(Block) - 1);
+    }
+
+    // The same for a caller holding a group number rather than a pointer. A block is 88 bytes, so
+    // the difference is a multiply, and a caller that already formed the address should not pay it
+    // twice.
+    template <typename Block>
+    static void prefetch_block(Block const* blocks, std::size_t group_idx) {
+        prefetch_block(blocks + group_idx);
     }
 
     // Forced inline because gcc does not do it on its own in a large translation unit, and the
@@ -2104,7 +2123,7 @@ private:
     // while the table is empty (do_find and do_find_hashed's callers, do_erase_key), or needs an
     // iterator into m_values and so
     // cannot be reached in this state (erase, extract, replace_key), or calls this first -- which
-    // is the three insert entry points, the only ones that reach the buckets without a prior
+    // is the four insert entry points, the only ones that reach the buckets without a prior
     // emptiness check.
     void allocate_buckets_if_none() {
         if (ANKERL_UNORDERED_DENSE_UNLIKELY(m_buckets.empty()))
@@ -2162,7 +2181,7 @@ private:
         // The index is counted in value_idx_type and never in the container's size, for the reason
         // spelled out in replace(): max_size() is exactly what value_idx_type can hold, so a
         // container of precisely that many has a size that is not representable in it.
-        constexpr auto ahead = std::size_t{16};
+        constexpr auto ahead = pipeline_depth;
         auto* const groups = m_buckets.data();
         auto const mask = m_group_mask;
         auto const shifts = m_shifts;
@@ -2345,8 +2364,55 @@ private:
         return {begin() + static_cast<difference_type>(value_idx), true};
     }
 
+    // The pipelined half of insert(first, last); see the comment there for what it buys.
+    //
+    // Growth during the loop is safe and not special-cased: it moves the bucket array, so prefetches
+    // already in flight are aimed at the old one and simply do nothing, and the hashes stay valid
+    // because a hash does not depend on the table. That is also why the array and the shift are read
+    // fresh for every element rather than hoisted the way the rehash hoists them -- the rehash never
+    // grows, and this may.
+    template <typename FwdIt>
+    void do_insert_range(FwdIt first, FwdIt last) {
+        if (first == last) {
+            return;
+        }
+        allocate_buckets_if_none();
+        auto ring = std::array<std::uint64_t, pipeline_depth>{};
+        auto lookahead = first;
+        auto hash_and_prefetch = [this](auto const& value) {
+            auto const mh = mixed_hash(get_key(value));
+            prefetch_block(m_buckets.data(), std::size_t{group_idx_from_hash(mh)});
+            return mh;
+        };
+        for (auto i = std::size_t{}; i < pipeline_depth && lookahead != last; ++i) {
+            ring[i] = hash_and_prefetch(*lookahead);
+            ++lookahead;
+        }
+        for (auto i = std::size_t{}; first != last; ++first, ++i) {
+            // This element's hash out of the ring before the slot it frees is refilled: the slot
+            // holding element i is the one element i + pipeline_depth goes into.
+            auto const slot = i % pipeline_depth;
+            auto const mh = ring[slot];
+            if (lookahead != last) {
+                ring[slot] = hash_and_prefetch(*lookahead);
+                ++lookahead;
+            }
+            do_insert_hashed(mh, *first);
+        }
+    }
+
     // An insert whose key has already been hashed, which is what lets a range insert hash ahead of
-    // where it is placing. Everything else about it is do_try_emplace's path.
+    // where it is placing.
+    //
+    // It is emplace()'s job rather than do_try_emplace's: it takes a whole value, not a key and
+    // pieces to build one from. Unlike emplace() it probes before constructing anything, which it
+    // can because a value_type already carries its key -- emplace() has to build the element first
+    // to find out what the key is, and pop it back off again when the key turns out to be present.
+    // Routing the single-element insert(value) through here too would save it that, and is left for
+    // its own change because the insert path is measured and this one is not about it.
+    //
+    // The caller allocates the buckets; every other insert helper does that itself, and this one
+    // cannot because the range insert has to prefetch against an array that already exists.
     //
     // Returns nothing on purpose: the only caller is the range insert, which has nothing to do with
     // an iterator to each element, and a returned pair nobody reads is surface no test can defend.
@@ -2384,9 +2450,7 @@ private:
         if (ANKERL_UNORDERED_DENSE_UNLIKELY(empty())) {
             return 0;
         }
-        // Sixteen, which is what boost's bulk visit uses. It is a count that has to fit inside the
-        // core's outstanding misses, and every size from 8 to 32 measured within 2% of it here.
-        constexpr auto bulk = std::size_t{16};
+        constexpr auto bulk = pipeline_depth;
         auto const* groups = m_buckets.data();
         // The block pointer rather than the group number: a block is 88 bytes, so forming its
         // address is a multiply, and passes two and three would each redo it.
@@ -2404,7 +2468,7 @@ private:
                 word[n] = fingerprint_word(mh);
                 home[n] = group_idx_from_hash(mh);
                 block[n] = groups + std::size_t{home[n]};
-                prefetch_block(groups, std::size_t{home[n]});
+                prefetch_block(block[n]);
             }
             for (auto i = std::size_t{}; i < n; ++i) {
                 lanes[i] = match_fingerprint(*block[i], word[i]);
@@ -2766,56 +2830,24 @@ public:
         return insert(std::forward<P>(value)).first;
     }
 
-    template <class InputIt>
-    // Inserting a range hashes sixteen elements ahead of the one it is placing, and asks for the
-    // block each of those will come home to.
+    // Inserting a range hashes ahead of the element it is placing, and asks for the block each of
+    // those will come home to.
     //
     // A single insert cannot do this: the hash is the first thing it computes and the block is the
     // next thing it needs, so there is nothing to put between them. Over a range there is -- the
     // hash of a later element, which depends on nothing the table is doing. It is the same trick the
-    // growth rehash uses, where it is worth 1.26x on the loop below cache, and the machinery for it
-    // was already here.
+    // growth rehash uses, where it is worth 1.26x on that loop.
     //
     // Only for an iterator that can be walked twice. An input iterator is single-pass, so reading
     // ahead would mean buffering the elements, and those copies would cost more than the prefetch
     // saves; such a range takes the plain loop.
-    //
-    // Growth during the loop is safe and not special-cased: it moves the array, so prefetches
-    // already in flight are aimed at the old one and simply do nothing, and the hashes stay valid
-    // because a hash does not depend on the table.
+    template <class InputIt>
     void insert(InputIt first, InputIt last) {
         if constexpr (detail::is_forward_iterator_v<InputIt>) {
-            if (first == last) {
-                return;
-            }
-            allocate_buckets_if_none();
-            constexpr auto ahead = std::size_t{16};
-            auto ring = std::array<std::uint64_t, ahead>{};
-            auto lookahead = first;
-            auto fetch = [&](std::size_t slot) -> void {
-                auto const mh = mixed_hash(get_key(*lookahead));
-                ++lookahead;
-                ring[slot] = mh;
-                // Read fresh rather than hoisted: a growth reallocates the array out from under it.
-                prefetch_block(m_buckets.data(), static_cast<std::size_t>(mh >> m_shifts));
-            };
-            for (auto i = std::size_t{}; i < ahead && lookahead != last; ++i) {
-                fetch(i);
-            }
-            for (auto i = std::size_t{}; first != last; ++first, ++i) {
-                // This element's hash out of the ring before the slot it frees is refilled: the slot
-                // holding element i is the one element i + ahead goes into.
-                auto const slot = i % ahead;
-                auto const mh = ring[slot];
-                if (lookahead != last) {
-                    fetch(slot);
-                }
-                do_insert_hashed(mh, *first);
-            }
+            do_insert_range(first, last);
         } else {
-            while (first != last) {
+            for (; first != last; ++first) {
                 insert(*first);
-                ++first;
             }
         }
     }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -772,6 +772,19 @@ using detect_is_transparent = typename T::is_transparent;
 template <typename T>
 using detect_iterator = typename T::iterator;
 
+// Whether a range can be walked twice, which is what reading ahead of where you are writing needs.
+// Written as a trait rather than asked inline, because a type with no iterator_traits at all -- a
+// test's hand-rolled iterator, say -- has to answer "no" rather than fail to compile.
+template <typename T, typename = void>
+struct is_forward_iterator : std::false_type {};
+
+template <typename T>
+struct is_forward_iterator<T, std::void_t<typename std::iterator_traits<T>::iterator_category>>
+    : std::is_convertible<typename std::iterator_traits<T>::iterator_category, std::forward_iterator_tag> {};
+
+template <typename T>
+constexpr bool is_forward_iterator_v = is_forward_iterator<T>::value;
+
 template <typename T>
 using detect_reserve = decltype(std::declval<T&>().reserve(std::size_t{}));
 
@@ -2332,6 +2345,21 @@ private:
         return {begin() + static_cast<difference_type>(value_idx), true};
     }
 
+    // An insert whose key has already been hashed, which is what lets a range insert hash ahead of
+    // where it is placing. Everything else about it is do_try_emplace's path.
+    //
+    // Returns nothing on purpose: the only caller is the range insert, which has nothing to do with
+    // an iterator to each element, and a returned pair nobody reads is surface no test can defend.
+    template <typename V>
+    void do_insert_hashed(std::uint64_t mh, V&& value) {
+        auto r = probe(get_key(value), mh);
+        if (r.found) {
+            move_home(r.slot, mh);
+            return;
+        }
+        do_place_element(mh, std::forward<V>(value));
+    }
+
     template <typename K, typename... Args>
     auto do_try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
         allocate_buckets_if_none();
@@ -2739,10 +2767,56 @@ public:
     }
 
     template <class InputIt>
+    // Inserting a range hashes sixteen elements ahead of the one it is placing, and asks for the
+    // block each of those will come home to.
+    //
+    // A single insert cannot do this: the hash is the first thing it computes and the block is the
+    // next thing it needs, so there is nothing to put between them. Over a range there is -- the
+    // hash of a later element, which depends on nothing the table is doing. It is the same trick the
+    // growth rehash uses, where it is worth 1.26x on the loop below cache, and the machinery for it
+    // was already here.
+    //
+    // Only for an iterator that can be walked twice. An input iterator is single-pass, so reading
+    // ahead would mean buffering the elements, and those copies would cost more than the prefetch
+    // saves; such a range takes the plain loop.
+    //
+    // Growth during the loop is safe and not special-cased: it moves the array, so prefetches
+    // already in flight are aimed at the old one and simply do nothing, and the hashes stay valid
+    // because a hash does not depend on the table.
     void insert(InputIt first, InputIt last) {
-        while (first != last) {
-            insert(*first);
-            ++first;
+        if constexpr (detail::is_forward_iterator_v<InputIt>) {
+            if (first == last) {
+                return;
+            }
+            allocate_buckets_if_none();
+            constexpr auto ahead = std::size_t{16};
+            auto ring = std::array<std::uint64_t, ahead>{};
+            auto lookahead = first;
+            auto fetch = [&](std::size_t slot) -> void {
+                auto const mh = mixed_hash(get_key(*lookahead));
+                ++lookahead;
+                ring[slot] = mh;
+                // Read fresh rather than hoisted: a growth reallocates the array out from under it.
+                prefetch_block(m_buckets.data(), static_cast<std::size_t>(mh >> m_shifts));
+            };
+            for (auto i = std::size_t{}; i < ahead && lookahead != last; ++i) {
+                fetch(i);
+            }
+            for (auto i = std::size_t{}; first != last; ++first, ++i) {
+                // This element's hash out of the ring before the slot it frees is refilled: the slot
+                // holding element i is the one element i + ahead goes into.
+                auto const slot = i % ahead;
+                auto const mh = ring[slot];
+                if (lookahead != last) {
+                    fetch(slot);
+                }
+                do_insert_hashed(mh, *first);
+            }
+        } else {
+            while (first != last) {
+                insert(*first);
+                ++first;
+            }
         }
     }
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -3358,9 +3358,20 @@ public:
     // what boost::concurrent_flat_map's bulk visit does and what this was built to try: the address
     // is known there, unlike in a single lookup, and it measured +3.8% on all hits and **-4.8% at
     // half hits**, because an absent key has nothing to fetch and a present one is already covered
-    // once the passes are separated. And it is a fixed-size chunk with straight passes rather than a
-    // sliding ring, because a ring has to be read before the slot it frees is refilled, and getting
-    // that backwards is a wrong answer rather than a crash.
+    // once the passes are separated.
+    //
+    // And it is a fixed-size chunk with straight passes rather than a sliding ring. A ring is the
+    // obvious shape and it is worse, measured: at four million entries 31.8 ns against 26.6 on all
+    // hits, at sixteen million 34.7 against 30.4. Not because of code generation -- both retire
+    // 224.5 instructions per lookup, identical to the tenth -- but because the ring takes 15% more
+    // cycles waiting. The gap is 15% on all hits and 6% at half hits, and a miss reads no value, so
+    // what it is losing is the *value* loads: the third pass issues sixteen of them back to back and
+    // nothing else here creates that parallelism, since the value is the one access not prefetched.
+    // A ring even has the better block prefetch -- a full depth of work for every element, where a
+    // chunk gives its last element less than its first -- and still loses.
+    //
+    // The second reason is that a ring has to be read before the slot it frees is refilled, and
+    // getting that backwards is a wrong answer rather than a crash.
     //
     // f is taken by value, as the standard algorithms take a callable, and is called with
     // value_type& -- or value_type const& on a const map. Keys that are absent are not reported; the

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -2165,8 +2165,14 @@ private:
         // them is read through `this`, which the fingerprint store may alias too.
         //
         // The loop hashes sixteen elements ahead of the one it places and prefetches the group
-        // each will land in. Below cache that is worth 1.26x on the loop (2.05 to 1.63 ns per
-        // element at 200000 entries) for the pipelining alone: the hash, which is a chain, is
+        // each will land in. A sliding ring rather than the bulk visit's chunks, and measured
+        // against it: chunking this loop is 5-17% slower, worst for a string key, for the same
+        // instructions and 12.5% more cycles. An element here has one dependent random access --
+        // the block it is placed in -- where a visit has two, so there is no second batch to issue
+        // concurrently and the only thing that matters is how much time separates a prefetch from
+        // its use. A ring gives every element a full sixteen placements of that; a chunk gives its
+        // first elements only the rest of the hashing pass, which is far cheaper than placing. Below cache that is worth 1.26x
+        // on the loop (2.05 to 1.63 ns per element at 200000 entries) for the pipelining alone: the hash, which is a chain, is
         // decoupled from the placement, which is a random access, so neither waits for the other.
         // Above cache the prefetch is what matters for a key whose hash has work to hide a miss
         // behind -- a string rehash at four million entries goes 30.6 to 12.4 ns per element -- and

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -333,10 +333,33 @@ all hits and -4.8% at half hits**, so it is not in the shipped version: an absen
 fetch, and a present one is already covered by the out-of-order window once the passes are separated.
 **The gain is the separation, not the fetch.** #229's conclusion stands and this does not reopen it.
 
-Three passes rather than a ring is also a correctness choice. A ring has to be read before the slot
-it frees is refilled -- `ring[i % depth]` is the slot `i + depth` writes -- and getting that backwards
-returns a wrong answer rather than crashing. It was got backwards twice while this was being built,
-once in a test and once in a README example, and only the test caught it.
+**Three passes rather than a sliding ring, and the ring is the one that loses** (asked 2026-09-11 as
+"would a streaming approach perform better, I guess not because this can unroll"). Built both:
+`map<uint64_t, size_t>`, medians of three, ns per lookup.
+
+| | 200000 hit | 4M hit | 16M hit | 4M half | 16M half |
+|---|---|---|---|---|---|
+| three passes | **6.94** | **26.63** | **30.35** | **28.27** | **31.67** |
+| sliding ring | 7.53 | 31.64 | 34.72 | 29.28 | 32.05 |
+
+**And it is not code generation**, which was the reason offered for expecting it: both retire
+**224.5 instructions per lookup**, identical to the tenth, and the ring spends **15% more cycles**
+(339.0 against 294.5 at four million, all hits). Same work, more waiting.
+
+The split between the columns says what it is waiting for. The gap is 15% on all hits and 6% at half
+hits, and **a miss reads no value at all** -- so what the ring gives up is the *value* loads. The
+third pass issues sixteen of them back to back, and nothing else creates that parallelism, because
+the value is the one access that is not prefetched (see above: prefetching it is a net loss). The
+ring issues one per iteration and leaves the overlap to the out-of-order window.
+
+What makes that conclusion clean is that the ring has the *better* block prefetch: every element
+gets a full depth of real work between its prefetch and its use, where a chunk gives its last element
+less than its first. It wins that axis and still loses by 19%.
+
+A ring is also the shape that has to be read before the slot it frees is refilled -- `ring[i % depth]`
+is the slot `i + depth` writes -- and getting that backwards returns a wrong answer rather than
+crashing. It was got backwards twice while this was being built, once in a test and once in a README
+example, and only the test caught it. So the chunk is both faster and harder to get wrong.
 
 **A chunk of 16 is not load-bearing**: 8 through 32 measured within 2%. Sixteen is what boost uses.
 

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- Chunks or a sliding ring: the rehash and the bulk visit want opposite answers
 - A bulk `visit()`, and the `prefetch(key)` API it replaced
 - Tiny pointers, and the bound insertion order puts on the value index
 - Splitting the probe past the home group: kept, for keys whose compare is a call
@@ -290,6 +291,43 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**Chunks or a sliding ring: the rehash and the bulk visit want opposite answers, and the reason
+generalises** (2026-09-11, asked as "would a streaming approach perform better" and then "but doesn't
+resize use that streaming too, it looks like it would be better with chunking"). Both shapes were
+built for both loops. Each loop is faster in the shape it already had, and the principle that decides
+it is worth more than either result.
+
+**The bulk visit wants chunks.** Three passes against a sliding ring, `map<uint64_t, size_t>`, ns per
+lookup: 26.6 against 31.6 at four million all hits, 30.4 against 34.7 at sixteen million. Both retire
+**224.5 instructions per lookup, identical to the tenth**; the ring spends 15% more cycles. The gap is
+15% on all hits and 6% at half hits, and a miss reads no value, so what the ring loses is the *value*
+loads -- the third pass issues sixteen back to back and nothing else creates that parallelism.
+
+**The rehash wants the ring.** Chunked against the shipped streaming version, ns per element:
+
+| | 200000 | 1000000 | 4000000 |
+|---|---|---|---|
+| `uint64_t`, streaming | **2.24** | **6.16** | **17.19** |
+| `uint64_t`, chunked | 2.42 | 6.89 | 18.03 |
+| string, streaming | **7.70** | **10.73** | **20.68** |
+| string, chunked | 8.25 | 12.57 | 22.91 |
+
+Same signature, other direction: for a string key both retire ~137 instructions per element and the
+chunked one spends **12.5% more cycles** (99.1 against 88.1).
+
+**What decides it is how many dependent random accesses an element has.** A visit has two -- the
+group's block, then the value the slot points at. Separating them into passes lets the second batch
+issue sixteen at once, which is the only parallelism available on an access that is not prefetched. A
+rehash has **one**: it reads the block and writes into it, and the value is already where it belongs.
+With nothing to batch, the only thing that matters is how much time sits between a prefetch and its
+use -- and a ring maximises exactly that, giving every element a full sixteen *placements* of cover.
+A chunk gives the first elements of each chunk only the rest of pass one, and pass one is hashing,
+which is far cheaper than placing. So the chunk's early elements stall.
+
+So: **chunk when an element has two dependent accesses, stream when it has one.** Predicting from the
+shape of the loop rather than from the code, and the string column is the check -- it is the case with
+the most work per element and it moves the most, in both loops, in opposite directions.
+
 **A bulk `visit()`, and the `prefetch(key)` API it replaced -- which was measured against the wrong
 baseline** (2026-09-11, issue #232, asked as "would it make sense to have a bulk api"). `prefetch(key)`
 shipped documented at 1.5x and was reverted the same day. Both halves are worth keeping, because the

--- a/scripts/ab/range_insert.cpp
+++ b/scripts/ab/range_insert.cpp
@@ -10,6 +10,9 @@
 // rehash -- which is pipelined already -- are out of the measurement and what is left is the insert.
 //
 //   argv: <loop|range> <n> [rounds] [reserved|grow]
+//
+// Built by hand; -DUDM_RI_STR swaps the key for a std::string, which is the shape where the hash
+// being pipelined is worth the most.
 #include <ankerl/unordered_dense.h>
 
 #include <bench/workloads.h>

--- a/scripts/ab/range_insert.cpp
+++ b/scripts/ab/range_insert.cpp
@@ -1,0 +1,83 @@
+// What hashing ahead is worth to insert(first, last).
+//
+// A single insert has nothing to put between computing a key's hash and needing the block that hash
+// points at. A range does: the hash of a later element, which depends on nothing the table is doing.
+// `loop` inserts one at a time, `range` hands the whole thing to insert(first, last); before the
+// pipelining landed the two were the same code.
+//
+// The map is rebuilt from empty every round, which is what a range insert is usually for, and the
+// round is what is timed. `reserved` builds into a map that was told its size, so growth and the
+// rehash -- which is pipelined already -- are out of the measurement and what is left is the insert.
+//
+//   argv: <loop|range> <n> [rounds] [reserved|grow]
+#include <ankerl/unordered_dense.h>
+
+#include <bench/workloads.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+#if defined(UDM_RI_STR)
+using key_type = std::string;
+#else
+using key_type = std::uint64_t;
+#endif
+using map_t = ankerl::unordered_dense::map<key_type, std::size_t>;
+
+struct rng {
+    std::uint64_t s;
+    explicit rng(std::uint64_t seed)
+        : s(seed * UINT64_C(0x9E3779B97F4A7C15) | 1U) {}
+    auto operator()() -> std::uint64_t {
+        s ^= s << 13U;
+        s ^= s >> 7U;
+        s ^= s << 17U;
+        return s;
+    }
+};
+} // namespace
+
+int main(int argc, char** argv) {
+    workloads::tame_allocator();
+    auto const how = std::string(argc > 1 ? argv[1] : "range");
+    auto const n = static_cast<std::size_t>(argc > 2 ? std::strtoull(argv[2], nullptr, 10) : 200000);
+    auto const rounds = static_cast<std::size_t>(argc > 3 ? std::strtoull(argv[3], nullptr, 10) : 20);
+    auto const reserved = std::string(argc > 4 ? argv[4] : "grow") == "reserved";
+
+    // Built once, outside the timing: what is being measured is the insert, not making the input.
+    auto input = std::vector<std::pair<key_type, std::size_t>>();
+    input.reserve(n);
+    auto r = rng(1);
+    for (std::size_t i = 0; i < n; ++i) {
+        input.emplace_back(workloads::key_for<map_t>(r() >> 2U), i);
+    }
+
+    auto acc = std::size_t{0};
+    auto const started = std::chrono::steady_clock::now();
+    for (std::size_t round = 0; round < rounds; ++round) {
+        auto map = map_t();
+        if (reserved) {
+            map.reserve(n);
+        }
+        if (how == "range") {
+            map.insert(input.begin(), input.end());
+        } else {
+            for (auto const& kv : input) {
+                map.insert(kv);
+            }
+        }
+        acc += map.size();
+    }
+    auto const elapsed = std::chrono::steady_clock::now() - started;
+    std::printf("%.3f ns/element  %s n=%zu rounds=%zu %s acc=%zu\n",
+                std::chrono::duration<double, std::nano>(elapsed).count() / static_cast<double>(n * rounds),
+                how.c_str(),
+                n,
+                rounds,
+                reserved ? "reserved" : "grow",
+                acc);
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -42,6 +42,7 @@ test_sources = [
     'unit/erase_churn.cpp',
     'unit/move_home.cpp',
     'unit/probe_split.cpp',
+    'unit/range_insert.cpp',
     'unit/erase_range.cpp',
     'unit/erase_throwing_move.cpp',
     'unit/erase_uncounts.cpp',

--- a/test/unit/lazy_bucket_allocation.cpp
+++ b/test/unit/lazy_bucket_allocation.cpp
@@ -150,6 +150,25 @@ TEST_CASE("the_first_insert_allocates_the_buckets") {
         REQUIRE(map.size() == 2);
     }
 
+    // A range insert hashes ahead of where it places, so it has to have an array to prefetch
+    // against and allocates one before it looks at anything. Inserting *nothing* must still not
+    // allocate, which means the empty case has to be answered before that -- a mutation sweep on
+    // 2026-09-11 removed the check and nothing noticed.
+    SUBCASE("empty range insert") {
+        auto source = std::vector<pair_t>();
+        auto map = tracked<counting_map>(counts);
+        map.insert(source.begin(), source.end());
+        REQUIRE(map.empty());
+        REQUIRE(map.bucket_count() == 0);
+
+        // and an empty sub-range of a container that is not empty
+        source.emplace_back(1, 2);
+        map.insert(source.begin(), source.begin());
+        REQUIRE(map.bucket_count() == 0);
+        map.insert(source.begin(), source.end());
+        REQUIRE(map.bucket_count() != 0);
+    }
+
     SUBCASE("initializer list insert") {
         auto map = tracked<counting_map>(counts);
         map.insert({{1, 2}, {3, 4}});

--- a/test/unit/range_insert.cpp
+++ b/test/unit/range_insert.cpp
@@ -1,0 +1,168 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <cstdint>
+#include <iterator>
+#include <list>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// insert(first, last) hashes ahead of where it places, which is a different code path from
+// insert(value) in a loop -- and only for an iterator that can be walked twice. What is testable is
+// that the two paths cannot be told apart: same elements, same "first one wins" on duplicates, same
+// answer at the range lengths where the sixteen-deep lookahead has edges.
+
+TEST_CASE("range_insert_matches_a_loop_of_single_inserts") {
+    auto input = std::vector<std::pair<uint64_t, size_t>>();
+    for (size_t i = 0; i < 5000; ++i) {
+        input.emplace_back(static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15), i);
+    }
+
+    // Every length from empty to past two lookahead windows, then the whole thing: the priming
+    // loop, the steady state and the tail are all short-range cases.
+    for (size_t len = 0; len <= 40; ++len) {
+        auto ranged = ankerl::unordered_dense::map<uint64_t, size_t>();
+        auto looped = ankerl::unordered_dense::map<uint64_t, size_t>();
+        ranged.insert(input.begin(), input.begin() + static_cast<std::ptrdiff_t>(len));
+        for (size_t i = 0; i < len; ++i) {
+            looped.insert(input[i]);
+        }
+        REQUIRE(ranged.size() == looped.size());
+        for (auto const& [k, v] : looped) {
+            REQUIRE(ranged.at(k) == v);
+        }
+    }
+
+    auto ranged = ankerl::unordered_dense::map<uint64_t, size_t>();
+    ranged.insert(input.begin(), input.end());
+    REQUIRE(ranged.size() == input.size());
+    for (auto const& [k, v] : input) {
+        REQUIRE(ranged.at(k) == v);
+    }
+}
+
+// insert() keeps the element already there, so a duplicate later in the range must not overwrite an
+// earlier one -- the lookahead sees later keys before the earlier ones are placed, which is exactly
+// where that could go wrong.
+TEST_CASE("range_insert_keeps_the_first_of_each_duplicate") {
+    auto input = std::vector<std::pair<int, int>>();
+    for (int round = 0; round < 40; ++round) {
+        for (int i = 0; i < 20; ++i) {
+            input.emplace_back(i, round); // the same twenty keys, forty times, spanning the window
+        }
+    }
+    auto map = ankerl::unordered_dense::map<int, int>();
+    map.insert(input.begin(), input.end());
+    REQUIRE(map.size() == 20U);
+    for (int i = 0; i < 20; ++i) {
+        REQUIRE(map.at(i) == 0); // the first round's value, not the last
+    }
+}
+
+// Into a map that already holds things, and one that has never allocated buckets.
+TEST_CASE("range_insert_into_a_populated_and_an_empty_map") {
+    auto input = std::vector<std::pair<int, int>>();
+    for (int i = 0; i < 1000; ++i) {
+        input.emplace_back(i, i * 2);
+    }
+    auto fresh = ankerl::unordered_dense::map<int, int>();
+    REQUIRE(fresh.bucket_count() == 0U);
+    fresh.insert(input.begin(), input.end());
+    REQUIRE(fresh.size() == 1000U);
+
+    auto populated = ankerl::unordered_dense::map<int, int>();
+    for (int i = 500; i < 1500; ++i) {
+        populated[i] = -1;
+    }
+    populated.insert(input.begin(), input.end());
+    REQUIRE(populated.size() == 1500U);
+    REQUIRE(populated.at(0) == 0);     // new, from the range
+    REQUIRE(populated.at(999) == -1);  // already there, so the range did not overwrite it
+    REQUIRE(populated.at(1499) == -1); // untouched
+}
+
+// A single-pass iterator cannot be walked twice, so it takes the plain loop rather than the
+// lookahead. It has to keep working, which is the only thing that says the fallback is wired up.
+TEST_CASE("range_insert_from_an_input_iterator") {
+    auto text = std::string("7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25");
+    auto in = std::istringstream(text);
+    auto set = ankerl::unordered_dense::set<int>();
+    set.insert(std::istream_iterator<int>(in), std::istream_iterator<int>());
+    REQUIRE(set.size() == 19U);
+    REQUIRE(set.count(7) == 1U);
+    REQUIRE(set.count(25) == 1U);
+    REQUIRE(set.count(26) == 0U);
+    static_assert(!ankerl::unordered_dense::detail::is_forward_iterator_v<std::istream_iterator<int>>,
+                  "an istream_iterator is single-pass and must take the fallback");
+    static_assert(ankerl::unordered_dense::detail::is_forward_iterator_v<std::vector<int>::iterator>,
+                  "a vector iterator can be walked twice");
+    static_assert(ankerl::unordered_dense::detail::is_forward_iterator_v<std::list<int>::iterator>,
+                  "so can a list iterator, which is not random access");
+}
+
+// A non-contiguous forward range still takes the lookahead path.
+TEST_CASE("range_insert_from_a_list") {
+    auto values = std::list<std::pair<int, int>>();
+    for (int i = 0; i < 500; ++i) {
+        values.emplace_back(i, i);
+    }
+    auto map = ankerl::unordered_dense::map<int, int>();
+    map.insert(values.begin(), values.end());
+    REQUIRE(map.size() == 500U);
+    REQUIRE(map.at(499) == 499);
+}
+
+// Against a reference, over a range big enough to grow the table several times -- growth moves the
+// bucket array, which is what the prefetches in flight are aimed at.
+TEST_CASE("range_insert_across_several_growths") {
+    auto input = std::vector<std::pair<uint64_t, uint64_t>>();
+    auto ref = std::unordered_map<uint64_t, uint64_t>();
+    for (uint64_t i = 0; i < 40000; ++i) {
+        auto const k = i * UINT64_C(0x9E3779B97F4A7C15);
+        input.emplace_back(k, i);
+        ref.emplace(k, i);
+    }
+    auto map = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    map.insert(input.begin(), input.end());
+    REQUIRE(map.size() == ref.size());
+    for (auto const& [k, v] : ref) {
+        REQUIRE(map.at(k) == v);
+    }
+    for (uint64_t i = 0; i < 1000; ++i) {
+        REQUIRE(map.count(i * UINT64_C(0x9E3779B97F4A7C15) + 1) == ref.count(i * UINT64_C(0x9E3779B97F4A7C15) + 1));
+    }
+}
+
+// A default-constructed table has no bucket array, and inserting nothing must not give it one --
+// the same promise lazy_bucket_allocation.cpp makes of the other entry points. The range insert
+// allocates before it hashes anything, so the empty case has to return before that.
+TEST_CASE("range_insert_of_an_empty_range_allocates_nothing") {
+    auto input = std::vector<std::pair<int, int>>();
+    auto map = ankerl::unordered_dense::map<int, int>();
+    map.insert(input.begin(), input.end());
+    REQUIRE(map.bucket_count() == 0U);
+    REQUIRE(map.empty());
+
+    // and the same for a non-empty container's empty sub-range
+    input.emplace_back(1, 1);
+    map.insert(input.begin(), input.begin());
+    REQUIRE(map.bucket_count() == 0U);
+    map.insert(input.begin(), input.end());
+    REQUIRE(map.bucket_count() != 0U);
+}
+
+TEST_CASE("range_insert_initializer_list_and_self_range") {
+    auto map = ankerl::unordered_dense::map<int, int>{{1, 10}, {2, 20}, {3, 30}};
+    REQUIRE(map.size() == 3U);
+    REQUIRE(map.at(2) == 20);
+
+    // inserting a map's own values back into it changes nothing
+    auto copy = map;
+    map.insert(copy.begin(), copy.end());
+    REQUIRE(map.size() == 3U);
+    REQUIRE(map.at(3) == 30);
+}

--- a/test/unit/range_insert.cpp
+++ b/test/unit/range_insert.cpp
@@ -22,9 +22,15 @@ TEST_CASE("range_insert_matches_a_loop_of_single_inserts") {
         input.emplace_back(static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15), i);
     }
 
-    // Every length from empty to past two lookahead windows, then the whole thing: the priming
-    // loop, the steady state and the tail are all short-range cases.
+    // Every length from empty to past two lookahead windows, and then the whole range: the priming
+    // loop, the steady state and the tail are all short-range cases, and the last one is the only
+    // length that grows the table while the lookahead is running.
+    auto lengths = std::vector<size_t>();
     for (size_t len = 0; len <= 40; ++len) {
+        lengths.push_back(len);
+    }
+    lengths.push_back(input.size());
+    for (auto const len : lengths) {
         auto ranged = ankerl::unordered_dense::map<uint64_t, size_t>();
         auto looped = ankerl::unordered_dense::map<uint64_t, size_t>();
         ranged.insert(input.begin(), input.begin() + static_cast<std::ptrdiff_t>(len));
@@ -35,13 +41,6 @@ TEST_CASE("range_insert_matches_a_loop_of_single_inserts") {
         for (auto const& [k, v] : looped) {
             REQUIRE(ranged.at(k) == v);
         }
-    }
-
-    auto ranged = ankerl::unordered_dense::map<uint64_t, size_t>();
-    ranged.insert(input.begin(), input.end());
-    REQUIRE(ranged.size() == input.size());
-    for (auto const& [k, v] : input) {
-        REQUIRE(ranged.at(k) == v);
     }
 }
 
@@ -98,10 +97,18 @@ TEST_CASE("range_insert_from_an_input_iterator") {
     REQUIRE(set.count(26) == 0U);
     static_assert(!ankerl::unordered_dense::detail::is_forward_iterator_v<std::istream_iterator<int>>,
                   "an istream_iterator is single-pass and must take the fallback");
-    static_assert(ankerl::unordered_dense::detail::is_forward_iterator_v<std::vector<int>::iterator>,
-                  "a vector iterator can be walked twice");
-    static_assert(ankerl::unordered_dense::detail::is_forward_iterator_v<std::list<int>::iterator>,
-                  "so can a list iterator, which is not random access");
+}
+
+// Which ranges get the lookahead at all. A type with no iterator_traits must answer no rather than
+// fail to compile, which is the case that decides how the trait is written.
+TEST_CASE("range_insert_which_iterators_can_be_walked_twice") {
+    struct no_traits {};
+    using namespace ankerl::unordered_dense::detail;
+    static_assert(is_forward_iterator_v<std::vector<int>::iterator>, "a vector iterator can be walked twice");
+    static_assert(is_forward_iterator_v<std::list<int>::iterator>, "so can a list iterator, which is not random access");
+    static_assert(is_forward_iterator_v<int const*>, "and a plain pointer, which is what an initializer_list gives");
+    static_assert(!is_forward_iterator_v<std::istream_iterator<int>>, "an istream_iterator cannot");
+    static_assert(!is_forward_iterator_v<no_traits>, "and a type with no iterator_traits must not fail to compile");
 }
 
 // A non-contiguous forward range still takes the lookahead path.
@@ -137,30 +144,12 @@ TEST_CASE("range_insert_across_several_growths") {
     }
 }
 
-// A default-constructed table has no bucket array, and inserting nothing must not give it one --
-// the same promise lazy_bucket_allocation.cpp makes of the other entry points. The range insert
-// allocates before it hashes anything, so the empty case has to return before that.
-TEST_CASE("range_insert_of_an_empty_range_allocates_nothing") {
-    auto input = std::vector<std::pair<int, int>>();
-    auto map = ankerl::unordered_dense::map<int, int>();
-    map.insert(input.begin(), input.end());
-    REQUIRE(map.bucket_count() == 0U);
-    REQUIRE(map.empty());
-
-    // and the same for a non-empty container's empty sub-range
-    input.emplace_back(1, 1);
-    map.insert(input.begin(), input.begin());
-    REQUIRE(map.bucket_count() == 0U);
-    map.insert(input.begin(), input.end());
-    REQUIRE(map.bucket_count() != 0U);
-}
-
-TEST_CASE("range_insert_initializer_list_and_self_range") {
+TEST_CASE("range_insert_initializer_list_and_from_a_copy") {
     auto map = ankerl::unordered_dense::map<int, int>{{1, 10}, {2, 20}, {3, 30}};
     REQUIRE(map.size() == 3U);
     REQUIRE(map.at(2) == 20);
 
-    // inserting a map's own values back into it changes nothing
+    // inserting a copy of a map's values back into it changes nothing
     auto copy = map;
     map.insert(copy.begin(), copy.end());
     REQUIRE(map.size() == 3U);


### PR DESCRIPTION
**Stacked on #241** — merge that first; this branch contains it.

Asked as "anything else in boost's concurrent map API we should take". The answer there was mostly no — the rest of that API substitutes for iterators a concurrent map cannot hand out — but the *idea* transfers to a method we already expose and were not exploiting.

## What it does

A single insert has nothing to put between computing a key's hash and needing the block that hash points at. A range does: the hash of a later element, which depends on nothing the table is doing. That is exactly the growth rehash's trick — already in the header, worth 1.26x on its loop, and sitting one function away from a range insert that did not use it.

**No new API.** `insert(first, last)` is a standard method; this is a faster implementation of it.

## What it is worth

Rebuilding a map from a `vector<pair<K,V>>`, ns per element, medians of three:

| n | | before | after | |
|---|---|---|---|---|
| 200 000 | reserved | 8.14 | 5.64 | **1.44x** |
| 200 000 | growing | 10.40 | 8.64 | 1.20x |
| 2 000 000 | reserved | 14.48 | 7.59 | **1.91x** |
| 2 000 000 | growing | 31.20 | 26.69 | 1.17x |

String keys at two million: **1.47x** reserved, 1.17x growing.

The reserved column is the insert path on its own. Where the table grows, the rehash dominates and *that* loop was already pipelined, which is why the growing column moves less — it is the part that was already fast.

## Limits, and why

**Only for an iterator that can be walked twice.** An input iterator is single-pass, so reading ahead would mean buffering the elements and those copies would cost more than the prefetch saves — such a range takes the plain loop. The detection is a trait rather than an inline `iterator_traits` query, because a type with no `iterator_traits` at all must answer "no" rather than fail to compile; the test suite has exactly such an iterator and caught this.

**Growth during the loop is safe and not special-cased.** It moves the bucket array, so prefetches already in flight are aimed at the old one and simply do nothing; the hashes stay valid because a hash does not depend on the table.

## Verification

- 799 tests pass under clang, gcc, both unity builds, and ASan+UBSan.
- Tests cover every range length from 0 past two lookahead windows, duplicates within a range (the lookahead sees later keys before earlier ones are placed, so "first one wins" is exactly where this could break), insertion into a populated map, a `std::list` range, an `istream_iterator` range taking the fallback, and 40 000 elements across several growths against `std::unordered_map`.
- **Mutation swept.** Two findings acted on: `do_insert_hashed` returned a `pair` nobody read — surface no test can defend, so it returns nothing — and deleting the empty-range early return went unnoticed, which would have made `insert(v.end(), v.end())` allocate buckets and break the lazy-allocation promise. Both fixed and the second now has a test that kills the mutant. The survivors that remain are the lookahead depth (16 → 15 or 17) and the prefetch itself, which are performance-only by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)