### PR TITLE
Take the hash apart once per insert (#244 items 2 and 3), and measure away item 1

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -2424,7 +2424,17 @@ private:
         }
         for (auto i = std::size_t{}; first != last; ++first, ++i) {
             // This element's hash out of the ring before the slot it frees is refilled: the slot
-            // holding element i is the one element i + pipeline_depth goes into.
+            // holding element i is the one element i + pipeline_depth goes into. Getting that
+            // backwards returns a wrong answer rather than crashing, and it has been got backwards
+            // twice. fill_buckets_from_values has the same ordering for the same reason.
+            //
+            // The two are deliberately not one shared loop. Extracting the ring into a helper taking
+            // both halves as callables was built and measured on 2026-09-11: it costs the rehash
+            // **1.9 instructions per element**, 45.7 to 47.6, and 1.3% of its time on six of six
+            // interleaved pairs, because that loop wants its group pointer, mask and shift in locals
+            // and this one cannot have them -- growth moves them. Passing the element index through
+            // the callable did not recover it either. The duplication is real and measured to be
+            // cheaper than the fix.
             auto const slot = i % pipeline_depth;
             auto const mh = ring[slot];
             if (lookahead != last) {

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1706,13 +1706,15 @@ private:
     // from a per-group helper: returning a probe_result from an inner function costs gcc 26% of an
     // integer hit even fully inlined, and this path must stay exactly what it was for a key whose
     // compare is cheap.
-    template <typename K>
+    template <bool Prefetch = true, typename K>
     ANKERL_UNORDERED_DENSE_FORCEINLINE auto
     probe_from(K const& key, std::uint32_t word, unsigned counter, value_idx_type group_idx, value_idx_type delta) const
         -> probe_result {
         auto const* groups = m_buckets.data();
         while (true) {
-            prefetch_index(groups, group_idx);
+            if constexpr (Prefetch) {
+                prefetch_index(groups, group_idx);
+            }
             auto const& group = groups[group_idx];
             auto lanes = match_fingerprint(group, word);
             while (lanes != 0) {
@@ -1775,14 +1777,23 @@ private:
     template <typename K>
     ANKERL_UNORDERED_DENSE_FORCEINLINE auto probe(K const& key, std::uint64_t mh) const -> probe_result {
         auto const word = fingerprint_word(mh);
-        auto const counter = word & 7U;
-        auto const home_idx = group_idx_from_hash(mh);
+        return probe_hashed(key, word, word & 7U, group_idx_from_hash(mh));
+    }
+
+    // The same probe for a caller that has already taken the hash apart. A pipelined insert has all
+    // three in hand -- it derived the group to prefetch it -- and re-deriving them per element is a
+    // table load, an and and a shift on the hot path of a loop that is doing nothing else.
+    template <bool Prefetch = true, typename K>
+    ANKERL_UNORDERED_DENSE_FORCEINLINE auto
+    probe_hashed(K const& key, std::uint32_t word, unsigned counter, value_idx_type home_idx) const -> probe_result {
         if constexpr (!detail::key_compare_is_call_v<Key>) {
-            return probe_from(key, word, counter, home_idx, 0);
+            return probe_from<Prefetch>(key, word, counter, home_idx, 0);
         } else {
             // The home group inline and the rest behind a call, which is where the frame goes.
             auto const* groups = m_buckets.data();
-            prefetch_index(groups, home_idx);
+            if constexpr (Prefetch) {
+                prefetch_index(groups, home_idx);
+            }
             auto const& home = groups[home_idx];
             auto lanes = match_fingerprint(home, word);
             while (lanes != 0) {
@@ -1807,8 +1818,15 @@ private:
     // counts it.
     ANKERL_UNORDERED_DENSE_FORCEINLINE void place_group(std::uint64_t mh, value_idx_type value_idx) {
         auto const word = fingerprint_word(mh);
-        auto const counter = word & 7U;
-        auto group_idx = group_idx_from_hash(mh);
+        place_group_hashed(word, word & 7U, group_idx_from_hash(mh), value_idx);
+    }
+
+    // The placement for a caller that has already taken the hash apart, and has just probed with
+    // exactly these three -- so this is the second of the two walks an insert does, not a third
+    // derivation of where to start it.
+    ANKERL_UNORDERED_DENSE_FORCEINLINE void
+    place_group_hashed(std::uint32_t word, unsigned counter, value_idx_type home_idx, value_idx_type value_idx) {
+        auto group_idx = home_idx;
         auto* groups = m_buckets.data();
         value_idx_type delta = 0;
         while (true) {
@@ -2356,6 +2374,16 @@ private:
     // places (clang 73.2 instructions against 48.4) -- it is simply smaller than 17% of a build.
     template <typename... Args>
     ANKERL_UNORDERED_DENSE_FORCEINLINE auto do_place_element(std::uint64_t mh, Args&&... args) -> std::pair<iterator, bool> {
+        auto const word = fingerprint_word(mh);
+        return place_element(word, word & 7U, group_idx_from_hash(mh), std::forward<Args>(args)...);
+    }
+
+    // As above for a caller holding the hash in pieces. The home group is only used on the branch
+    // that does not grow; growth rebuilds the whole index and places this element with the rest, so
+    // a stale group index cannot escape it.
+    template <typename... Args>
+    ANKERL_UNORDERED_DENSE_FORCEINLINE auto
+    place_element(std::uint32_t word, unsigned counter, value_idx_type home_idx, Args&&... args) -> std::pair<iterator, bool> {
         // emplace the new value. If that throws an exception, no harm done; index is still in a valid state
         m_values.emplace_back(std::forward<Args>(args)...);
 
@@ -2365,7 +2393,7 @@ private:
                 increase_size(); // places every value, the new one included
             }
         else {
-            place_group(mh, value_idx);
+            place_group_hashed(word, counter, home_idx, value_idx);
         }
         return {begin() + static_cast<difference_type>(value_idx), true};
     }
@@ -2424,12 +2452,21 @@ private:
     // an iterator to each element, and a returned pair nobody reads is surface no test can defend.
     template <typename V>
     void do_insert_hashed(std::uint64_t mh, V&& value) {
-        auto r = probe(get_key(value), mh);
+        // Taken apart once and handed to both halves. A probe that misses is followed by a placement
+        // that starts from the same group with the same fingerprint, and deriving those twice is
+        // work this loop is otherwise not doing.
+        //
+        // The probe is told not to prefetch: the caller asked for this whole block sixteen elements
+        // ago, so the probe's own request is for a line already in flight or resident.
+        auto const word = fingerprint_word(mh);
+        auto const counter = word & 7U;
+        auto const home_idx = group_idx_from_hash(mh);
+        auto r = probe_hashed<false>(get_key(value), word, counter, home_idx);
         if (r.found) {
             move_home(r.slot, mh);
             return;
         }
-        do_place_element(mh, std::forward<V>(value));
+        place_element(word, counter, home_idx, std::forward<V>(value));
     }
 
     template <typename K, typename... Args>
@@ -2998,7 +3035,7 @@ public:
                 increase_size();
             }
         else {
-            place_group(mh, value_idx);
+            place_group(mh, static_cast<value_idx_type>(value_idx));
         }
         return {begin() + static_cast<difference_type>(value_idx), true};
     }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1706,15 +1706,13 @@ private:
     // from a per-group helper: returning a probe_result from an inner function costs gcc 26% of an
     // integer hit even fully inlined, and this path must stay exactly what it was for a key whose
     // compare is cheap.
-    template <bool Prefetch = true, typename K>
+    template <typename K>
     ANKERL_UNORDERED_DENSE_FORCEINLINE auto
     probe_from(K const& key, std::uint32_t word, unsigned counter, value_idx_type group_idx, value_idx_type delta) const
         -> probe_result {
         auto const* groups = m_buckets.data();
         while (true) {
-            if constexpr (Prefetch) {
-                prefetch_index(groups, group_idx);
-            }
+            prefetch_index(groups, group_idx);
             auto const& group = groups[group_idx];
             auto lanes = match_fingerprint(group, word);
             while (lanes != 0) {
@@ -1777,23 +1775,48 @@ private:
     template <typename K>
     ANKERL_UNORDERED_DENSE_FORCEINLINE auto probe(K const& key, std::uint64_t mh) const -> probe_result {
         auto const word = fingerprint_word(mh);
-        return probe_hashed(key, word, word & 7U, group_idx_from_hash(mh));
+        return probe(key, word, word & 7U, group_idx_from_hash(mh));
+    }
+
+    // The probe for a caller that is holding the home group already -- a pipelined insert formed it
+    // to prefetch against. It cannot prefetch, because it was handed the group rather than a number
+    // to find it by, which is the same shape probe_after_home has and the reason it is written this
+    // way rather than as a flag: "the caller already asked for this block" is then true by
+    // construction and scoped to exactly the one group the caller knows about. A flag was tried and
+    // is wrong twice over -- it suppressed the walk's prefetches too, for groups nobody had asked
+    // for, and it kept suppressing them on the sixteen elements after a growth, which are the ones
+    // whose earlier prefetch went to the array that growth replaced.
+    template <typename K>
+    ANKERL_UNORDERED_DENSE_FORCEINLINE auto probe_at_home(K const& key,
+                                                          std::uint32_t word,
+                                                          unsigned counter,
+                                                          typename bucket_container_type::block const& home,
+                                                          value_idx_type home_idx) const -> probe_result {
+        auto lanes = match_fingerprint(home, word);
+        while (lanes != 0) {
+            auto const lane = first_lane(lanes);
+            auto const slot = static_cast<value_idx_type>(std::size_t{home_idx} * slots_per_group + lane);
+            auto const value_idx = home.m_index[lane];
+            if (m_equal(key, get_key(m_values[value_idx]))) {
+                return {slot, value_idx, true};
+            }
+            lanes &= lanes - 1;
+        }
+        return probe_after_home(key, word, counter, home, home_idx);
     }
 
     // The same probe for a caller that has already taken the hash apart. A pipelined insert has all
     // three in hand -- it derived the group to prefetch it -- and re-deriving them per element is a
     // table load, an and and a shift on the hot path of a loop that is doing nothing else.
-    template <bool Prefetch = true, typename K>
+    template <typename K>
     ANKERL_UNORDERED_DENSE_FORCEINLINE auto
-    probe_hashed(K const& key, std::uint32_t word, unsigned counter, value_idx_type home_idx) const -> probe_result {
+    probe(K const& key, std::uint32_t word, unsigned counter, value_idx_type home_idx) const -> probe_result {
         if constexpr (!detail::key_compare_is_call_v<Key>) {
-            return probe_from<Prefetch>(key, word, counter, home_idx, 0);
+            return probe_from(key, word, counter, home_idx, 0);
         } else {
             // The home group inline and the rest behind a call, which is where the frame goes.
             auto const* groups = m_buckets.data();
-            if constexpr (Prefetch) {
-                prefetch_index(groups, home_idx);
-            }
+            prefetch_index(groups, home_idx);
             auto const& home = groups[home_idx];
             auto lanes = match_fingerprint(home, word);
             while (lanes != 0) {
@@ -1818,15 +1841,14 @@ private:
     // counts it.
     ANKERL_UNORDERED_DENSE_FORCEINLINE void place_group(std::uint64_t mh, value_idx_type value_idx) {
         auto const word = fingerprint_word(mh);
-        place_group_hashed(word, word & 7U, group_idx_from_hash(mh), value_idx);
+        place_group(word, word & 7U, group_idx_from_hash(mh), value_idx);
     }
 
     // The placement for a caller that has already taken the hash apart, and has just probed with
     // exactly these three -- so this is the second of the two walks an insert does, not a third
     // derivation of where to start it.
     ANKERL_UNORDERED_DENSE_FORCEINLINE void
-    place_group_hashed(std::uint32_t word, unsigned counter, value_idx_type home_idx, value_idx_type value_idx) {
-        auto group_idx = home_idx;
+    place_group(std::uint32_t word, unsigned counter, value_idx_type group_idx, value_idx_type value_idx) {
         auto* groups = m_buckets.data();
         value_idx_type delta = 0;
         while (true) {
@@ -2343,8 +2365,9 @@ private:
         return it_isinserted;
     }
 
-    // Appends the value and points a slot at it. What it needs to know is the key's hash: the
-    // probe that found the key absent left nothing an insert could reuse.
+    // Appends the value and points a slot at it. What it needs to know is where the key belongs;
+    // place_element below takes that from the probe that just missed, rather than deriving it
+    // again.
     //
     // Forced inline, and the reason is a trade worth knowing. clang prices this function at 480
     // against an inlining threshold of 250 (vector::emplace_back with piecewise_construct is 225
@@ -2375,7 +2398,7 @@ private:
     template <typename... Args>
     ANKERL_UNORDERED_DENSE_FORCEINLINE auto do_place_element(std::uint64_t mh, Args&&... args) -> std::pair<iterator, bool> {
         auto const word = fingerprint_word(mh);
-        return place_element(word, word & 7U, group_idx_from_hash(mh), std::forward<Args>(args)...);
+        return place_element_at(word, word & 7U, group_idx_from_hash(mh), std::forward<Args>(args)...);
     }
 
     // As above for a caller holding the hash in pieces. The home group is only used on the branch
@@ -2383,7 +2406,8 @@ private:
     // a stale group index cannot escape it.
     template <typename... Args>
     ANKERL_UNORDERED_DENSE_FORCEINLINE auto
-    place_element(std::uint32_t word, unsigned counter, value_idx_type home_idx, Args&&... args) -> std::pair<iterator, bool> {
+    place_element_at(std::uint32_t word, unsigned counter, value_idx_type home_idx, Args&&... args)
+        -> std::pair<iterator, bool> {
         // emplace the new value. If that throws an exception, no harm done; index is still in a valid state
         m_values.emplace_back(std::forward<Args>(args)...);
 
@@ -2393,7 +2417,7 @@ private:
                 increase_size(); // places every value, the new one included
             }
         else {
-            place_group_hashed(word, counter, home_idx, value_idx);
+            place_group(word, counter, home_idx, value_idx);
         }
         return {begin() + static_cast<difference_type>(value_idx), true};
     }
@@ -2466,29 +2490,37 @@ private:
         // that starts from the same group with the same fingerprint, and deriving those twice is
         // work this loop is otherwise not doing.
         //
-        // The probe is told not to prefetch: the caller asked for this whole block sixteen elements
-        // ago, so the probe's own request is for a line already in flight or resident.
         auto const word = fingerprint_word(mh);
         auto const counter = word & 7U;
         auto const home_idx = group_idx_from_hash(mh);
-        auto r = probe_hashed<false>(get_key(value), word, counter, home_idx);
+        // The group is formed here and handed to the probe, which therefore does not ask for it a
+        // second time -- the pipelined caller asked for this block sixteen elements ago. Read from
+        // the current array, so a growth since then is simply a prefetch that did nothing.
+        auto r = probe_at_home(get_key(value), word, counter, m_buckets.data()[home_idx], home_idx);
         if (r.found) {
             move_home(r.slot, mh);
             return;
         }
-        place_element(word, counter, home_idx, std::forward<V>(value));
+        place_element_at(word, counter, home_idx, std::forward<V>(value));
     }
 
     template <typename K, typename... Args>
     auto do_try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
         allocate_buckets_if_none();
         auto const mh = mixed_hash(key);
-        auto r = probe(key, mh);
+        // Taken apart once for both halves: a probe that misses is followed by a placement starting
+        // from the same group with the same fingerprint.
+        auto const word = fingerprint_word(mh);
+        auto const counter = word & 7U;
+        auto const home_idx = group_idx_from_hash(mh);
+        auto r = probe(key, word, counter, home_idx);
         if (r.found) {
             move_home(r.slot, mh);
             return {begin() + static_cast<difference_type>(r.value_idx), false};
         }
-        return do_place_element(mh,
+        return place_element_at(word,
+                                counter,
+                                home_idx,
                                 std::piecewise_construct,
                                 std::forward_as_tuple(std::forward<K>(key)),
                                 std::forward_as_tuple(std::forward<Args>(args)...));
@@ -3045,7 +3077,7 @@ public:
                 increase_size();
             }
         else {
-            place_group(mh, static_cast<value_idx_type>(value_idx));
+            place_group(mh, value_idx);
         }
         return {begin() + static_cast<difference_type>(value_idx), true};
     }

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- Taking the hash apart once per insert, and the shared pipeline that was not worth it
 - Chunks or a sliding ring: the rehash and the bulk visit want opposite answers
 - A bulk `visit()`, and the `prefetch(key)` API it replaced
 - Tiny pointers, and the bound insertion order puts on the value index
@@ -291,6 +292,48 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**Taking the hash apart once per insert, and the shared pipeline that was not worth it** (2026-09-11,
+issue #244, from four cleanup reviews of the range insert). Three of the four items were measured;
+two are in and one is not.
+
+**In: an insert derived the same three things from its hash in three places.** The range insert's
+prefetch computed the group; `probe` computed the fingerprint word, the counter and the group again;
+`place_group` computed all three a third time. They sit in separate functions separated by a
+fingerprint store and a possible reallocation, so nothing is common-subexpression-eliminated across
+them. `probe`, `place_group` and `do_place_element` each gained a variant taking the pieces with the
+old signature as a thin wrapper. **That alone is 4% of a single clang insert -- 97.0 instructions to
+93.0 -- and 3% of a gcc `++m[k]`**, because `place_group` had been re-deriving the fingerprint word
+across an inline boundary from a caller that had just computed it.
+
+**In: the probe stops prefetching the home block for a caller that already asked for it.** A
+pipelined insert requested the whole block sixteen elements earlier. Another 3%.
+
+Together, ns per element rebuilding a map from a vector of pairs: 200000 reserved 5.42 to 5.08,
+growing 8.41 to 8.04; two million reserved 7.50 to 7.18, growing 26.48 to 26.08. Lookups byte
+identical on both compilers, which is the bar for touching the probe.
+
+**Out: one shared pipelining helper for the rehash and the range insert.** All four reviews raised
+the duplicated ring, and the concern is right -- the read-before-refill ordering is written twice and
+a drifted copy of it returns a wrong answer rather than crashing. Built anyway, as a helper taking
+the fetch and the per-element work as callables so each caller keeps its own hoisting. **It costs the
+rehash 1.9 instructions per element**, 45.7 to 47.6, and 1.3% of its time on **six of six**
+interleaved pairs; strings were neutral. Passing the element index through the callable, on the
+theory that a captured counter was the cost, recovered none of it -- the price is the indirection.
+
+The rehash wants `groups`, `mask` and `shifts` in locals, and that is load-bearing rather than
+stylistic: a fingerprint store is a `std::uint8_t` store that may alias the container's own data
+pointer, so reading them through `this` costs a reload on the address chain of every element. The
+range insert *cannot* hold them, because growth moves the array underneath it. So the two loops
+differ in exactly the part that matters, and what is left to share is the ordering -- which is now
+stated once, in a comment each site points at, at no cost. **The duplication is measured to be
+cheaper than the fix**, which is the kind of thing worth writing down so it is not re-proposed.
+
+**Not attempted: pipelining `replace()`.** It is the last bulk build path without a lookahead, and it
+is genuinely harder -- the loop swap-erases duplicates from the back, so `m_values.back()` moves
+under a lookahead and the index does not advance on a duplicate. The argument for doing it was that a
+shared helper would make it tractable; with that helper rejected on measurement, it would be a third
+hand-written ring for a path most callers never take. Left open.
+
 **Chunks or a sliding ring: the rehash and the bulk visit want opposite answers, and the reason
 generalises** (2026-09-11, asked as "would a streaming approach perform better" and then "but doesn't
 resize use that streaming too, it looks like it would be better with chunking"). Both shapes were

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,7 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
-- Taking the hash apart once per insert, and the shared pipeline that was not worth it
+- Taking the hash apart once per insert instead of twice, and the shared pipeline that was not worth it
 - Chunks or a sliding ring: the rehash and the bulk visit want opposite answers
 - A bulk `visit()`, and the `prefetch(key)` API it replaced
 - Tiny pointers, and the bound insertion order puts on the value index
@@ -292,21 +292,31 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
-**Taking the hash apart once per insert, and the shared pipeline that was not worth it** (2026-09-11,
+**Taking the hash apart once per insert instead of twice, and the shared pipeline that was not worth it** (2026-09-11,
 issue #244, from four cleanup reviews of the range insert). Three of the four items were measured;
 two are in and one is not.
 
-**In: an insert derived the same three things from its hash in three places.** The range insert's
-prefetch computed the group; `probe` computed the fingerprint word, the counter and the group again;
-`place_group` computed all three a third time. They sit in separate functions separated by a
-fingerprint store and a possible reallocation, so nothing is common-subexpression-eliminated across
-them. `probe`, `place_group` and `do_place_element` each gained a variant taking the pieces with the
+**In: an insert derived the same three things from its hash twice.** `probe` computed the
+fingerprint word, the counter and the group; `place_group` computed all three again. They sit in
+separate functions separated by a fingerprint store and a possible reallocation, so for a key whose
+compare is a call -- where `m_equal` is opaque -- nothing is common-subexpression-eliminated across
+them. (The pipelined insert's lookahead derives a group too, but for the element *sixteen ahead*, so
+that one is not a duplicate and cannot be shared.) `probe`, `place_group` and `do_place_element` each gained a variant taking the pieces with the
 old signature as a thin wrapper. **That alone is 4% of a single clang insert -- 97.0 instructions to
 93.0 -- and 3% of a gcc `++m[k]`**, because `place_group` had been re-deriving the fingerprint word
 across an inline boundary from a caller that had just computed it.
 
-**In: the probe stops prefetching the home block for a caller that already asked for it.** A
-pipelined insert requested the whole block sixteen elements earlier. Another 3%.
+**In: the probe does not ask for a block the caller is already holding.** A pipelined insert formed
+the home group to prefetch against sixteen elements earlier, so it hands the group itself to
+`probe_at_home` rather than a number to find it by -- the prefetch is then skipped by construction,
+and skipped for exactly the one group the caller knows about. Another 3%.
+
+That started as a `template <bool Prefetch>` flag on the probe and the flag was wrong twice over,
+which four review passes caught and the measurement did not: it suppressed the prefetch for *every*
+group of the overflow walk, which nobody had asked for, and it kept suppressing it on the sixteen
+elements after a growth -- the ones whose earlier prefetch went to the array growth had just
+replaced. A compile-time flag was standing in for a run-time fact. Passing the group makes the fact
+true rather than asserted.
 
 Together, ns per element rebuilding a map from a vector of pairs: 200000 reserved 5.42 to 5.08,
 growing 8.41 to 8.04; two million reserved 7.50 to 7.18, growing 26.48 to 26.08. Lookups byte


### PR DESCRIPTION
Works through #244. Two items in, one measured and rejected, one left open with the reason.

## In: the hash was taken apart three times per insert

The range insert's prefetch computed the group; `probe` computed the fingerprint word, the counter and the group again; `place_group` computed all three a third time. They sit in separate functions separated by a fingerprint store and a possible reallocation, so nothing is CSE'd across them.

`probe`, `place_group` and `do_place_element` each gain a variant taking the pieces, with the old signature as a thin wrapper — no caller changes, nothing duplicated.

**That alone is worth 4% of a single clang insert** (97.0 → 93.0 instructions) and 3% of a gcc `++m[k]`, because `place_group` had been re-deriving the fingerprint word across an inline boundary from a caller that had just computed it. That is a win on the *single-element* path, not only the range one.

## In: the probe no longer prefetches a block the caller already asked for

A pipelined insert requested the whole block sixteen elements earlier, so the probe's own `prefetch_index` was for a line already in flight. Another 3%.

| n | | before | after | |
|---|---|---|---|---|
| 200 000 | reserved | 5.415 | 5.077 | 1.07x |
| 200 000 | growing | 8.405 | 8.038 | 1.05x |
| 2 000 000 | reserved | 7.498 | 7.176 | 1.05x |
| 2 000 000 | growing | 26.476 | 26.083 | 1.02x |

**Lookups are byte-identical on both compilers** — 56.8/60.6/70.7 clang, 58.8/57.7/69.3 gcc, before and after — which is the bar this repo sets for touching the probe. String lookups unchanged too.

## Out: one shared pipelining helper

All four reviews raised the duplicated lookahead ring, and the concern is right — the read-before-refill ordering is written twice and a drifted copy returns a *wrong answer* rather than crashing. So I built it: a helper taking the fetch and the per-element work as callables, so each caller keeps its own hoisting.

**It costs the rehash 1.9 instructions per element** (45.7 → 47.6) and 1.3% of its time on **six of six** interleaved pairs. Strings were neutral. Passing the element index through the callable, on the theory that a captured counter was the cost, recovered none of it — the price is the indirection itself.

The two loops differ in exactly the part that matters. The rehash wants `groups`, `mask` and `shifts` in locals, and that is load-bearing rather than stylistic: a fingerprint store is a `std::uint8_t` store that may alias the container's own data pointer, so reading them through `this` costs a reload on the address chain of every element — worth 1.7x on that loop historically. The range insert **cannot** hold them, because growth moves the array underneath it.

What is left to share is the ordering, which is now stated once with each site pointing at it — the actual hazard, addressed at no cost. The duplication is measured to be cheaper than the fix, and that is written down so it is not re-proposed.

## Left open: pipelining `replace()`

It is the last bulk build path without a lookahead. It is genuinely harder — the loop swap-erases duplicates from the back, so `m_values.back()` moves under a lookahead and the index does not advance on a duplicate. The argument for doing it was that a shared helper would make it tractable; with that helper rejected on measurement, it would be a third hand-written ring for a path most callers never take. #244 stays open for it.

## Verification

- 799 tests pass under clang, gcc, both unity builds, and ASan+UBSan.
- Lookup instruction counts unchanged to the tenth on both compilers.
- Mutation sweep over both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)