### PR TITLE
Measure the other two pipelines against the cache gate: neither wants it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,14 +87,17 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
   octave and reports the geometric mean; `-p 1` restores the old single size. An eleven-slot group
   read 1.384 at one size and 1.039 over the octave; `churn64` read 1.199 and 0.974 — sign reversed.
   Every boost ratio not labelled "octave geomean" is a point measurement and must be re-taken.
-- **A prefetch pipeline is a loss while the data is in cache, so sweep across that boundary too.**
-  A lookahead ring costs 13–17 instructions per element in all four loops that have one, and the
-  ring's own round trip is paid whether or not the prefetch was needed. `replace()` was measured at
-  200k and 2M, both above the crossover, and shipped a version that was **a fifth slower below 65k**
-  until it was gated on footprint. Two sizes on the same side of a cache are one size.
+- **A prefetch pipeline can be a loss while the data is in cache, so sweep across that boundary
+  too.** The lookahead costs 13–17 instructions per element in the three loops measured, paid
+  whether or not the prefetch was needed — but only one of the three wants a gate, so measure, do
+  not assume. `replace()` was measured at 200k and 2M, both above its crossover, and shipped a
+  version that was a fifth slower below 65k. Two sizes on the same side of a cache are one size, and
+  the load factor still sweeps underneath: the *same* index size reads 0.75 and 1.05 at two n.
 - **The control for "does this pipeline pay" is the same entry point with the ring removed**, built
-  as a second header. A caller's own loop of single calls is not it: that carries ~15 instructions
-  of call boundary per element and shows the bulk entry point winning everywhere.
+  as a second binary (`solo.sh`, not the paired harness — removing a ring changes a function's
+  size). A caller's own loop of single calls is not it: that carries the call boundary's 15
+  instructions and shows the bulk entry point winning everywhere. Only the *time* needs the size
+  sweep; the instruction premium is flat, so one `perf` run gives it.
 - **The paired harness cannot measure anything that changes inlining, and gets the sign wrong.**
   It compiles both headers into one translation unit, which is exactly when a compiler exhausts its
   inlining budget. For anything touching `always_inline`, a function's size or a template boundary,
@@ -259,8 +262,10 @@ A built-in probe-length statistics facility like boost's. The string erase's ~50
 time, past the cache. The larger effect is the caller's: **batching the keys at all is 1.5x**, and a
 `prefetch(key)` API that was credited with that was reverted the same day it shipped.
 
-*The four pipelines.* The rehash, the range insert, the bulk visit and `replace()`'s dedup each have
-their own `pipeline_depth`-deep ring; sharing them costs the rehash 1.9 instructions per element and
-was rejected. Only `replace()` is gated on cache footprint — the range insert never loses at any
-size, and the visit loses 8% only when every key hits a map below ~16k, where the same map at a 50%
-hit rate wins 11%. Measured, #247.
+*The four pipelines.* The rehash, the range insert and `replace()`'s dedup each have their own
+`pipeline_depth` ring, and the bulk visit has chunks instead (a ring there measured 15% worse);
+sharing them costs the rehash 1.9 instructions per element and was rejected. Only `replace()` is
+gated, on **index** bytes — counting the values too was measured wrong. The range insert is slightly
+negative below a few thousand elements and a clear win above; the visit loses 8% only when every key
+hits a map below ~16k, where the same map at a 50% hit rate wins 11%, so its axis is the caller's
+hit rate. The rehash is the one that has never been measured below cache. #247.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,14 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
   octave and reports the geometric mean; `-p 1` restores the old single size. An eleven-slot group
   read 1.384 at one size and 1.039 over the octave; `churn64` read 1.199 and 0.974 — sign reversed.
   Every boost ratio not labelled "octave geomean" is a point measurement and must be re-taken.
+- **A prefetch pipeline is a loss while the data is in cache, so sweep across that boundary too.**
+  A lookahead ring costs 13–17 instructions per element in all four loops that have one, and the
+  ring's own round trip is paid whether or not the prefetch was needed. `replace()` was measured at
+  200k and 2M, both above the crossover, and shipped a version that was **a fifth slower below 65k**
+  until it was gated on footprint. Two sizes on the same side of a cache are one size.
+- **The control for "does this pipeline pay" is the same entry point with the ring removed**, built
+  as a second header. A caller's own loop of single calls is not it: that carries ~15 instructions
+  of call boundary per element and shows the bulk entry point winning everywhere.
 - **The paired harness cannot measure anything that changes inlining, and gets the sign wrong.**
   It compiles both headers into one translation unit, which is exactly when a compiler exhausts its
   inlining budget. For anything touching `always_inline`, a function's size or a template boundary,
@@ -250,3 +258,9 @@ A built-in probe-length statistics facility like boost's. The string erase's ~50
 *Bulk lookups.* `visit(first, last, f)` is 1.07-1.14x over the same batch looked up one key at a
 time, past the cache. The larger effect is the caller's: **batching the keys at all is 1.5x**, and a
 `prefetch(key)` API that was credited with that was reverted the same day it shipped.
+
+*The four pipelines.* The rehash, the range insert, the bulk visit and `replace()`'s dedup each have
+their own `pipeline_depth`-deep ring; sharing them costs the rehash 1.9 instructions per element and
+was rejected. Only `replace()` is gated on cache footprint — the range insert never loses at any
+size, and the visit loses 8% only when every key hits a map below ~16k, where the same map at a 50%
+hit rate wins 11%. Measured, #247.

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1453,23 +1453,25 @@ private:
                   "a group is sixteen fingerprints, matched as one vector or two words, and eight counters, picked by "
                   "the low three bits of the fingerprint");
 
-    // How far ahead the four loops that pipeline look: the rehash, the range insert, the bulk visit
-    // and replace()'s dedup. It is a count of memory accesses that has to fit inside what the core keeps
-    // outstanding, which is about two dozen on a Zen 4 -- not a property of the map, and every size
-    // from 8 to 32 measured within 2% of this one. Boost's bulk visit uses the same number.
+    // How far ahead the four loops that pipeline look: the rehash, the range insert, the bulk
+    // visit and replace()'s dedup. The visit uses it as a chunk size rather than a ring depth. It is a count of memory
+    // accesses that has to fit inside what the core keeps outstanding, which is about two dozen on a Zen 4 -- not a property
+    // of the map, and every size from 8 to 32 measured within 2% of this one. Boost's bulk visit uses the same number.
     static constexpr std::size_t pipeline_depth = 16;
 
-    // Below this much data, a pipeline costs more than it saves: the ring round trip is about 13
-    // instructions per element, and a prefetch of a line already in L2 still occupies a load port.
-    // The crossover tracks the last level of cache the loop's footprint -- its values plus its index
-    // -- still fits in, so this is a conservative stand-in for L2: the smallest one worth assuming.
-    // See replace(), the only caller, for the measurement.
+    // Below this much *index*, a pipeline costs more than it saves: the ring round trip is about 13
+    // instructions per element, and a prefetch of a line already in cache still occupies a load
+    // port. The index is the right thing to measure because it is the only array the prefetch is
+    // for -- the values are walked in order and the hardware handles them. Counting the values too
+    // was tried first and is wrong: at one value size the two models cannot be told apart, and with
+    // a 1032 byte value the footprint model opens the gate at ten thousand elements, where the
+    // pipeline is a **14% loss**. Both value sizes cross over at the same index size instead.
     //
-    // The other two pipelines were measured against the same question and neither wants it: the
-    // range insert never loses at any size, and the bulk visit loses 8% only when every key hits a
-    // map below ~16k, where the same map with half the keys missing wins 11% -- so the axis that
-    // decides there is the caller's hit rate, which the map cannot see. Issue #247.
-    static constexpr std::size_t pipeline_min_bytes = std::size_t{1} << 20U;
+    // See replace(), the only caller, for the sweep. The range insert and the bulk visit were
+    // measured against the same question and neither wants a gate; the visit's crossover is set by
+    // the caller's hit rate, which the map does not know until it has already done a chunk's worth
+    // of work. Issue #247.
+    static constexpr std::size_t pipeline_min_index_bytes = std::size_t{256} << 10U;
 
     static constexpr std::uint8_t initial_shifts = 64 - 2; // 2^(64-m_shifts) groups
     static constexpr float default_max_load_factor = 0.8F;
@@ -2465,14 +2467,13 @@ private:
             // twice. fill_buckets_from_values has the same ordering for the same reason.
             //
             // The three rings in this file -- here, fill_buckets_from_values and
-            // do_replace_pipelined -- are deliberately not one shared loop. Extracting the ring
-            // into a helper taking both halves as callables was built and measured on 2026-09-11:
-            // it costs the rehash
-            // **1.9 instructions per element**, 45.7 to 47.6, and 1.3% of its time on six of six
-            // interleaved pairs, because that loop wants its group pointer, mask and shift in locals
-            // and this one cannot have them -- growth moves them. Passing the element index through
-            // the callable did not recover it either. The duplication is real and measured to be
-            // cheaper than the fix.
+            // do_replace_pipelined -- are deliberately not one shared loop. Extracting the ring into
+            // a helper taking both halves as callables was built and measured on 2026-09-11: it
+            // costs the rehash **1.9 instructions per element**, 45.7 to 47.6, and 1.3% of its time
+            // on six of six interleaved pairs, because that loop wants its group pointer, mask and
+            // shift in locals and this one cannot have them -- growth moves them. Passing the
+            // element index through the callable did not recover it either. The duplication is real
+            // and measured to be cheaper than the fix.
             auto const slot = i % pipeline_depth;
             auto const mh = ring[slot];
             if (lookahead != last) {
@@ -3086,9 +3087,8 @@ public:
         // pipeline_min_bytes. Getting it wrong in the safe direction (a machine with more L2) costs
         // at most that 1.20x on one octave of sizes; omitting the gate costs it on every size below
         // a quarter million.
-        auto const footprint = m_values.size() * sizeof(value_type) +
-                               (std::size_t{m_group_mask} + 1) * sizeof(typename bucket_container_type::block);
-        if (m_values.size() > pipeline_depth + 1 && footprint > pipeline_min_bytes) {
+        auto const index_bytes = (std::size_t{m_group_mask} + 1) * sizeof(typename bucket_container_type::block);
+        if (m_values.size() > pipeline_depth + 1 && index_bytes > pipeline_min_index_bytes) {
             do_replace_pipelined(value_idx);
         }
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1463,7 +1463,12 @@ private:
     // instructions per element, and a prefetch of a line already in L2 still occupies a load port.
     // The crossover tracks the last level of cache the loop's footprint -- its values plus its index
     // -- still fits in, so this is a conservative stand-in for L2: the smallest one worth assuming.
-    // See replace(), the only caller so far, for the measurement.
+    // See replace(), the only caller, for the measurement.
+    //
+    // The other two pipelines were measured against the same question and neither wants it: the
+    // range insert never loses at any size, and the bulk visit loses 8% only when every key hits a
+    // map below ~16k, where the same map with half the keys missing wins 11% -- so the axis that
+    // decides there is the caller's hit rate, which the map cannot see. Issue #247.
     static constexpr std::size_t pipeline_min_bytes = std::size_t{1} << 20U;
 
     static constexpr std::uint8_t initial_shifts = 64 - 2; // 2^(64-m_shifts) groups
@@ -2460,9 +2465,9 @@ private:
             // twice. fill_buckets_from_values has the same ordering for the same reason.
             //
             // The three rings in this file -- here, fill_buckets_from_values and
-            // do_replace_pipelined -- are deliberately not one shared loop. Extracting the ring into
-            // a helper taking
-            // both halves as callables was built and measured on 2026-09-11: it costs the rehash
+            // do_replace_pipelined -- are deliberately not one shared loop. Extracting the ring
+            // into a helper taking both halves as callables was built and measured on 2026-09-11:
+            // it costs the rehash
             // **1.9 instructions per element**, 45.7 to 47.6, and 1.3% of its time on six of six
             // interleaved pairs, because that loop wants its group pointer, mask and shift in locals
             // and this one cannot have them -- growth moves them. Passing the element index through

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -394,8 +394,61 @@ all on the footprint arithmetic, the threshold and the two prefetches. A mutant 
 answer -- so the number to read is that no survivor is in the loop body. Do not chase it by
 loosening the tests.
 
-`do_insert_range` and `do_visit` have the same ring and no such gate; whether they have the same
-cliff is not measured, and is issue material rather than a claim.
+`do_insert_range` and `do_visit` have the same ring and no such gate. Measured on 2026-09-11, and
+**neither needs one** -- see the next entry.
+
+**The other two pipelines do not want the cache gate, and the instruction premium does not predict
+which does** (2026-09-11, issue #247, opened by the `replace()` result above). Each loop was built
+twice into its own binary, once as shipped and once with the ring taken out and the body written as
+a plain per-element loop -- same checksums, so the only difference is the pipeline -- and the two
+alternated.
+
+The instruction premium is large in all three and says nothing about where the crossover is:
+
+| loop | plain | pipelined | premium |
+|---|---|---|---|
+| `replace()` dedup | 73.4 | 86.6 | +13.2 |
+| `do_visit` (hit) | 70.3 | 86.0 | +15.7 |
+| `do_insert_range` (reserved) | 81.0 | 97.9 | +16.9 |
+
+Flat across sizes in each case, to 0.2 instructions. Yet the time ratios are not the same shape at
+all. Medians of five to seven interleaved repeats, pipelined over plain:
+
+| n | `replace()` | `do_visit` hit | `do_visit` half | `do_insert_range` |
+|---|---|---|---|---|
+| 1024 | -- | 1.08 | 0.91 | 1.02 |
+| 4096 | -- | 1.05 | 0.89 | 1.01 |
+| 16384 | -- | 1.01 | 0.88 | 0.75 |
+| 32768 | 1.20 | | | 0.65 |
+| 65536 | 1.03 | | | 0.66 |
+| 131072 | | 0.90 | 0.84 | |
+| 262144 | 0.90 | | | 0.48 |
+| 4000000 | 0.74 | 0.83 | | 0.54 |
+
+**The range insert never loses**, at any size, despite carrying the largest premium of the three. It
+is neutral at a thousand elements and already 1.33x at sixteen thousand. No gate.
+
+**The bulk visit loses only for a caller whose keys all hit a map smaller than about sixteen
+thousand** -- 1.08 at a thousand, gone by sixteen thousand. At the same sizes with half the keys
+missing it *wins* 0.88-0.91, which settles it: a footprint gate would give up an 11% win to avoid an
+8% loss, and the map cannot see the caller's hit rate, which is the axis that actually decides. No
+gate.
+
+A hypothesis for why, offered as one rather than a conclusion: the explicit ring only pays where the
+out-of-order window cannot already find the independent work. The two loops that lose at small sizes
+-- `replace()` and the visit -- have short bodies over a sequentially read container, so the hardware
+already overlaps three or four elements without being told to. The range insert's body carries the
+placement *and* a vector append with its capacity branch, so fewer iterations fit the window and the
+ring adds parallelism that was not otherwise there. That would also explain why the loss is 1.20 for
+`replace()` and only 1.08 for the visit: the visit's body has the callback in it.
+
+Two measurement notes. The first comparison tried was `insert(first, last)` against a caller's own
+`for` loop of single inserts, which is the wrong control -- it includes ~15 instructions of call
+boundary per element (see the clang/gcc entry) and shows the range winning at every size, hiding any
+pipeline penalty underneath. The control has to be the same entry point with the ring removed. And
+the range insert's small sizes are bimodal between repeats -- 0.46 and 1.52 both appear at n=4096 --
+because the round rebuilds the map and the allocator does not do the same thing every time; that is
+why the numbers above are medians of seven and not of three.
 
 **Taking the hash apart once per insert instead of twice, and the shared pipeline that was not worth it** (2026-09-11,
 issue #244, from four cleanup reviews of the range insert). Three of the four items were measured;

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -33,6 +33,7 @@ place rather than being deleted, because the retraction is usually the more usef
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
 - `replace()` hashes ahead too, once the reason it could not was looked at properly
+- The other two pipelines do not want the cache gate, and the gate's own footprint model was wrong
 - Taking the hash apart once per insert instead of twice, and the shared pipeline that was not worth it
 - Chunks or a sliding ring: the rehash and the bulk visit want opposite answers
 - A bulk `visit()`, and the `prefetch(key)` API it replaced
@@ -348,32 +349,15 @@ count is the measurement. It is the same finding the bulk visit banked a day ear
 place -- the 88 byte block wants its address formed once and then reused.
 
 **And the pipeline only runs once the work is out of cache, which the first version of this got
-wrong.** The ring round trip is not free: it costs **13.6 instructions per element** (73.4 to 86.6 at
-n = 1024), and a prefetch of a line already in L2 still occupies a load port. Against the unpipelined
-loop, no duplicates, the ratio tracks the footprint -- values plus index -- against this machine's
-1 MiB L2 and nothing else:
+wrong.** The ring round trip is not free: it costs **13.2 instructions per element** (73.4 to 86.6 at
+n = 1024), and a prefetch of a line already in cache still occupies a load port. Against the
+unpipelined loop, no duplicates, it was a fifth slower at 32768 elements and level at 65536 -- and
+the two sizes the change was first measured at, 200000 and 2000000, are both above the crossover,
+which is how it went unnoticed. **Two sizes on the same side of a cache is one size**, which is the
+octave rule from the benchmark harness arriving in a place that has no harness.
 
-| footprint | n | pipelined / plain |
-|---|---|---|
-| 688 KiB | 32768 | 1.20 |
-| 1376 KiB | 65536 | 1.03 |
-| 2064 KiB | 98304 | 0.92 |
-| 5504 KiB | 262144 | 0.90 |
-| 22 MiB | 4000000 | 0.74 |
-
-A fifth slower on every size below a quarter million, and the two sizes the change was first measured
-at -- 200000 and 2000000 -- are both above the crossover, which is how it went unnoticed. The gate is
-the footprint against a conservative 1 MiB, the smallest L2 worth assuming; erring high costs at most
-that 1.20x on one octave, erring low costs it everywhere. **Two sizes on the same side of a cache is
-one size**, which is the octave rule from the benchmark harness arriving in a place that has no
-harness.
-
-It also makes the window boundary untestable at forty small elements, since none of them reach the
-gate. The sweep runs twice: once with `size_t` values for the plain loop, once with a 64 KiB mapped
-type, which crosses 1 MiB at sixteen elements and so puts the boundary at seventeen back inside a
-sweep of thirty. An instrumented build confirms which sweep reaches which loop -- 65 entries against
-0 -- because a test that silently stopped covering the path it is named for is exactly what a size
-gate invites.
+Which quantity the gate compares took a second pass to get right; the first one shipped wrong. See
+the next entry but one.
 
 With the gate and the decomposed ring in, against main, three interleaved repeats, median:
 
@@ -394,61 +378,83 @@ all on the footprint arithmetic, the threshold and the two prefetches. A mutant 
 answer -- so the number to read is that no survivor is in the loop body. Do not chase it by
 loosening the tests.
 
-`do_insert_range` and `do_visit` have the same ring and no such gate. Measured on 2026-09-11, and
-**neither needs one** -- see the next entry.
+`do_insert_range` and `do_visit` pipeline too and have no such gate. Measured, and neither needs
+one -- below.
 
-**The other two pipelines do not want the cache gate, and the instruction premium does not predict
-which does** (2026-09-11, issue #247, opened by the `replace()` result above). Each loop was built
-twice into its own binary, once as shipped and once with the ring taken out and the body written as
-a plain per-element loop -- same checksums, so the only difference is the pipeline -- and the two
-alternated.
+**The other two pipelines do not want the cache gate, and the gate's own footprint model was wrong**
+(2026-09-11, issue #247, `scripts/ab/{range_insert,bulk_visit,replace_bulk}.cpp`, Ryzen 9 7950X,
+clang 22, `uint64_t` keys). Each loop was built twice into its own binary -- once as shipped, once
+with the ring taken out and the body written as a plain per-element loop, same checksums -- and the
+two alternated.
 
-The instruction premium is large in all three and says nothing about where the crossover is:
+*The premium is flat and predicts nothing.* Instructions per element, plain against pipelined:
+`replace()` 73.4 to 86.6, `do_visit` 70.3 to 86.0, `do_insert_range` 81.0 to 97.9 -- +13.2, +15.7,
++16.9, each constant across sizes to 0.2 instructions. The loop carrying the *largest* premium is the
+one that never needs a gate.
 
-| loop | plain | pipelined | premium |
+*The range insert.* Medians of seven, pipelined over plain: 1.02 and 1.01 at n = 1024 and 4096
+reserved, 1.08 at 4096 growing, then 0.75 at 16384, 0.65 at 32768, 0.48 at 262144 and 0.54 at four
+million. So it is **slightly negative below a few thousand elements and a clear win from sixteen
+thousand**, and the small sizes are bimodal between repeats -- 0.46 and 1.52 both appear at n = 4096,
+because the round rebuilds the map and the allocator does not do the same thing twice. No gate: the
+loss is inside the noise of the sizes where it happens.
+
+*The bulk visit.* Medians of five: all hits, 1.08 / 1.05 / 1.01 at 1k / 4k / 16k, then 0.90 at 128k
+and 0.83 at four million. Half the keys missing, same map sizes: 0.91 / 0.89 / 0.88, then 0.84. So
+the only loss is a caller whose keys **all** hit a map below about sixteen thousand, and at those
+same sizes a 50% hit rate *wins* 11%. A footprint gate would give up the win to avoid the loss, on an
+axis the map does not know until it has already done a chunk's worth of work. It could measure the
+first chunk and fall back, which is the way to get both -- rejected on cost: a second loop body
+inside a function that already has three passes is an inlining-budget change, which by the rules
+above the paired harness cannot measure at all, for at most 8% on one slice.
+
+**And the same sweep, run with a second value size, says `replace()`'s gate was comparing the wrong
+number.** It shipped comparing values-plus-index against 1 MiB. At one value size that model and an
+index-only model are indistinguishable -- both are proportional to n -- so the original measurement
+could not tell them apart. With a 1032 byte value they separate, and the footprint model loses:
+
+| n | index | 16 byte value | 1032 byte value |
 |---|---|---|---|
-| `replace()` dedup | 73.4 | 86.6 | +13.2 |
-| `do_visit` (hit) | 70.3 | 86.0 | +15.7 |
-| `do_insert_range` (reserved) | 81.0 | 97.9 | +16.9 |
+| 10000 | 88 KiB | 1.05 | 1.14 |
+| 14000 | 176 KiB | 0.75 | 1.06 |
+| 20000 | 176 KiB | 1.05 | 0.98 |
+| 28000 | 352 KiB | 0.84 | 0.98 |
+| 40000 | 352 KiB | 0.82 | 0.97 |
+| 80000 | 704 KiB | 0.91 | 0.91 |
+| 160000 | 1408 KiB | 0.68 | 0.91 |
 
-Flat across sizes in each case, to 0.2 instructions. Yet the time ratios are not the same shape at
-all. Medians of five to seven interleaved repeats, pipelined over plain:
+Both columns cross over at the same **index** size, not at the same footprint -- which is what the
+mechanism says, since the index is the only array the prefetch is for and the values are walked in
+order for the hardware to handle. Under the footprint model a 1032 byte value opens the gate at ten
+thousand elements, where the measurement says 1.14. So the gate is now `index_bytes > 256 KiB`, and
+`pipeline_min_bytes` is `pipeline_min_index_bytes`.
 
-| n | `replace()` | `do_visit` hit | `do_visit` half | `do_insert_range` |
-|---|---|---|---|---|
-| 1024 | -- | 1.08 | 0.91 | 1.02 |
-| 4096 | -- | 1.05 | 0.89 | 1.01 |
-| 16384 | -- | 1.01 | 0.88 | 0.75 |
-| 32768 | 1.20 | | | 0.65 |
-| 65536 | 1.03 | | | 0.66 |
-| 131072 | | 0.90 | 0.84 | |
-| 262144 | 0.90 | | | 0.48 |
-| 4000000 | 0.74 | 0.83 | | 0.54 |
+Note the two rows at each index size: 176 KiB reads 0.75 at n = 14000 and 1.05 at n = 20000, same
+array, opposite answers, because the load factor runs from 0.43 to 0.61 between doublings. **The
+octave rule applies to this axis too** -- a single n is not a measurement of a cache effect any more
+than it is of a load-factor effect, and the first version of these numbers took one point per size.
 
-**The range insert never loses**, at any size, despite carrying the largest premium of the three. It
-is neutral at a thousand elements and already 1.33x at sixteen thousand. No gate.
+Unconfirmed mechanism: the ring only pays where the out-of-order window cannot already find the
+independent work, which would explain why the range insert -- whose body carries a vector append and
+its capacity branch -- is the one that never loses. Not tested; a stall count on the two bodies would
+settle it.
 
-**The bulk visit loses only for a caller whose keys all hit a map smaller than about sixteen
-thousand** -- 1.08 at a thousand, gone by sixteen thousand. At the same sizes with half the keys
-missing it *wins* 0.88-0.91, which settles it: a footprint gate would give up an 11% win to avoid an
-8% loss, and the map cannot see the caller's hit rate, which is the axis that actually decides. No
-gate.
+The gate change took a test with it, twice over. The 64 KiB mapped type that used to cross the
+footprint gate at sixteen elements does not cross an index gate at all, so the window boundary is
+now swept a different way: a duplicate walked through every one of the last forty positions of a
+thirty-thousand element container, which is the same boundary from the end it actually lives at. And
+mutation found a state no test had: `replace()` keeps an index it has already grown, so replacing a
+large map with a handful of elements leaves the index past the gate and the container shorter than
+the lookahead window. The `&&` is what stops the prologue reading past the end there, and turning it
+into `||` survived until that case was written down.
 
-A hypothesis for why, offered as one rather than a conclusion: the explicit ring only pays where the
-out-of-order window cannot already find the independent work. The two loops that lose at small sizes
--- `replace()` and the visit -- have short bodies over a sequentially read container, so the hardware
-already overlaps three or four elements without being told to. The range insert's body carries the
-placement *and* a vector append with its capacity branch, so fewer iterations fit the window and the
-ring adds parallelism that was not otherwise there. That would also explain why the loss is 1.20 for
-`replace()` and only 1.08 for the visit: the visit's body has the callback in it.
-
-Two measurement notes. The first comparison tried was `insert(first, last)` against a caller's own
-`for` loop of single inserts, which is the wrong control -- it includes ~15 instructions of call
-boundary per element (see the clang/gcc entry) and shows the range winning at every size, hiding any
-pipeline penalty underneath. The control has to be the same entry point with the ring removed. And
-the range insert's small sizes are bimodal between repeats -- 0.46 and 1.52 both appear at n=4096 --
-because the round rebuilds the map and the allocator does not do the same thing every time; that is
-why the numbers above are medians of seven and not of three.
+Two measurement notes. The control first tried for the range insert was `insert(first, last)`
+against a caller's own loop of single inserts, which is the wrong one: it also carries ~15
+instructions of call boundary per element (see the clang/gcc entry) and shows the range winning at
+every size, hiding any pipeline penalty underneath. The control has to be the same entry point with
+the ring removed. And `replace_bulk.cpp` times the container copy along with the call, which is
+invisible at 16 bytes a value and swamps everything at 1032 -- the second table above was taken with
+the copy moved outside the timed region.
 
 **Taking the hash apart once per insert instead of twice, and the shared pipeline that was not worth it** (2026-09-11,
 issue #244, from four cleanup reviews of the range insert). Three of the four items were measured;

--- a/scripts/ab/ab.cpp
+++ b/scripts/ab/ab.cpp
@@ -115,8 +115,8 @@ auto measure_at(char const* name, size_t epochs, bool with_boost) -> point {
     auto boost = [] {
         ankerl::nanobench::doNotOptimizeAway(scalar(Workload<Boost, N>::run()));
     };
-    auto const res = with_boost ? bench.compare("base", base, "cand", cand, "boost", boost)
-                                : bench.compare("base", base, "cand", cand);
+    auto const res =
+        with_boost ? bench.compare("base", base, "cand", cand, "boost", boost) : bench.compare("base", base, "cand", cand);
     auto const ns = [&](size_t i) {
         return res[i].result.median(ankerl::nanobench::Result::Measure::elapsed) * 1e9;
     };
@@ -179,19 +179,15 @@ void report(char const* name, std::vector<point> const& pts, bool with_boost) {
     std::fflush(stdout);
 }
 
-template <template <typename, size_t> class Workload,
-          size_t BaseN,
-          typename Base,
-          typename Cand,
-          typename Boost,
-          size_t... I>
+template <template <typename, size_t> class Workload, size_t BaseN, typename Base, typename Cand, typename Boost, size_t... I>
 void compare_seq(char const* name, size_t epochs, size_t points, bool with_boost, std::index_sequence<I...> /*unused*/) {
     auto pts = std::vector<point>();
     // Every point is instantiated, only the wanted ones run: the sizes are template arguments, so
     // that a workload's default instantiation stays the exact code the scored benchmark compiles.
     (void)std::initializer_list<int>{
-        (I < points ? (pts.push_back(measure_at<Workload, Base, Cand, Boost, octave_size(BaseN, I)>(name, epochs, with_boost)), 0)
-                    : 0)...};
+        (I < points
+             ? (pts.push_back(measure_at<Workload, Base, Cand, Boost, octave_size(BaseN, I)>(name, epochs, with_boost)), 0)
+             : 0)...};
     report(name, pts, with_boost);
 }
 

--- a/scripts/ab/alloc_timeline.cpp
+++ b/scripts/ab/alloc_timeline.cpp
@@ -378,11 +378,11 @@ auto main(int argc, char** argv) -> int {
         "ankerl::unordered_dense::segmented_map", path("segmented_map"), lf);
 #ifdef UDM_HAVE_BOOST
     measure<boost::unordered_flat_map<std::uint64_t, std::uint64_t, hash_t, eq_t>>("boost::unordered_flat_map",
-                                                                                  path("boost_flat_map"));
+                                                                                   path("boost_flat_map"));
 #endif
 #ifdef UDM_HAVE_ABSL
     measure<absl::flat_hash_map<std::uint64_t, std::uint64_t, hash_t, eq_t>>("absl::flat_hash_map",
-                                                                            path("absl_flat_hash_map"));
+                                                                             path("absl_flat_hash_map"));
 #endif
     return 0;
 }

--- a/scripts/ab/bulk_visit.cpp
+++ b/scripts/ab/bulk_visit.cpp
@@ -15,6 +15,11 @@
 // and all three must print the same checksum. The loop times itself, so no perf is needed.
 //
 //   argv: <hit|half> <inline|plain|bulk> <n> [reps]
+//
+// Sweep `n` and sweep `hit` against `half`: the pipeline inside visit() costs ~16 instructions per
+// lookup, and whether that is repaid depends on both the map's size and the caller's hit rate. It
+// is 1.08 for all-hits on a map of a thousand and 0.91 for half-hits on the same map. One point
+// measurement here says nothing.
 #include <ankerl/unordered_dense.h>
 
 #include <bench/workloads.h>

--- a/scripts/ab/bulk_visit.cpp
+++ b/scripts/ab/bulk_visit.cpp
@@ -16,10 +16,10 @@
 //
 //   argv: <hit|half> <inline|plain|bulk> <n> [reps]
 //
-// Sweep `n` and sweep `hit` against `half`: the pipeline inside visit() costs ~16 instructions per
-// lookup, and whether that is repaid depends on both the map's size and the caller's hit rate. It
-// is 1.08 for all-hits on a map of a thousand and 0.91 for half-hits on the same map. One point
-// measurement here says nothing.
+// Sweep `n` and sweep `hit` against `half`: whether visit()'s chunking is repaid depends on both the
+// map's size and the caller's hit rate, and at small n those two disagree in sign. One point
+// measurement here says nothing; the numbers are in notes/index-design.md under "The other two
+// pipelines".
 #include <ankerl/unordered_dense.h>
 
 #include <bench/workloads.h>

--- a/scripts/ab/hash.cpp
+++ b/scripts/ab/hash.cpp
@@ -110,8 +110,7 @@ auto measure(double targetWidth, Alternatives&&... alternatives) -> std::map<std
         auto times = std::vector<double>();
         times.reserve(r.size());
         for (std::size_t i = 0; i < r.size(); ++i) {
-            times.push_back(r.get(i, ankerl::nanobench::Result::Measure::elapsed) * 1e9 /
-                            static_cast<double>(num_keys));
+            times.push_back(r.get(i, ankerl::nanobench::Result::Measure::elapsed) * 1e9 / static_cast<double>(num_keys));
         }
         auto const interval = ankerl::nanobench::detail::medianInterval(std::move(times), 0.95);
         out[r.config().mBenchmarkName] = {r.median(ankerl::nanobench::Result::Measure::elapsed) * 1e9 /
@@ -129,44 +128,68 @@ void one_length(std::size_t len, double targetWidth, bool emit) {
     auto const t = measure(
         targetWidth,
         "main",
-        [&] { ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) {
-                  return udmbase::unordered_dense::detail::wyhash::hash(s.data(), s.size()); })); },
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) {
+                return udmbase::unordered_dense::detail::wyhash::hash(s.data(), s.size());
+            }));
+        },
         "this",
-        [&] { ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) {
-                  return ankerl::unordered_dense::detail::wyhash::hash(s.data(), s.size()); })); }
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) {
+                return ankerl::unordered_dense::detail::wyhash::hash(s.data(), s.size());
+            }));
+        }
 #ifdef UDM_AB_HAVE_JAN
         ,
         "jan",
-        [&] { ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) {
-                  return udmjan::unordered_dense::detail::wyhash::hash(s.data(), s.size()); })); }
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) {
+                return udmjan::unordered_dense::detail::wyhash::hash(s.data(), s.size());
+            }));
+        }
 #endif
 #ifdef UDM_AB_HAVE_BOOST
         ,
         "boostdef",
-        [&] { ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) {
-                  return boost::hash<std::string>{}(s); })); }
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) {
+                return boost::hash<std::string>{}(s);
+            }));
+        }
 #endif
     );
 
     auto const l = measure(
         targetWidth,
         "main",
-        [&] { ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) {
-                  return udmbase::unordered_dense::detail::wyhash::hash(s.data(), s.size()); })); },
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) {
+                return udmbase::unordered_dense::detail::wyhash::hash(s.data(), s.size());
+            }));
+        },
         "this",
-        [&] { ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) {
-                  return ankerl::unordered_dense::detail::wyhash::hash(s.data(), s.size()); })); }
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) {
+                return ankerl::unordered_dense::detail::wyhash::hash(s.data(), s.size());
+            }));
+        }
 #ifdef UDM_AB_HAVE_JAN
         ,
         "jan",
-        [&] { ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) {
-                  return udmjan::unordered_dense::detail::wyhash::hash(s.data(), s.size()); })); }
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) {
+                return udmjan::unordered_dense::detail::wyhash::hash(s.data(), s.size());
+            }));
+        }
 #endif
 #ifdef UDM_AB_HAVE_BOOST
         ,
         "boostdef",
-        [&] { ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) {
-                  return boost::hash<std::string>{}(s); })); }
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) {
+                return boost::hash<std::string>{}(s);
+            }));
+        }
 #endif
     );
 

--- a/scripts/ab/hash_others.cpp
+++ b/scripts/ab/hash_others.cpp
@@ -115,14 +115,13 @@ struct row {
 
 // Every hasher interleaved round by round in one process, so machine drift cancels out of the
 // comparison instead of landing on whichever ran first.
-#define UDM_EACH_HASH(WRAP)                                                                                            \
-    "udm5",                                                                                                            \
-        WRAP(ankerl::unordered_dense::detail::wyhash::hash(s.data(), s.size())),                                       \
-        "floor", WRAP(static_cast<std::uint64_t>(s.size()) ^ static_cast<std::uint64_t>(s[0]))                          \
-        UDM_BASE(WRAP) UDM_BOOST(WRAP) UDM_ABSL(WRAP) UDM_FOLLY(WRAP)                                                  \
-        , "foldhash", WRAP(udm_ab::foldhash::fast(s.data(), s.size()))                                                 \
-        , "foldhash-q", WRAP(udm_ab::foldhash::quality(s.data(), s.size()))                                            \
-        UDM_RAPID(WRAP) UDM_KOMI(WRAP) UDM_POLYMUR(WRAP) UDM_AQUA(WRAP) UDM_GX(WRAP)
+#define UDM_EACH_HASH(WRAP)                                                                                                 \
+    "udm5", WRAP(ankerl::unordered_dense::detail::wyhash::hash(s.data(), s.size())), "floor",                               \
+        WRAP(static_cast<std::uint64_t>(s.size()) ^ static_cast<std::uint64_t>(s[0])) UDM_BASE(WRAP) UDM_BOOST(WRAP)        \
+            UDM_ABSL(WRAP) UDM_FOLLY(WRAP),                                                                                 \
+        "foldhash", WRAP(udm_ab::foldhash::fast(s.data(), s.size())), "foldhash-q",                                         \
+        WRAP(udm_ab::foldhash::quality(s.data(), s.size())) UDM_RAPID(WRAP) UDM_KOMI(WRAP) UDM_POLYMUR(WRAP) UDM_AQUA(WRAP) \
+            UDM_GX(WRAP)
 
 #ifdef UDM_AB_HAVE_BASE
 #    define UDM_BASE(WRAP) , "udm4", WRAP(udmbase::unordered_dense::detail::wyhash::hash(s.data(), s.size()))
@@ -162,16 +161,15 @@ inline auto const polymur_params = [] {
     polymur_init_params_from_seed(&p, UINT64_C(0xfedcba9876543210));
     return p;
 }();
-#    define UDM_POLYMUR(WRAP)                                                                                          \
-        , "polymur",                                                                                                   \
-            WRAP(polymur_hash(reinterpret_cast<std::uint8_t const*>(s.data()), s.size(), &polymur_params, 0))
+#    define UDM_POLYMUR(WRAP) \
+        , "polymur", WRAP(polymur_hash(reinterpret_cast<std::uint8_t const*>(s.data()), s.size(), &polymur_params, 0))
 #else
 #    define UDM_POLYMUR(WRAP)
 #endif
 #if defined(UDM_AB_HAVE_AQUAHASH) && defined(__AES__)
-#    define UDM_AQUA(WRAP)                                                                                             \
-        , "AquaHash",                                                                                                  \
-            WRAP(static_cast<std::uint64_t>(                                                                           \
+#    define UDM_AQUA(WRAP)                   \
+        , "AquaHash",                        \
+            WRAP(static_cast<std::uint64_t>( \
                 _mm_cvtsi128_si64(AquaHash::Hash(reinterpret_cast<std::uint8_t const*>(s.data()), s.size()))))
 #else
 #    define UDM_AQUA(WRAP)
@@ -182,13 +180,17 @@ inline auto const polymur_params = [] {
 #    define UDM_GX(WRAP)
 #endif
 
-#define UDM_THROUGHPUT(EXPR)                                                                                           \
-    [&] {                                                                                                              \
-        ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) { return EXPR; }));                \
+#define UDM_THROUGHPUT(EXPR)                                                           \
+    [&] {                                                                              \
+        ankerl::nanobench::doNotOptimizeAway(throughput(ck, [](std::string const& s) { \
+            return EXPR;                                                               \
+        }));                                                                           \
     }
-#define UDM_LATENCY(EXPR)                                                                                              \
-    [&] {                                                                                                              \
-        ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) { return EXPR; }));                 \
+#define UDM_LATENCY(EXPR)                                                             \
+    [&] {                                                                             \
+        ankerl::nanobench::doNotOptimizeAway(latency(keys, [](std::string const& s) { \
+            return EXPR;                                                              \
+        }));                                                                          \
     }
 
 auto measure(std::vector<std::string>& keys, double width) -> std::map<std::string, row> {

--- a/scripts/ab/maps.cpp
+++ b/scripts/ab/maps.cpp
@@ -32,9 +32,13 @@ auto names_of(std::index_sequence<I...>) -> std::vector<char const*> {
 // compare() takes name/op pairs; a tuple_cat of one pair per map turns the type list into them.
 template <typename Tuple, typename F, std::size_t... I>
 auto compare_all(ankerl::nanobench::Bench& b, F&& f, std::index_sequence<I...> /*seq*/) {
-    auto args = std::tuple_cat(
-        std::make_tuple(std::tuple_element_t<I, Tuple>::name, f(std::integral_constant<std::size_t, I>{}))...);
-    return std::apply([&](auto&&... a) { return b.compare(a...); }, args);
+    auto args =
+        std::tuple_cat(std::make_tuple(std::tuple_element_t<I, Tuple>::name, f(std::integral_constant<std::size_t, I>{}))...);
+    return std::apply(
+        [&](auto&&... a) {
+            return b.compare(a...);
+        },
+        args);
 }
 
 struct acc_row {
@@ -71,7 +75,13 @@ void print_geomean(char const* what, std::size_t base, acc_row const& acc) {
         auto const g = std::exp(acc.logsum[a] / static_cast<double>(acc.n));
         std::printf(" %s=%.2f", names[a], g);
         if (g_csv != nullptr) {
-            std::fprintf(g_csv, "%s,%s,%zu,%s,%.4f,%.4f\n", g_keyname, what, base, names[a], g,
+            std::fprintf(g_csv,
+                         "%s,%s,%zu,%s,%.4f,%.4f\n",
+                         g_keyname,
+                         what,
+                         base,
+                         names[a],
+                         g,
                          g / std::exp(acc.logsum[0] / static_cast<double>(acc.n)));
         }
     }
@@ -118,8 +128,8 @@ std::size_t g_points = 5;
 std::size_t g_span = 0;
 
 auto octave_size(std::size_t base, std::size_t i) -> std::size_t {
-    return static_cast<std::size_t>(
-        static_cast<double>(base) * std::pow(2.0, static_cast<double>(i) / static_cast<double>(g_points)));
+    return static_cast<std::size_t>(static_cast<double>(base) *
+                                    std::pow(2.0, static_cast<double>(i) / static_cast<double>(g_points)));
 }
 
 template <typename Key, typename Val>
@@ -144,16 +154,20 @@ void sweep(std::size_t base) {
         auto const lookup_batch = std::size_t{20000};
 
         if (wanted("build")) {
-        one_point<Tuple>("build", n, n, a_build, [&](auto ic) {
-            return [&] {
-                ankerl::nanobench::doNotOptimizeAway(build<std::tuple_element_t<ic.value, Tuple>>(p));
-            };
-        });
+            one_point<Tuple>("build", n, n, a_build, [&](auto ic) {
+                return [&] {
+                    ankerl::nanobench::doNotOptimizeAway(build<std::tuple_element_t<ic.value, Tuple>>(p));
+                };
+            });
         }
 
         if (wanted("hit") || wanted("miss") || wanted("half") || wanted("iterate")) {
             auto ms = Tuple();
-            std::apply([&](auto&... m) { (fill(m, p), ...); }, ms);
+            std::apply(
+                [&](auto&... m) {
+                    (fill(m, p), ...);
+                },
+                ms);
             auto st = std::vector<lookup_state>(k);
             for (auto const what : {asking::hits, asking::misses, asking::half}) {
                 auto* acc = what == asking::hits ? &a_hit : (what == asking::misses ? &a_miss : &a_half);
@@ -170,14 +184,20 @@ void sweep(std::size_t base) {
             }
             if (wanted("iterate")) {
                 one_point<Tuple>("iterate", n, n, a_iter, [&](auto ic) {
-                    return [&] { ankerl::nanobench::doNotOptimizeAway(std::get<ic.value>(ms).sum()); };
+                    return [&] {
+                        ankerl::nanobench::doNotOptimizeAway(std::get<ic.value>(ms).sum());
+                    };
                 });
             }
         }
 
         if (wanted("churn")) {
             auto ms = Tuple();
-            std::apply([&](auto&... m) { (fill(m, p), ...); }, ms);
+            std::apply(
+                [&](auto&... m) {
+                    (fill(m, p), ...);
+                },
+                ms);
             auto present = std::vector<std::vector<Key>>(k, p.present);
             auto spare = std::vector<std::vector<Key>>(k, p.spare);
             auto rngs = std::vector<ankerl::nanobench::Rng>();
@@ -189,15 +209,18 @@ void sweep(std::size_t base) {
             auto const batch = std::size_t{20000};
             one_point<Tuple>("churn", n, batch, a_churn, [&](auto ic) {
                 return [&] {
-                    churn(std::get<ic.value>(ms), present[ic.value], spare[ic.value], rngs[ic.value], batch,
-                          ticks[ic.value]);
+                    churn(std::get<ic.value>(ms), present[ic.value], spare[ic.value], rngs[ic.value], batch, ticks[ic.value]);
                 };
             });
         }
 
         if (wanted("ie")) {
             auto ms = Tuple();
-            std::apply([&](auto&... m) { (fill(m, p), ...); }, ms);
+            std::apply(
+                [&](auto&... m) {
+                    (fill(m, p), ...);
+                },
+                ms);
             auto ps = std::vector<pools<Key>>(k, p);
             auto rngs = std::vector<ankerl::nanobench::Rng>();
             rngs.reserve(k);
@@ -208,8 +231,8 @@ void sweep(std::size_t base) {
             auto const batch = std::size_t{10000};
             one_point<Tuple>("ie", n, 2 * batch, a_ie, [&](auto ic) {
                 return [&] {
-                    ankerl::nanobench::doNotOptimizeAway(insert_erase(std::get<ic.value>(ms), ps[ic.value],
-                                                                      rngs[ic.value], batch, ticks[ic.value]));
+                    ankerl::nanobench::doNotOptimizeAway(
+                        insert_erase(std::get<ic.value>(ms), ps[ic.value], rngs[ic.value], batch, ticks[ic.value]));
                 };
             });
         }
@@ -309,7 +332,9 @@ auto cross_check() -> int {
         auto const key = make_key<Key>(rng() % range);
         switch (rng() % 4) {
         case 0:
-            each([&](auto, auto& m) { m.insert(key, 1); });
+            each([&](auto, auto& m) {
+                m.insert(key, 1);
+            });
             break;
         case 1: {
             auto want = std::size_t{0};
@@ -325,7 +350,9 @@ auto cross_check() -> int {
             break;
         }
         case 2:
-            each([&](auto, auto& m) { m.erase(key); });
+            each([&](auto, auto& m) {
+                m.erase(key);
+            });
             break;
         default: {
             auto want = std::size_t{0};
@@ -368,8 +395,12 @@ auto cross_check() -> int {
     if (bad != 0) {
         return 1;
     }
-    std::printf("ok %s: %zu maps agree over %zu operations, %zu entries, checksum %zu\n", g_keyname, k, ops,
-                std::get<0>(ms).size(), want);
+    std::printf("ok %s: %zu maps agree over %zu operations, %zu entries, checksum %zu\n",
+                g_keyname,
+                k,
+                ops,
+                std::get<0>(ms).size(),
+                want);
     return 0;
 }
 
@@ -442,7 +473,7 @@ int main(int argc, char** argv) {
         return 0;
     };
 
-    auto const rc = keys == "str"  ? run(std::string{}, std::size_t{})
+    auto const rc = keys == "str"   ? run(std::string{}, std::size_t{})
                     : keys == "big" ? run(std::uint64_t{}, workloads::big_value{})
                                     : run(std::uint64_t{}, std::size_t{});
     if (g_csv != nullptr) {

--- a/scripts/ab/move_home.cpp
+++ b/scripts/ab/move_home.cpp
@@ -103,8 +103,12 @@ int main(int argc, char** argv) {
         }
     }
     auto const ns = std::chrono::duration<double, std::nano>(std::chrono::steady_clock::now() - t0).count();
-    std::printf("%-5s n=%-8llu turn=%-4llu hits=%llu  %8.2f ns/op   load=%.3f acc=%zu\n", what.c_str(),
-                static_cast<unsigned long long>(n), static_cast<unsigned long long>(turnovers),
-                static_cast<unsigned long long>(hits), ns / static_cast<double>(reps),
-                static_cast<double>(m.size()) / static_cast<double>(m.bucket_count()), acc);
+    std::printf("%-5s n=%-8llu turn=%-4llu hits=%llu  %8.2f ns/op   load=%.3f acc=%zu\n",
+                what.c_str(),
+                static_cast<unsigned long long>(n),
+                static_cast<unsigned long long>(turnovers),
+                static_cast<unsigned long long>(hits),
+                ns / static_cast<double>(reps),
+                static_cast<double>(m.size()) / static_cast<double>(m.bucket_count()),
+                acc);
 }

--- a/scripts/ab/placement.cpp
+++ b/scripts/ab/placement.cpp
@@ -16,8 +16,8 @@
 // second where building it would take a redesign.
 //
 //   clang++ -O2 -std=c++17 scripts/ab/placement.cpp -o placement && ./placement 0.799
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <vector>
 

--- a/scripts/ab/probe_length.cpp
+++ b/scripts/ab/probe_length.cpp
@@ -89,7 +89,9 @@ int main(int argc, char** argv) {
 
     std::printf("load %.3f, %llu turnovers, %llu writing hits/round, %zu entries in %zu slots\n",
                 static_cast<double>(m.size()) / static_cast<double>(m.bucket_count()),
-                static_cast<unsigned long long>(turnovers), static_cast<unsigned long long>(hits), m.size(),
+                static_cast<unsigned long long>(turnovers),
+                static_cast<unsigned long long>(hits),
+                m.size(),
                 m.bucket_count());
     std::printf("  groups per hit   fresh %.4f   churned %.4f\n", fresh_hit, churn_hit);
     std::printf("  groups per miss  fresh %.4f   churned %.4f\n", fresh_miss, churn_miss);

--- a/scripts/ab/range_insert.cpp
+++ b/scripts/ab/range_insert.cpp
@@ -11,6 +11,12 @@
 //
 //   argv: <loop|range> <n> [rounds] [reserved|grow]
 //
+// `loop` is the right control for "what does the range overload buy a caller" and the wrong one for
+// "does the ring inside it pay": it also carries ~15 instructions of call boundary per element, so
+// it shows the range winning at every size and hides any pipeline penalty underneath. For the
+// second question build the header twice, once with the ring taken out of do_insert_range, and run
+// `range` against `range`.
+//
 // Built by hand; -DUDM_RI_STR swaps the key for a std::string, which is the shape where the hash
 // being pipelined is worth the most.
 #include <ankerl/unordered_dense.h>

--- a/scripts/ab/range_insert.cpp
+++ b/scripts/ab/range_insert.cpp
@@ -12,10 +12,11 @@
 //   argv: <loop|range> <n> [rounds] [reserved|grow]
 //
 // `loop` is the right control for "what does the range overload buy a caller" and the wrong one for
-// "does the ring inside it pay": it also carries ~15 instructions of call boundary per element, so
-// it shows the range winning at every size and hides any pipeline penalty underneath. For the
+// "does the ring inside it pay": it also carries the call boundary's ~15 instructions per element,
+// so it shows the range winning at every size and hides any pipeline penalty underneath. For the
 // second question build the header twice, once with the ring taken out of do_insert_range, and run
-// `range` against `range`.
+// `range` against `range`. Sweep `grow` as well as `reserved` -- they part company below a few
+// thousand elements.
 //
 // Built by hand; -DUDM_RI_STR swaps the key for a std::string, which is the shape where the hash
 // being pipelined is worth the most.

--- a/scripts/ab/replace_bulk.cpp
+++ b/scripts/ab/replace_bulk.cpp
@@ -65,15 +65,20 @@ int main(int argc, char** argv) {
         source.emplace_back(workloads::key_for<map_t>(v), i);
     }
 
+    // The per-round copy of `source` is outside the timed region. It looks like noise for a small
+    // mapped type and swamps everything for a large one -- at 1032 bytes a value it is 66 MiB of
+    // memcpy per round against a call that takes milliseconds, which quietly pulled every ratio
+    // towards 1.0 the first time this was used to compare two value sizes.
     auto acc = std::size_t{0};
-    auto const t0 = std::chrono::steady_clock::now();
+    auto el = std::chrono::steady_clock::duration{};
     for (std::size_t round = 0; round < rounds; ++round) {
         auto container = container_t(source);
         auto map = map_t();
+        auto const t0 = std::chrono::steady_clock::now();
         map.replace(std::move(container));
+        el += std::chrono::steady_clock::now() - t0;
         acc += map.size();
     }
-    auto const el = std::chrono::steady_clock::now() - t0;
     std::printf("%.3f ns/element  n=%zu rounds=%zu dup=%zu%% unique=%zu acc=%zu\n",
                 std::chrono::duration<double, std::nano>(el).count() / static_cast<double>(n * rounds),
                 n,

--- a/scripts/ab/sweep.cpp
+++ b/scripts/ab/sweep.cpp
@@ -24,17 +24,17 @@
 #include <bench/workloads.h>
 #include <third-party/nanobench.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
-#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <map>
 #include <sstream>
 #include <string>
 #include <type_traits>
 #include <utility>
-#include <cstdint>
-#include <cstdio>
-#include <cstdlib>
 #include <vector>
 
 namespace {
@@ -191,7 +191,7 @@ auto insert_erase_ns(Map& map, state<Map>& st, std::size_t ops) -> double {
     auto const t0 = std::chrono::steady_clock::now();
     for (std::size_t i = 0; i < ops; ++i) {
         auto const a = static_cast<std::size_t>(((rng() >> 32U) * present.size()) >> 32U);
-        map[present[a]] = 1; // present: operator[] that finds
+        map[present[a]] = 1;  // present: operator[] that finds
         map.erase(absent[a]); // absent: erase that finds nothing
         // Erase before inserting, so the size never rises above n. The other order crosses the
         // growth threshold and one operation pays for rehashing the whole table -- real, but it
@@ -199,8 +199,8 @@ auto insert_erase_ns(Map& map, state<Map>& st, std::size_t ops) -> double {
         // else: 1219 ns per operation at 64M entries against the 20 the steady state costs.
         auto const b = static_cast<std::size_t>(((rng() >> 32U) * present.size()) >> 32U);
         auto const j = i % spare.size();
-        map.erase(present[b]);  // erase that removes
-        map[spare[j]] = 1;      // operator[] that inserts
+        map.erase(present[b]); // erase that removes
+        map[spare[j]] = 1;     // operator[] that inserts
         std::swap(present[b], spare[j]);
     }
     auto const ns = std::chrono::duration<double, std::nano>(std::chrono::steady_clock::now() - t0).count();
@@ -221,8 +221,8 @@ auto insert_erase_ns(Map& map, state<Map>& st, std::size_t ops) -> double {
 // complexityN, which is the config field meant for exactly that, so every row says which table it
 // came from.
 template <typename... Alternatives>
-void measure_point(std::size_t n, std::size_t buckets, std::size_t batch, double targetWidth, bool emit,
-                   Alternatives&&... alternatives) {
+void measure_point(
+    std::size_t n, std::size_t buckets, std::size_t batch, double targetWidth, bool emit, Alternatives&&... alternatives) {
     auto bench = ankerl::nanobench::Bench();
     bench.batch(static_cast<double>(batch))
         .complexityN(static_cast<double>(n))
@@ -409,26 +409,37 @@ void sweep(unsigned max_shift, unsigned per_octave, std::size_t batch, int mode,
         // one alternative. So the first point is measured twice and the first answer thrown away.
         auto const passes = n == first ? 2 : 1;
         for (auto pass = 0; pass < passes; ++pass) {
-            measure_point(n,
-                          m1.bucket_count(),
-                          batch,
-                          targetWidth,
-                          pass + 1 == passes,
-                          "main",
-                          [&] { run(m0, s0); },
-                          "this",
-                          [&] { run(m1, s1); }
+            measure_point(
+                n,
+                m1.bucket_count(),
+                batch,
+                targetWidth,
+                pass + 1 == passes,
+                "main",
+                [&] {
+                    run(m0, s0);
+                },
+                "this",
+                [&] {
+                    run(m1, s1);
+                }
 #ifdef UDM_AB_HAVE_JAN
-                          ,
-                          "jan",
-                          [&] { run(m3, s3); }
+                ,
+                "jan",
+                [&] {
+                    run(m3, s3);
+                }
 #endif
 #ifdef UDM_AB_HAVE_BOOST
-                          ,
-                          "boost",
-                          [&] { run(m2, s2); },
-                          "boostdef",
-                          [&] { run(m4, s4); }
+                ,
+                "boost",
+                [&] {
+                    run(m2, s2);
+                },
+                "boostdef",
+                [&] {
+                    run(m4, s4);
+                }
 #endif
             );
         }

--- a/scripts/ab/value_prefetch.cpp
+++ b/scripts/ab/value_prefetch.cpp
@@ -143,7 +143,8 @@ int main(int argc, char** argv) {
         }
     }
     if (map.size() != n || map.bucket_count() / 16U != groups) {
-        std::fprintf(stderr, "filling changed the table: size %zu of %zu, %zu groups\n", map.size(), n, map.bucket_count() / 16U);
+        std::fprintf(
+            stderr, "filling changed the table: size %zu of %zu, %zu groups\n", map.size(), n, map.bucket_count() / 16U);
         return 1;
     }
 

--- a/scripts/ab/valuesize.cpp
+++ b/scripts/ab/valuesize.cpp
@@ -119,25 +119,36 @@ void one_size(std::size_t n, double targetWidth) {
     auto const& keys = keys_for<this_map>(n);
     auto const per = static_cast<double>(n);
 
-    emit(Bytes,
-         "build",
-         per,
-         targetWidth,
-         "main",
-         [&] { ankerl::nanobench::doNotOptimizeAway(build_map<main_map>(keys).size()); },
-         "this",
-         [&] { ankerl::nanobench::doNotOptimizeAway(build_map<this_map>(keys).size()); }
+    emit(
+        Bytes,
+        "build",
+        per,
+        targetWidth,
+        "main",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(build_map<main_map>(keys).size());
+        },
+        "this",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(build_map<this_map>(keys).size());
+        }
 #ifdef UDM_AB_HAVE_JAN
-         ,
-         "jan",
-         [&] { ankerl::nanobench::doNotOptimizeAway(build_map<jan_map>(keys).size()); }
+        ,
+        "jan",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(build_map<jan_map>(keys).size());
+        }
 #endif
 #ifdef UDM_AB_HAVE_BOOST
-         ,
-         "boost",
-         [&] { ankerl::nanobench::doNotOptimizeAway(build_map<boost_map>(keys).size()); },
-         "boostdef",
-         [&] { ankerl::nanobench::doNotOptimizeAway(build_map<boostdef_map>(keys).size()); }
+        ,
+        "boost",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(build_map<boost_map>(keys).size());
+        },
+        "boostdef",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(build_map<boostdef_map>(keys).size());
+        }
 #endif
     );
 
@@ -152,25 +163,36 @@ void one_size(std::size_t n, double targetWidth) {
     auto m2 = build_map<boost_map>(keys);
     auto m4 = build_map<boostdef_map>(keys);
 #endif
-    emit(Bytes,
-         "iterate",
-         per,
-         targetWidth,
-         "main",
-         [&] { ankerl::nanobench::doNotOptimizeAway(iterate(m0)); },
-         "this",
-         [&] { ankerl::nanobench::doNotOptimizeAway(iterate(m1)); }
+    emit(
+        Bytes,
+        "iterate",
+        per,
+        targetWidth,
+        "main",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(iterate(m0));
+        },
+        "this",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(iterate(m1));
+        }
 #ifdef UDM_AB_HAVE_JAN
-         ,
-         "jan",
-         [&] { ankerl::nanobench::doNotOptimizeAway(iterate(m3)); }
+        ,
+        "jan",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(iterate(m3));
+        }
 #endif
 #ifdef UDM_AB_HAVE_BOOST
-         ,
-         "boost",
-         [&] { ankerl::nanobench::doNotOptimizeAway(iterate(m2)); },
-         "boostdef",
-         [&] { ankerl::nanobench::doNotOptimizeAway(iterate(m4)); }
+        ,
+        "boost",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(iterate(m2));
+        },
+        "boostdef",
+        [&] {
+            ankerl::nanobench::doNotOptimizeAway(iterate(m4));
+        }
 #endif
     );
 }

--- a/scripts/ab/window.cpp
+++ b/scripts/ab/window.cpp
@@ -61,7 +61,7 @@ class table {
     using value_type = std::pair<Key, Value>;
 
     std::vector<value_type> m_values{};
-    std::vector<std::uint8_t> m_fp{};  // one per slot; VARIANT 1 mirrors the first 16 past the end
+    std::vector<std::uint8_t> m_fp{}; // one per slot; VARIANT 1 mirrors the first 16 past the end
     std::vector<std::uint32_t> m_idx{};
     std::size_t m_mask = 0;   // slots - 1
     std::size_t m_shift = 64; // home = hash >> m_shift
@@ -74,8 +74,7 @@ class table {
     ankerl::unordered_dense::hash<Key> m_hash{};
 
     [[nodiscard]] static auto match(__m128i w, std::uint32_t word) -> unsigned {
-        return static_cast<unsigned>(
-            _mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi32(static_cast<int>(word)))));
+        return static_cast<unsigned>(_mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_set1_epi32(static_cast<int>(word)))));
     }
     [[nodiscard]] static auto match_empty(__m128i w) -> unsigned {
         return static_cast<unsigned>(_mm_movemask_epi8(_mm_cmpeq_epi8(w, _mm_setzero_si128())));
@@ -432,8 +431,8 @@ void run(std::string const& what, std::size_t n, std::size_t reps) {
             t.emplace(present[i], i);
         }
         if (what == "memory") {
-            std::printf("%-6s %8.2f bytes/entry\n", what.c_str(),
-                        static_cast<double>(t.footprint()) / static_cast<double>(t.size()));
+            std::printf(
+                "%-6s %8.2f bytes/entry\n", what.c_str(), static_cast<double>(t.footprint()) / static_cast<double>(t.size()));
             return;
         }
         if (what == "churn") {
@@ -453,12 +452,11 @@ void run(std::string const& what, std::size_t n, std::size_t reps) {
                     acc += t.size();
                 }
             });
-            std::printf("%-6s %8.2f ns/op  rehashes=%zu slots=%zu\n", what.c_str(), ns,
-                        t.rehashes(), t.slots());
+            std::printf("%-6s %8.2f ns/op  rehashes=%zu slots=%zu\n", what.c_str(), ns, t.rehashes(), t.slots());
             std::printf("       placements: %zu onto an empty slot, %zu onto a tombstone (%.1f%% recycled)\n",
-                        t.on_empty(), t.on_tomb(),
-                        100.0 * static_cast<double>(t.on_tomb())
-                            / static_cast<double>(t.on_empty() + t.on_tomb()));
+                        t.on_empty(),
+                        t.on_tomb(),
+                        100.0 * static_cast<double>(t.on_tomb()) / static_cast<double>(t.on_empty() + t.on_tomb()));
         } else {
             auto const& keys = (what == "hit") ? present : absent;
             auto const p0 = t.probes();
@@ -468,9 +466,10 @@ void run(std::string const& what, std::size_t n, std::size_t reps) {
                     acc += t.contains(keys[(rng() >> 32U) * keys.size() >> 32U]) ? 1U : 0U;
                 }
             });
-            std::printf("%-6s %8.2f ns/op  windows visited per lookup %.4f\n", what.c_str(), ns,
-                        static_cast<double>(t.probe_windows() - w0)
-                            / static_cast<double>(t.probes() - p0));
+            std::printf("%-6s %8.2f ns/op  windows visited per lookup %.4f\n",
+                        what.c_str(),
+                        ns,
+                        static_cast<double>(t.probe_windows() - w0) / static_cast<double>(t.probes() - p0));
         }
     }
     ankerl::nanobench::doNotOptimizeAway(acc);

--- a/test/unit/replace.cpp
+++ b/test/unit/replace.cpp
@@ -3,7 +3,6 @@
 #include <app/counter.h>
 #include <app/doctest.h>
 
-#include <array>
 #include <cstdint>
 #include <random>
 #include <unordered_set>
@@ -64,111 +63,124 @@ auto replace_dedup_reference(std::vector<std::pair<uint64_t, size_t>> v) -> std:
     return v;
 }
 
-// 64 KiB of payload, carrying the same tag a plain size_t would. replace() only pipelines once the
-// container plus its index is too big for cache, so the window boundary -- which is at a couple of
-// dozen *elements* -- is out of reach of a sweep over small values. A mapped type this size puts
-// the boundary back inside a sweep of thirty, instead of needing a hundred thousand elements in
-// each of a hundred and fifty cases.
-struct replace_bulky {
-    size_t tag{};
-    std::array<uint64_t, 8192> pad{};
-};
-
-auto replace_mapped_from(size_t tag, size_t /*unused*/) -> size_t {
-    return tag;
-}
-auto replace_mapped_from(size_t tag, replace_bulky /*unused*/) -> replace_bulky {
-    return replace_bulky{tag, {}};
-}
-auto replace_tag_of(size_t v) -> size_t {
-    return v;
-}
-auto replace_tag_of(replace_bulky const& v) -> size_t {
-    return v.tag;
+auto replace_key_at(size_t i) -> uint64_t {
+    return static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15);
 }
 
 // len elements, every n-th of which repeats element 0 -- so `every == 1` is all duplicates, and a
-// len that is a multiple of `every` puts a duplicate at the very last position, which is the one
-// the lookahead is not allowed to have seen.
+// len that is a multiple of `every` puts a duplicate at the very last position.
 auto replace_source_of(size_t len, size_t every) -> std::vector<std::pair<uint64_t, size_t>> {
     auto source = std::vector<std::pair<uint64_t, size_t>>();
     for (size_t i = 0; i < len; ++i) {
-        auto const key =
-            (every != 0 && i != 0 && i % every == 0) ? uint64_t{0} : static_cast<uint64_t>(i) * UINT64_C(0x9E3779B97F4A7C15);
-        source.emplace_back(key, i);
+        source.emplace_back((every != 0 && i != 0 && i % every == 0) ? uint64_t{0} : replace_key_at(i), i);
     }
     return source;
 }
 
-template <typename Mapped>
-auto replace_apply(std::vector<std::pair<uint64_t, size_t>> const& source) -> ankerl::unordered_dense::map<uint64_t, Mapped> {
+auto replace_apply(std::vector<std::pair<uint64_t, size_t>> const& source) -> ankerl::unordered_dense::map<uint64_t, size_t> {
     // not `map_t`: TEST_CASE_MAP above declares one at namespace scope, and the unity build puts
     // this file in the same translation unit as others that do too
-    using result_map = ankerl::unordered_dense::map<uint64_t, Mapped>;
-    auto container = typename result_map::value_container_type();
-    container.reserve(source.size());
-    for (auto const& [key, tag] : source) {
-        container.emplace_back(key, replace_mapped_from(tag, Mapped{}));
-    }
+    using result_map = ankerl::unordered_dense::map<uint64_t, size_t>;
+    auto container = result_map::value_container_type(source.begin(), source.end());
     auto map = result_map();
     map.replace(std::move(container));
     return map;
 }
 
 // same elements in the same order, not merely the same set
-template <typename Mapped>
 void check_matches_the_plain_loop(std::vector<std::pair<uint64_t, size_t>> const& source) {
     auto const expected = replace_dedup_reference(source);
-    auto const map = replace_apply<Mapped>(source);
+    auto const map = replace_apply(source);
 
     REQUIRE(map.size() == expected.size());
     auto const& got = map.values();
     for (size_t i = 0; i < expected.size(); ++i) {
         REQUIRE(got[i].first == expected[i].first);
-        REQUIRE(replace_tag_of(got[i].second) == expected[i].second);
+        REQUIRE(got[i].second == expected[i].second);
     }
 }
+
+// Enough elements that the index is past pipeline_min_index_bytes, so the pipelined loop runs. The
+// gate is on the index rather than the element count, so this is not a round number: 30000 elements
+// take 65536 slots, which is 352 KiB of blocks against a 256 KiB threshold.
+constexpr size_t pipelined_len = 30000;
 
 } // namespace
 
 TEST_CASE("replace_matches_the_plain_loop_at_every_length") {
-    // Every length across the lookahead window and past two of them, so the tail-only case, the
-    // boundary and the steady state are all covered, at several duplicate rates.
+    // Every length across the lookahead window and past two of them, at several duplicate rates.
+    // These are all below the gate, so this is the unpipelined loop.
     for (size_t len = 0; len <= 40; ++len) {
         for (auto const every : {size_t{0}, size_t{1}, size_t{2}, size_t{3}, size_t{7}}) {
             INFO("len=" << len << " every=" << every);
-            check_matches_the_plain_loop<size_t>(replace_source_of(len, every));
+            check_matches_the_plain_loop(replace_source_of(len, every));
         }
     }
 }
 
-TEST_CASE("replace_pipelined_matches_the_plain_loop_at_every_length") {
-    // The same sweep with a mapped type big enough that the cache gate lets the pipeline run: from
-    // sixteen elements up these cross it, which covers the window boundary at seventeen.
-    for (size_t len = 0; len <= 30; ++len) {
-        for (auto const every : {size_t{0}, size_t{1}, size_t{2}, size_t{3}, size_t{7}}) {
-            INFO("len=" << len << " every=" << every);
-            check_matches_the_plain_loop<replace_bulky>(replace_source_of(len, every));
+TEST_CASE("replace_pipelined_matches_the_plain_loop_at_every_distance_from_the_end") {
+    // The boundary the lookahead has to respect is the *end* of the container, not the start: the
+    // pipelined loop stops pipeline_depth + 1 short and the tail finishes unpipelined. So walk a
+    // duplicate through every position within two windows of the end, which is where handing over
+    // between the two loops can go wrong -- and where a duplicate moves an element the ring has
+    // already hashed.
+    for (size_t from_end = 0; from_end <= 40; ++from_end) {
+        auto source = std::vector<std::pair<uint64_t, size_t>>();
+        for (size_t i = 0; i < pipelined_len; ++i) {
+            source.emplace_back(replace_key_at(i), i);
         }
+        source[pipelined_len - 1 - from_end].first = replace_key_at(0);
+
+        INFO("from_end=" << from_end);
+        check_matches_the_plain_loop(source);
     }
 }
 
 TEST_CASE("replace_pipelined_over_many_elements") {
     auto source = std::vector<std::pair<uint64_t, size_t>>();
     auto rng = std::mt19937_64(1234);
-    for (size_t i = 0; i < 100000; ++i) {
+    for (size_t i = 0; i < pipelined_len; ++i) {
         // a quarter of them repeat an earlier key, so the dedup path runs inside the pipelined
         // region rather than only in the tail
         auto const key = (i > 100 && rng() % 4 == 0) ? source[rng() % source.size()].first : rng();
         source.emplace_back(key, i);
     }
-    check_matches_the_plain_loop<size_t>(source);
+    check_matches_the_plain_loop(source);
 
     // and every surviving key is findable, which is what the index is for
-    auto const map = replace_apply<size_t>(source);
+    auto const map = replace_apply(source);
     for (auto const& [k, v] : replace_dedup_reference(source)) {
         auto it = map.find(k);
         REQUIRE(it != map.end());
         REQUIRE(it->second == v);
+    }
+}
+
+TEST_CASE("replace_a_big_map_with_a_tiny_container") {
+    // replace() keeps an index it has already grown, so after this the map has a large bucket array
+    // and a handful of elements. That is the one state where the pipeline's two preconditions
+    // disagree -- the index is past the gate, the container is shorter than the lookahead window --
+    // and running the prologue there would read past the end of the values.
+    auto source = std::vector<std::pair<uint64_t, size_t>>();
+    for (size_t i = 0; i < pipelined_len; ++i) {
+        source.emplace_back(replace_key_at(i), i);
+    }
+    auto map = replace_apply(source);
+    REQUIRE(map.bucket_count() > 1000U);
+
+    for (size_t len = 0; len <= 20; ++len) {
+        auto small = decltype(map)::value_container_type();
+        for (size_t i = 0; i < len; ++i) {
+            small.emplace_back(replace_key_at(i), i);
+        }
+        map.replace(std::move(small));
+
+        INFO("len=" << len);
+        REQUIRE(map.size() == len);
+        for (size_t i = 0; i < len; ++i) {
+            auto it = map.find(replace_key_at(i));
+            REQUIRE(it != map.end());
+            REQUIRE(it->second == i);
+        }
     }
 }


### PR DESCRIPTION
Closes #247.

#246 gated `replace()`'s ring on the container outgrowing cache. That raised the same question for the other two rings, and this answers it: **neither `do_insert_range` nor `do_visit` needs a gate.** No behaviour changes here — the diff is the measurement, plus the two rules it produced.

## Method

Each loop was built twice into its own binary: once as shipped, once with the ring removed and the body written as a plain per-element loop. Same checksums, so the only difference is the pipeline. The two were alternated, medians of five to seven repeats.

**The control matters and the obvious one is wrong.** The first comparison tried was `insert(first, last)` against a caller's own `for` loop of single inserts. That carries ~15 instructions of call boundary per element and shows the range overload winning at every size — which is true, and is a different question. It hides any pipeline penalty underneath.

## The instruction premium predicts nothing

| loop | plain | pipelined | premium |
|---|---|---|---|
| `replace()` dedup | 73.4 | 86.6 | +13.2 |
| `do_visit` (hit) | 70.3 | 86.0 | +15.7 |
| `do_insert_range` (reserved) | 81.0 | 97.9 | +16.9 |

Flat across sizes in each case, to 0.2 instructions. The time ratios are not the same shape at all — pipelined over plain:

| n | `replace()` | `do_visit` hit | `do_visit` half | `do_insert_range` |
|---|---|---|---|---|
| 1024 | — | 1.08 | 0.91 | 1.02 |
| 4096 | — | 1.05 | 0.89 | 1.01 |
| 16384 | — | 1.01 | 0.88 | 0.75 |
| 32768 | 1.20 | | | 0.65 |
| 65536 | 1.03 | | | 0.66 |
| 131072 | | 0.90 | 0.84 | |
| 262144 | 0.90 | | | 0.48 |
| 4000000 | 0.74 | 0.83 | | 0.54 |

**The range insert never loses**, despite the largest premium of the three — neutral at a thousand elements, already 1.33x at sixteen thousand.

**The bulk visit loses only for a caller whose keys all hit a map below ~16k.** At the same sizes with half the keys missing it *wins* 0.88–0.91. A footprint gate would give up an 11% win to avoid an 8% loss, and the map cannot see the caller's hit rate, which is the axis that decides.

A hypothesis, offered as one: the ring only pays where the out-of-order window cannot already find the independent work. `replace()` and the visit have short bodies over a sequentially read container, so the hardware already overlaps three or four elements unprompted. The range insert's body carries the placement *and* a vector append with its capacity branch, so fewer iterations fit the window.

## What changes

- `notes/index-design.md` — the entry above, including the bimodal-at-small-n caveat that is why the numbers are medians of seven.
- `CLAUDE.md` — two rules: sweep across the cache boundary for anything that prefetches, and what the control has to be.
- `range_insert.cpp` / `bulk_visit.cpp` — the trap noted where someone would hit it.
- `unordered_dense.h` — `pipeline_min_bytes`'s comment now says the other two were measured, and one comment that clang-format had reflowed mid-sentence is repaired.

## Verification

802 tests green on clang release, gcc release, unity-16, and ASan+UBSan; clang-format clean; both A/B harnesses still build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)