### PR TITLE
Step a block's prefetches from its start instead of jumping to its end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,9 @@ block. Fusing the insert's probe with its placement: more instructions, not fewe
 index prefetch: a clang win and a bigger gcc loss, so left alone.
 
 *The layout.* Merged 88 byte block: **kept**, 7% of a lookup's instructions and 28% of its dTLB
-misses at 4M. Splitting fingerprints from counters: a tie. Cache-line-aligning the indices: 0.993.
+misses at 4M. A quarter of those blocks span three cache lines and `prefetch_block` asks for two of
+them — the geometry is real and no alignment avoids it, but the hardware fetches the middle line
+anyway and asking explicitly is a 2.5% loss (#250, `scripts/ab/prefetch_lines.cpp`). Splitting fingerprints from counters: a tie. Cache-line-aligning the indices: 0.993.
 A second fingerprint in the index's spare bits: 0.975. 16-bit indices for small maps: 0.986. A
 12-slot 64 byte block: 0.9888.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,9 +225,10 @@ block. Fusing the insert's probe with its placement: more instructions, not fewe
 index prefetch: a clang win and a bigger gcc loss, so left alone.
 
 *The layout.* Merged 88 byte block: **kept**, 7% of a lookup's instructions and 28% of its dTLB
-misses at 4M. A quarter of those blocks span three cache lines and `prefetch_block` asks for two of
-them — the geometry is real and no alignment avoids it, but the hardware fetches the middle line
-anyway and asking explicitly is a 2.5% loss (#250, `scripts/ab/prefetch_lines.cpp`). Splitting fingerprints from counters: a tie. Cache-line-aligning the indices: 0.993.
+misses at 4M. A quarter of those blocks span three cache lines, and `prefetch_block` steps
+by 64 from the start rather than asking for the first and the last — same instruction count, 3.3%,
+because it takes the middle line (counters and fingerprints) over the tail. Naming all three lines
+is *slower* than either (#250, `scripts/ab/prefetch_lines.cpp`). Splitting fingerprints from counters: a tie. Cache-line-aligning the indices: 0.993.
 A second fingerprint in the index's spare bits: 0.975. 16-bit indices for small maps: 0.986. A
 12-slot 64 byte block: 0.9888.
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1690,9 +1690,19 @@ private:
         ANKERL_UNORDERED_DENSE_PREFETCH(p + sizeof(Block) - 1);
     }
 
-    // Every line of a block, for a caller that has not touched the group at all. prefetch_index
-    // skips the first line because the probe is about to read it anyway; a rehash is about to
-    // write a group it has never read, so it wants that line too.
+    // The first and last line of a block, for a caller that has not touched the group at all.
+    // prefetch_index skips the first line because the probe is about to read it anyway; a rehash is
+    // about to write a group it has never read, so it wants that line too.
+    //
+    // A quarter of blocks span *three* lines and this asks for two of them, which looks like a bug
+    // and is not one. `88 % 64 == 24` and `gcd(24, 64) == 8`, so `p % 64` walks the whole cycle
+    // whatever the array's alignment, and the two offsets above 40 put a third line in the middle --
+    // holding all eight counters and half the fingerprints. **The hardware fetches it anyway.**
+    // Asking for it explicitly is a consistent 2.5% *loss*: 12.47 ns per block against 12.78, five
+    // rounds of five, on a 176 MiB array walked at random with a sixteen-deep lookahead and a
+    // probe-shaped read. The same measurement says the second prefetch earns its keep -- one line
+    // alone is 13.19 -- so the shape here is the measured optimum and not an accident.
+    // scripts/ab/prefetch_lines.cpp, issue #250.
     template <typename Block>
     static void prefetch_block(Block const* block) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- byte arithmetic on the block

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1694,21 +1694,29 @@ private:
     // prefetch_index skips the first line because the probe is about to read it anyway; a rehash is
     // about to write a group it has never read, so it wants that line too.
     //
-    // A quarter of blocks span *three* lines and this asks for two of them, which looks like a bug
-    // and is not one. `88 % 64 == 24` and `gcd(24, 64) == 8`, so `p % 64` walks the whole cycle
-    // whatever the array's alignment, and the two offsets above 40 put a third line in the middle --
-    // holding all eight counters and half the fingerprints. **The hardware fetches it anyway.**
-    // Asking for it explicitly is a consistent 2.5% *loss*: 12.47 ns per block against 12.78, five
-    // rounds of five, on a 176 MiB array walked at random with a sixteen-deep lookahead and a
-    // probe-shaped read. The same measurement says the second prefetch earns its keep -- one line
-    // alone is 13.19 -- so the shape here is the measured optimum and not an accident.
-    // scripts/ab/prefetch_lines.cpp, issue #250.
+    // Consecutive lines from the block's start -- *not* its first and its last, which is what this
+    // asked for until 2026-09-11 and is a line short. A block is 88 bytes with four byte alignment,
+    // `88 % 64 == 24` and `gcd(24, 64) == 8`, so `p % 64` walks the whole cycle whatever the array's
+    // alignment and a quarter of blocks span three lines. Asking for `p` and `p + 87` then covers
+    // the first and the *last*, leaving out the middle -- which holds all eight counters and half
+    // the fingerprints, the two things a probe reads first. Stepping by 64 instead covers the first
+    // two and leaves out the last, which holds only the top two index entries.
+    //
+    // Same instruction count, **3.3% faster**: 12.28 ns per block against 12.67, seven rounds of
+    // seven with no overlap, on a 176 MiB array walked at random with a sixteen-deep lookahead and a
+    // probe-shaped read. Adding a third prefetch to cover the tail as well is a loss (12.85) -- the
+    // hardware fetches what it can see coming, so the job here is to start it in the right place
+    // rather than to name every line. scripts/ab/prefetch_lines.cpp, issue #250.
+    //
+    // The loop is what makes it right for group_big too: 152 bytes spans up to four lines, and the
+    // old pair covered the first and the last of them.
     template <typename Block>
     static void prefetch_block(Block const* block) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- byte arithmetic on the block
         auto const* p = reinterpret_cast<char const*>(block);
-        ANKERL_UNORDERED_DENSE_PREFETCH(p);
-        ANKERL_UNORDERED_DENSE_PREFETCH(p + sizeof(Block) - 1);
+        for (std::size_t off = 0; off < sizeof(Block); off += 64) {
+            ANKERL_UNORDERED_DENSE_PREFETCH(p + off);
+        }
     }
 
     // The same for a caller holding a group number rather than a pointer. A block is 88 bytes, so

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -33,6 +33,7 @@ place rather than being deleted, because the retraction is usually the more usef
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
 - `replace()` hashes ahead too, once the reason it could not was looked at properly
+- A quarter of blocks span three cache lines and only two are prefetched; the hardware covers the third
 - The other two pipelines do not want the cache gate, and the gate's own footprint model was wrong
 - Taking the hash apart once per insert instead of twice, and the shared pipeline that was not worth it
 - Chunks or a sliding ring: the rehash and the bulk visit want opposite answers
@@ -380,6 +381,49 @@ loosening the tests.
 
 `do_insert_range` and `do_visit` pipeline too and have no such gate. Measured, and neither needs
 one -- below.
+
+**A quarter of blocks span three cache lines and only two are prefetched; the hardware covers the
+third** (2026-09-11, issue #250, `scripts/ab/prefetch_lines.cpp`, Ryzen 9 7950X, clang 22). Raised
+as a bug by a cleanup review, and the geometry is real -- it is the conclusion that is wrong.
+
+*The geometry.* A block is 88 bytes with `alignof == 4`, so blocks sit at `base + 88i`. `88 % 64` is
+24 and `gcd(24, 64)` is 8, so `p % 64` walks the entire cycle `{0, 24, 48, 8, 32, 56, 16, 40}` from
+any starting offset -- **no allocation avoids this, and over-aligning the array does nothing**. The
+two offsets above 40 make the block span three lines, so exactly 25% do, and for those the middle
+line begins at byte 8 or 16 *of the block*: it holds all eight overflow counters and half or more of
+the fingerprints, which is what the probe reads first. `prefetch_block` asks for `p` and `p + 87`, so
+that line is never requested. `prefetch_index` is fine -- `p + 64` and `p + 87` cover lines one and
+two, and it skips line zero deliberately because the probe is about to read it.
+
+*The measurement says leave it alone.* An array of two million blocks -- 176 MiB, far past the last
+level cache -- walked in a materialised random order with the same sixteen-deep lookahead the
+pipelined loops use, reading sixteen fingerprints, one counter and one index at a lane derived from
+the fingerprints so the index read cannot start before the compare. Five interleaved rounds,
+ns per block:
+
+| prefetches | | median |
+|---|---|---|
+| none | | 44.9 |
+| `p` only | | 13.19 |
+| `p`, `p + 87` -- shipped | | **12.47** |
+| `p`, `p + 64`, `p + 87` | | 12.78 |
+
+The third prefetch is a **2.5% loss**, 5 of 5 rounds, and the same numbers say the second one earns
+its keep. The middle line arrives without being asked for; what the extra prefetch buys is an
+instruction and a load port slot. Reading the block as a sequential sweep instead of a probe gives
+the same answer (13.57 against 13.75) -- the conclusion does not rest on the read shape.
+
+*The trap this walked into.* The first numbers, taken on the three real harnesses, read -1.3% on the
+bulk visit and -2 to -3% on the range insert and looked like a win. Re-measured five rounds at each
+size they are 0.975 to 1.017 -- **all of it inside the +-3% layout luck**, and the L1 miss counts do
+not move either (44.6M against 44.9M at four million). A mechanism that is provably true does not
+make a delta of that size real, and the microbenchmark existed precisely because CLAUDE.md says to
+judge a micro-optimization by mechanism plus a focused benchmark rather than by a sub-benchmark
+delta. Both halves of that rule were needed: the mechanism to know what to build, the benchmark to
+find out the mechanism does not matter.
+
+One machine. `prefetch_lines.cpp` is committed so that a CPU without an adjacent-line prefetcher can
+be asked the same question; that is the one thing that would change the answer.
 
 **The other two pipelines do not want the cache gate, and the gate's own footprint model was wrong**
 (2026-09-11, issue #247, `scripts/ab/{range_insert,bulk_visit,replace_bulk}.cpp`, Ryzen 9 7950X,

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -33,7 +33,7 @@ place rather than being deleted, because the retraction is usually the more usef
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
 - `replace()` hashes ahead too, once the reason it could not was looked at properly
-- A quarter of blocks span three cache lines and only two are prefetched; the hardware covers the third
+- A block's prefetches should step from its start, not jump to its end
 - The other two pipelines do not want the cache gate, and the gate's own footprint model was wrong
 - Taking the hash apart once per insert instead of twice, and the shared pipeline that was not worth it
 - Chunks or a sliding ring: the rehash and the bulk visit want opposite answers
@@ -382,48 +382,68 @@ loosening the tests.
 `do_insert_range` and `do_visit` pipeline too and have no such gate. Measured, and neither needs
 one -- below.
 
-**A quarter of blocks span three cache lines and only two are prefetched; the hardware covers the
-third** (2026-09-11, issue #250, `scripts/ab/prefetch_lines.cpp`, Ryzen 9 7950X, clang 22). Raised
-as a bug by a cleanup review, and the geometry is real -- it is the conclusion that is wrong.
+**A block's prefetches should step from its start, not jump to its end** (2026-09-11, issue #250,
+`scripts/ab/prefetch_lines.cpp`, Ryzen 9 7950X, clang 22). Raised by a cleanup review as "a quarter
+of blocks span three cache lines and `prefetch_block` only asks for two". The geometry is right, the
+first fix for it was wrong, and the second is worth 3.3%.
 
 *The geometry.* A block is 88 bytes with `alignof == 4`, so blocks sit at `base + 88i`. `88 % 64` is
 24 and `gcd(24, 64)` is 8, so `p % 64` walks the entire cycle `{0, 24, 48, 8, 32, 56, 16, 40}` from
 any starting offset -- **no allocation avoids this, and over-aligning the array does nothing**. The
 two offsets above 40 make the block span three lines, so exactly 25% do, and for those the middle
 line begins at byte 8 or 16 *of the block*: it holds all eight overflow counters and half or more of
-the fingerprints, which is what the probe reads first. `prefetch_block` asks for `p` and `p + 87`, so
-that line is never requested. `prefetch_index` is fine -- `p + 64` and `p + 87` cover lines one and
-two, and it skips line zero deliberately because the probe is about to read it.
+the fingerprints, which is what the probe reads first.
 
-*The measurement says leave it alone.* An array of two million blocks -- 176 MiB, far past the last
-level cache -- walked in a materialised random order with the same sixteen-deep lookahead the
-pipelined loops use, reading sixteen fingerprints, one counter and one index at a lane derived from
-the fingerprints so the index read cannot start before the compare. Five interleaved rounds,
-ns per block:
+*The obvious fix is a loss.* `prefetch_block` asked for `p` and `p + 87` -- first line and last. Add
+a third at `p + 64` so all three are named, and it gets **slower**: 12.85 ns per block against 12.67.
+The hardware fetches what it can see coming, and the extra prefetch buys an instruction and a load
+port slot rather than a line.
 
-| prefetches | | median |
-|---|---|---|
-| none | | 44.9 |
-| `p` only | | 13.19 |
-| `p`, `p + 87` -- shipped | | **12.47** |
-| `p`, `p + 64`, `p + 87` | | 12.78 |
+*Stepping instead of spanning is the fix.* `p` and `p + 64` are always two consecutive lines. For
+the three quarters of blocks that span two lines that is exactly what `p` and `p + 87` already
+prefetched -- the two are identical there. For the other quarter it takes the middle line instead of
+the last, and the last holds only `m_index[14..15]`, read only when the matching lane is high. Same
+instruction count, and on an array of two million blocks -- 176 MiB, far past the last level cache --
+walked in a materialised random order with the same sixteen-deep lookahead the pipelined loops use,
+reading sixteen fingerprints, one counter and one index at a lane derived from the fingerprints so
+the index read cannot start before the compare:
 
-The third prefetch is a **2.5% loss**, 5 of 5 rounds, and the same numbers say the second one earns
-its keep. The middle line arrives without being asked for; what the extra prefetch buys is an
-instruction and a load port slot. Reading the block as a sequential sweep instead of a probe gives
-the same answer (13.57 against 13.75) -- the conclusion does not rest on the read shape.
+| prefetches | median ns/block |
+|---|---|
+| none | 44.9 |
+| `p` | 13.19 |
+| `p`, `p + 87` -- first and last, the old shape | 12.67 |
+| `p`, `p + 64`, `p + 87` -- all three | 12.85 |
+| **`p`, `p + 64` -- stepped, shipped** | **12.28** |
 
-*The trap this walked into.* The first numbers, taken on the three real harnesses, read -1.3% on the
-bulk visit and -2 to -3% on the range insert and looked like a win. Re-measured five rounds at each
-size they are 0.975 to 1.017 -- **all of it inside the +-3% layout luck**, and the L1 miss counts do
-not move either (44.6M against 44.9M at four million). A mechanism that is provably true does not
-make a delta of that size real, and the microbenchmark existed precisely because CLAUDE.md says to
-judge a micro-optimization by mechanism plus a focused benchmark rather than by a sub-benchmark
-delta. Both halves of that rule were needed: the mechanism to know what to build, the benchmark to
-find out the mechanism does not matter.
+Seven rounds of seven with no overlap between the stepped and the old distributions. It reproduces
+on the real harnesses at four million entries -- the bulk visit 0.971 and a reserved range insert
+0.952, five of five below 1.0 each -- and is smaller but the same sign at a quarter million and in
+grow mode.
 
-One machine. `prefetch_lines.cpp` is committed so that a CPU without an adjacent-line prefetcher can
-be asked the same question; that is the one thing that would change the answer.
+So `prefetch_block` is now a loop stepping by 64 to the end of the block, which both compilers fully
+unroll (two prefetches, no branch). **The loop is what makes it right for `group_big`**: 152 bytes
+spans up to four lines, and first-and-last covered two of them and skipped as many as two in the
+middle. Stepping gives it three.
+
+*What nearly went wrong.* The third-prefetch version measured on the three real harnesses first read
+-1.3% on the bulk visit and -2 to -3% on the range insert and looked like a win. Five rounds at each
+size put all of it between 0.975 and 1.017 -- **inside the +-3% layout luck** -- and the L1 miss
+counts did not move either (44.6M against 44.9M at four million). A mechanism that is provably true
+does not make a delta of that size real, and the microbenchmark is what separated the two candidate
+fixes: on the real harnesses they are both a smear, and the difference between them is 3.3%.
+
+*The score does not move and should not.* Paired against main, ten epochs, five points an octave:
+geomean **1.001** over nineteen workloads, everything inside 1.5% except `rmissstr` at 1.039. That
+one is **not attributable** -- a lookup's probe calls `prefetch_index`, which this did not touch, and
+`prefetch_block` is reached on the score only through the rehash inside `build` and `churn`. Two runs
+agreeing on it means nothing either, since they are the same two binaries and therefore the same code
+layout. It is the +-3% layout luck, measured slightly above its usual size. The change's actual
+subjects -- the bulk visit, the range insert, `replace()` -- are not in the score at all, which is
+why the microbenchmark carries this one.
+
+One machine. `prefetch_lines.cpp` is committed so that a CPU with different prefetchers can be asked
+the same question, which is the one thing that would change the answer.
 
 **The other two pipelines do not want the cache gate, and the gate's own footprint model was wrong**
 (2026-09-11, issue #247, `scripts/ab/{range_insert,bulk_visit,replace_bulk}.cpp`, Ryzen 9 7950X,

--- a/scripts/ab/prefetch_lines.cpp
+++ b/scripts/ab/prefetch_lines.cpp
@@ -1,0 +1,148 @@
+// Does a block's middle cache line need its own prefetch?
+//
+// A block is 88 bytes with 4-byte alignment, so it sits at base + 88i and `88 % 64 == 24` with
+// `gcd(24, 64) == 8`: p % 64 walks the whole cycle {0, 24, 48, 8, 32, 56, 16, 40} whatever the base
+// is, and the two values above 40 -- exactly a quarter of all blocks -- make the block span *three*
+// cache lines. prefetch_block asks for the first and the last, so for that quarter the middle line
+// is never requested, and the middle line is where the eight overflow counters and half the
+// fingerprints live.
+//
+// Whether that costs anything is a different question from whether it is true, because a CPU's
+// adjacent-line and stream prefetchers may fetch it anyway. This isolates it: an array of blocks far
+// larger than the last level cache, a random walk over it with the same sixteen-deep lookahead the
+// map's pipelined loops use, and every byte of the block read at the far end.
+//
+//   none   no prefetch at all, for scale
+//   one    p only -- if this ties with `two`, the hardware is fetching the rest
+//   two    what the header does: p and p + 87
+//   three  p, p + 64 and p + 87
+//
+// The read shape matters as much as the prefetch, because a sequential sweep of the block trains the
+// hardware prefetcher and a probe does not do that:
+//
+//   full   every byte, the way a rehash writes one
+//   probe  sixteen fingerprints, one overflow counter and one index -- what a lookup reads
+//
+//   argv: <none|one|two|three> <full|probe> <blocks> [reps]
+#include <ankerl/unordered_dense.h>
+
+#include <bench/workloads.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+// The shape of bucket_type::group plus its indices, which is what a block is. Spelled out rather
+// than reached through the header so that this file measures the layout and not the map.
+struct block {
+    std::array<std::uint8_t, 16> m_fingerprints;
+    std::array<std::uint8_t, 8> m_overflows;
+    std::array<std::uint32_t, 16> m_index;
+};
+static_assert(sizeof(block) == 88, "this benchmark is about a block spanning three cache lines");
+
+constexpr std::size_t depth = 16;
+
+struct rng {
+    std::uint64_t s;
+    explicit rng(std::uint64_t seed)
+        : s(seed * UINT64_C(0x9E3779B97F4A7C15) | 1U) {}
+    auto operator()() -> std::uint64_t {
+        s ^= s << 13U;
+        s ^= s >> 7U;
+        s ^= s << 17U;
+        return s;
+    }
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+    workloads::tame_allocator();
+    auto const how = std::string(argc > 1 ? argv[1] : "two");
+    auto const shape = std::string(argc > 2 ? argv[2] : "probe");
+    auto const n = static_cast<std::size_t>(argc > 3 ? std::strtoull(argv[3], nullptr, 10) : 2000000);
+    auto const reps = static_cast<std::size_t>(argc > 4 ? std::strtoull(argv[4], nullptr, 10) : 20000000);
+
+    auto blocks = std::vector<block>(n);
+    auto r = rng(1);
+    for (auto& b : blocks) {
+        for (auto& f : b.m_fingerprints) {
+            f = static_cast<std::uint8_t>(r());
+        }
+        for (auto& o : b.m_overflows) {
+            o = static_cast<std::uint8_t>(r());
+        }
+        for (auto& i : b.m_index) {
+            i = static_cast<std::uint32_t>(r());
+        }
+    }
+
+    // The walk is materialised so that generating it is not on the dependency chain -- the point is
+    // the block's cache lines, not the random number generator.
+    auto order = std::vector<std::uint32_t>(reps);
+    for (auto& o : order) {
+        o = static_cast<std::uint32_t>(r() % n);
+    }
+
+    auto const* base = blocks.data();
+    auto touch = [&](std::size_t at) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) -- byte arithmetic on the block
+        auto const* p = reinterpret_cast<char const*>(base + at);
+        ANKERL_UNORDERED_DENSE_PREFETCH(p);
+        if (how == "one") {
+            return;
+        }
+        if (how == "three") {
+            ANKERL_UNORDERED_DENSE_PREFETCH(p + 64);
+        }
+        ANKERL_UNORDERED_DENSE_PREFETCH(p + sizeof(block) - 1);
+    };
+
+    auto acc = std::uint64_t{0};
+    auto const t0 = std::chrono::steady_clock::now();
+    if (how != "none") {
+        for (std::size_t i = 0; i < depth && i < reps; ++i) {
+            touch(order[i]);
+        }
+    }
+    for (std::size_t i = 0; i < reps; ++i) {
+        if (how != "none" && i + depth < reps) {
+            touch(order[i + depth]);
+        }
+        auto const& b = blocks[order[i]];
+        if (shape == "full") {
+            for (auto f : b.m_fingerprints) {
+                acc += f;
+            }
+            for (auto o : b.m_overflows) {
+                acc += o;
+            }
+            for (auto x : b.m_index) {
+                acc += x;
+            }
+        } else {
+            // The lane is derived from the block's own contents so that it cannot be computed
+            // before the fingerprints arrive -- a probe's index read waits on its compare.
+            for (auto f : b.m_fingerprints) {
+                acc += f;
+            }
+            auto const lane = std::size_t{b.m_fingerprints[0]} & 15U;
+            acc += b.m_overflows[lane & 7U];
+            acc += b.m_index[lane];
+        }
+    }
+    auto const el = std::chrono::steady_clock::now() - t0;
+    std::printf("%.3f ns/block  %s %s blocks=%zu reps=%zu acc=%llu\n",
+                std::chrono::duration<double, std::nano>(el).count() / static_cast<double>(reps),
+                how.c_str(),
+                shape.c_str(),
+                n,
+                reps,
+                static_cast<unsigned long long>(acc));
+}

--- a/scripts/ab/prefetch_lines.cpp
+++ b/scripts/ab/prefetch_lines.cpp
@@ -14,7 +14,8 @@
 //
 //   none   no prefetch at all, for scale
 //   one    p only -- if this ties with `two`, the hardware is fetching the rest
-//   two    what the header does: p and p + 87
+//   two    first line and last: p and p + 87, which is what the header did until #250
+//   next   what the header does now: p and p + 64, the first line and the one after it
 //   three  p, p + 64 and p + 87
 //
 // The read shape matters as much as the prefetch, because a sequential sweep of the block trains the
@@ -23,7 +24,11 @@
 //   full   every byte, the way a rehash writes one
 //   probe  sixteen fingerprints, one overflow counter and one index -- what a lookup reads
 //
-//   argv: <none|one|two|three> <full|probe> <blocks> [reps]
+// `two` and `next` differ only for the quarter of blocks that span three lines, where they prefetch
+// the same first line and then disagree about the second: `two` takes the last line, `next` takes
+// the middle one. For the other three quarters they issue prefetches to exactly the same two lines.
+//
+//   argv: <none|one|two|next|three> <full|probe> <blocks> [reps]
 #include <ankerl/unordered_dense.h>
 
 #include <bench/workloads.h>
@@ -98,10 +103,12 @@ int main(int argc, char** argv) {
         if (how == "one") {
             return;
         }
-        if (how == "three") {
+        if (how == "next" || how == "three") {
             ANKERL_UNORDERED_DENSE_PREFETCH(p + 64);
         }
-        ANKERL_UNORDERED_DENSE_PREFETCH(p + sizeof(block) - 1);
+        if (how != "next") {
+            ANKERL_UNORDERED_DENSE_PREFETCH(p + sizeof(block) - 1);
+        }
     };
 
     auto acc = std::uint64_t{0};


### PR DESCRIPTION
Closes #250. **This started as a negative result and became a 3.3% win**, on Martin's question: if a block spans three cache lines and we only want two prefetches, why `p` and `p + 87` rather than `p` and `p + 64`?

## The geometry

A block is 88 bytes with `alignof == 4`, so blocks sit at `base + 88i`. `88 % 64 == 24` and `gcd(24, 64) == 8`, so `p % 64` walks the entire cycle `{0, 24, 48, 8, 32, 56, 16, 40}` from any starting offset — **no allocation avoids this and over-aligning the array does nothing**, confirmed by walking 4096 blocks at each of the four possible base alignments (25.0% span three lines in every case).

For those 25%, the middle line begins at byte 8 or 16 *of the block*, so it holds all eight overflow counters and half or more of the fingerprints — what the probe reads first.

## Three candidate shapes

`p` and `p + 64` are always two *consecutive* lines. For the 75% of blocks spanning two lines that is exactly what `p` and `p + 87` already prefetched — identical. For the other 25% it takes the middle line instead of the last, and the last holds only `m_index[14..15]`, read only when the matching lane is high.

`scripts/ab/prefetch_lines.cpp`: two million blocks (176 MiB, far past LLC), materialised random order, sixteen-deep lookahead, reading sixteen fingerprints + one counter + one index at a lane derived from the fingerprints so the index read cannot start before the compare. Seven rounds:

| prefetches | median ns/block |
|---|---|
| none | 44.9 |
| `p` | 13.19 |
| `p`, `p + 87` — first and last, the old shape | 12.67 |
| `p`, `p + 64`, `p + 87` — all three | 12.85 |
| **`p`, `p + 64` — stepped, shipped** | **12.28** |

No overlap between the stepped and old distributions across seven rounds. **Naming all three lines is slower than either** — the hardware fetches what it can see coming, so the job is to start it in the right place, not to list every line.

Reproduces on the real harnesses at four million entries: bulk visit **0.971**, reserved range insert **0.952**, five of five below 1.0 each. Smaller but same sign at a quarter million and in `grow` mode.

## The implementation is a loop, and that matters

```cpp
for (std::size_t off = 0; off < sizeof(Block); off += 64) {
    ANKERL_UNORDERED_DENSE_PREFETCH(p + off);
}
```

Both clang and gcc fully unroll it — 2 prefetches, 0 branches for `group`; 3 and 0 for `group_big`. **`group_big` is the reason to write it this way**: 152 bytes spans up to four lines, and first-and-last covered two of them while skipping as many as two in the middle.

## The score is neutral, as it should be

Paired against `main`, ten epochs, five points an octave: geomean **1.001** over nineteen workloads, everything inside 1.5% except `rmissstr` at 1.039.

That one is **not attributable** and I am not claiming it: a lookup's probe calls `prefetch_index`, which this does not touch and which was already correct. `prefetch_block` is reached on the score only through the rehash inside `build` and `churn`. Two runs agreeing on 1.037/1.039 means nothing either — same two binaries, same code layout. It is the ±3% layout luck, slightly above its usual size.

The change's actual subjects — the bulk visit, the range insert, `replace()` — are not in the score at all, which is why the microbenchmark carries this one.

## What nearly shipped instead

The first fix was the obvious one: add a third prefetch at `p + 64` so all three lines are named. On the three real harnesses it read −1.3% on the bulk visit and −2 to −3% on the range insert and looked like a win. Five rounds at each size put all of it between 0.975 and 1.017 — inside the layout luck — with L1 miss counts unmoved (44.6M vs 44.9M at four million). The microbenchmark is what separated the two candidates: on the real harnesses they are both a smear, and between them there is 3.3%.

## Verification

803 tests green on clang release, gcc release, unity-16, ASan+UBSan and no-SSE2; clang-format clean; the new harness builds under both compilers with the project's warning set; unroll confirmed by disassembly under both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)