### PR TITLE
insert(first, last) sizing from the range: built, measured, declined

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,15 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
 - **Code layout luck is ±3%**, from edits to code that never executes. Judge micro-optimizations by
   mechanism plus a focused microbenchmark, never by a single sub-benchmark delta.
 - **Rerun if nanobench prints `err%` above ~3.** A CPU-governor warning is normal noise.
+- **Take a null run before believing a sub-benchmark delta.** `scripts/ab/run.sh -r HEAD` on a clean
+  tree puts the *same* header on both sides; it reads `rmissstr` 1.036, `buildbig` 0.983 and
+  `hashstr` 0.872. That bias was reported as a win in two consecutive PRs before it was checked. One
+  run, and it retires anything under about 5% on those workloads.
+- **A benchmark's own input model can make a wrong heuristic look right.** `scripts/ab/range_insert.cpp`
+  draws duplicates from a pool that grows with the range, so the fresh-key rate is stationary — and a
+  range-insert sizing rule that extrapolated that rate reproduced the right bucket count at every
+  duplicate rate from 0% to 99% while being **64x wrong** on a fixed set of keys. The unit tests
+  caught it; the benchmark never would have. A benchmark says how fast, not whether it is right.
 - **A benchmark with a small per-epoch batch must advance its own randomness.** A replayed key
   sequence is learned by the branch predictor and flatters the branchiest probe by up to 2.7x. This
   mistake has been made twice, in two different tools.
@@ -257,6 +266,15 @@ on boost, so it is the call boundary and not this map's register allocation. **P
 it** (96.4 to 69.3 instructions, 34.0 to 17.5 cycles) on both maps. No source change steers it, and
 six have been tried; what is left against boost once the boundary is gone is eleven instructions,
 and at 4M entries the two are level.
+
+*Range insert sizing.* `insert(first, last)` reserving from the range is **2x** and was **declined**,
+#248 — every version that gets the 2x is a heuristic about data the map cannot see, and an ordered
+range defeats all of them. `reserve(size() + distance())` is 128x the index at a 99% duplicate rate
+*and* 1.21 slower; a sampled fresh rate is 64x (2048 keys drawn from ten thousand come back 90% new
+— the birthday bound, not a duplicate rate); a capture-recapture read of the same sample is accurate
+and still guesses. Note the cost is the **value vector's** reallocation, not the index rehash:
+reserving only the values gets 10.4 ns/element against 9.9 for both and 19.6 for neither, and
+reserving only the buckets is *worse* than not reserving.
 
 *Still open.* Huge pages (22% of a large lookup, nothing asks for them).
 A built-in probe-length statistics facility like boost's. The string erase's ~50 ns second hash.

--- a/handoff/2026-09-10_boost-rehash-gcc-codegen.md
+++ b/handoff/2026-09-10_boost-rehash-gcc-codegen.md
@@ -1,0 +1,121 @@
+# Session Handoff — 2026-09-10 — gcc is 1.5x slower than clang on boost's rehash loop
+
+## Resume prompt
+
+Paste this into a fresh session:
+
+> Read `handoff/2026-09-10_boost-rehash-gcc-codegen.md` in the unordered_dense worktree
+> `/home/martinus/gra/unordered_dense/dawncorn`. A measurement from 2026-09-08 found that
+> `boost::unordered_flat_map`'s rehash loop is about 1.5x slower when built with gcc than with
+> clang, on identical source, and that merely restructuring the loop takes gcc to clang's floor.
+> That points at a compiler serialising something, not at a design problem, and it has never been
+> confirmed or reported. Reproduce it, find the instruction that causes it, and decide whether it is
+> a gcc bug worth filing or a source change worth sending to Boost.Unordered. Do not change
+> `include/ankerl/unordered_dense.h` — this is about boost.
+
+## The finding
+
+Measured 2026-09-08 while asking whether this library's pipelined rehash would transfer to boost.
+The port itself failed, which is not what this handoff is about. What it turned up on the way is
+the table below: **isolated `rehash()`, doubling the bucket count and back, nanoseconds per element**.
+
+| | u64 200K | u64 1M | str 200K | str 1M |
+|---|---|---|---|---|
+| clang, boost as shipped | 6.5 | 10.6 | 19.0–19.5 | 77.4 |
+| clang, pipelined port | 7.0–7.2 | 11.1–11.3 | 17.9–18.7 | 80–82 |
+| **gcc, boost as shipped** | **10.2–10.5** | 10.4–11.5 | 17.1–17.8 | 71–73 |
+| **gcc, pipelined port** | **7.0** | 10.2–10.5 | 16.7–17.2 | 73–77 |
+
+Read the first column. Same source, same machine, same boost: clang 6.5, gcc 10.2–10.5. Restructure
+the loop and gcc goes to 7.0 while clang gets slightly worse. The effect is specific — it does not
+show at 1M, and it does not show for string keys — which is itself a clue: at 200K the index is
+still in cache, so a serialised dependency is exposed, and at 1M memory latency hides it.
+
+**This is the same shape as a bug already found and fixed in this library**, with the compilers
+swapped. `fill_buckets_from_values` used to read `m_values[value_idx]`; placing an entry stores a
+`std::uint8_t` fingerprint, a byte store may alias anything, so after every placement clang had to
+reload the container's data pointer before it could form the address of the next key — one memory
+latency per element, on the address chain of a random access. Walking with an iterator instead took
+that build from 16.72 ms to 8.96. See `notes/index-design.md`, "Indexing the value container in the
+rehash cost clang a memory latency per element". **Look for that pattern first.** Boost's
+`unchecked_rehash` writes a metadata byte and then computes the next element's address.
+
+## What to do
+
+1. **Reproduce it before anything else.** The numbers are from one afternoon and were never re-run.
+   If gcc and clang now agree, stop and record that in `notes/index-design.md`; boost and both
+   compilers have moved since.
+2. **Find the instruction.** `perf stat` first (instructions, cycles, IPC — is gcc retiring more
+   work or stalling on the same work?), then `objdump -d --no-show-raw-insn` on
+   `boost::unordered::detail::foa::table_core<...>::unchecked_rehash` from both compilers and diff
+   the inner loop. The question to answer is narrow: **what is on the address chain in gcc's loop
+   that is not on clang's?**
+3. **Then decide which of two things it is.** A gcc bug (report with a reduced test case), or a
+   source pattern boost could change (report to Boost.Unordered with the measurement). The
+   restructured loop already reaching clang's floor suggests the second is available even if the
+   first is true.
+
+## How to build and run it
+
+Boost is the system install, **1.90.0** (`/usr/include/boost/version.hpp`). The harnesses are
+beside this file, recovered from `/tmp` before it cleared:
+
+- `2026-09-10_boost-rehash/brh.cpp` — the timing harness that produced the table. Builds a map,
+  then calls `rehash()` alternately to double the bucket count and back, timing each; reports the
+  best ns per element. Takes the key type, size and repetitions.
+- `2026-09-10_boost-rehash/rhperf.cpp` — nothing but rehashes, so `perf stat` counts the loop and
+  little else. This is what produced "boost 97.5 instructions and 110.9 cycles per element against
+  this map's 51.9 and 46.7".
+- `2026-09-10_boost-rehash/bsplit2.cpp` — splits a build into reserved inserts and growth. Not
+  needed for the codegen question; included because it is the context (68–75% of a boost build is
+  growth, against 11–28% here).
+
+All three include `<bench/workloads.h>` from this repo, so build them with `-I include -I test`:
+
+```sh
+cd /home/martinus/gra/unordered_dense/dawncorn
+for cxx in clang++ g++; do
+    $cxx -O2 -DNDEBUG -std=c++17 -w -Iinclude -Itest \
+        handoff/2026-09-10_boost-rehash/brh.cpp -o /tmp/brh_$cxx
+done
+taskset -c 2 /tmp/brh_clang++ ; taskset -c 2 /tmp/brh_g++
+```
+
+**The patched boost is gone.** `/tmp/boostpf` was a copy of `boost/unordered/detail/foa/core.hpp`
+with `unchecked_rehash` rewritten as a sixteen-entry ring of (element pointer, hash) that prefetches
+the destination group, and in a second variant all four cache lines of the group's fifteen slots.
+It has to be rebuilt if you want the "pipelined" rows. For the codegen question you do not need it:
+the shipped rows are the ones that disagree.
+
+## Rules for this measurement
+
+From `CLAUDE.md`; these apply here and two of them have burned this exact question before.
+
+- Never compare runs taken at different times. Alternate the two binaries in one sitting.
+- A ratio at one size is a point on a sawtooth. This effect is size-specific — it shows at 200K and
+  not at 1M — so **sweep the size** rather than quoting 200K, and say where it starts and stops.
+- Instruction counts are the number neither code layout nor drift can move. If gcc and clang retire
+  the same instructions and differ in cycles, it is a dependency chain; if gcc retires more, it is
+  doing more work. Answer that before reading any disassembly.
+- `-march=native` silently upgrades boost's SSE2 intrinsics to AVX-512 on this machine, so a profile
+  taken that way is not the code most callers run. Use the default `-march`.
+
+## Context you may want, and where it is
+
+`notes/index-design.md` is the lab notebook; search it by phrase.
+
+- "The pipelined rehash does not transfer to `boost::unordered_flat_map`" — the whole experiment,
+  including why the port failed (boost's rehash is instruction-bound from moving `value_type`s, not
+  latency-bound: 97.5 instructions and 110.9 cycles per element against this map's 51.9 and 46.7, on
+  the *same* L1 misses and with *lower* dTLB misses).
+- "And the radix partition does not rescue it either" — the other idea, also measured, also a loss.
+- "What that says about boost's build, which is its weakest column" — the reserved/growth split.
+- "Indexing the value container in the rehash cost clang a memory latency per element" — the bug
+  this one probably rhymes with, with the compilers swapped.
+
+## What success looks like
+
+Either a reduced test case in a gcc bug report, or a patch and a measurement for
+Boost.Unordered — plus an entry in `notes/index-design.md` saying what it was. A negative result
+("it no longer reproduces on boost 1.90 with gcc 16") is a perfectly good outcome and should be
+recorded in the same place, because the claim is currently sitting in the notes unqualified.

--- a/handoff/2026-09-10_boost-rehash/brh.cpp
+++ b/handoff/2026-09-10_boost-rehash/brh.cpp
@@ -1,0 +1,40 @@
+#include <boost/unordered/unordered_flat_map.hpp>
+#include <ankerl/unordered_dense.h>
+#include <bench/workloads.h>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+template <typename K> auto keys(std::size_t n) { std::vector<K> v; v.reserve(n); for (std::size_t i = 0; i < n; ++i) v.push_back(workloads::key_source<K>::get(i * 7919 + 13)); return v; }
+template <typename K> void run(char const* name, std::size_t n, int reps) {
+    workloads::tame_allocator();
+    auto ks = keys<K>(n);
+    using clk = std::chrono::steady_clock;
+    boost::unordered_flat_map<K, std::size_t, ankerl::unordered_dense::hash<K>> m;
+    for (std::size_t i = 0; i < n; ++i) m[ks[i]] = i;
+    double best = 1e30; auto bc = m.bucket_count();
+    for (int r = 0; r < reps; ++r) {
+        auto target = (r % 2 == 0) ? bc * 2 : bc;
+        auto t0 = clk::now(); m.rehash(target); auto t1 = clk::now();
+        if (m.bucket_count() == ((r % 2 == 0) ? bc : bc * 2)) std::abort();
+        best = std::min(best, std::chrono::duration<double, std::nano>(t1 - t0).count() / static_cast<double>(n));
+    }
+    std::size_t bad = 0;
+    for (std::size_t i = 0; i < n; ++i) if (auto it = m.find(ks[i]); it == m.end() || it->second != i) ++bad;
+    double bbest = 1e30;
+    for (int r = 0; r < reps / 4 + 1; ++r) {
+        boost::unordered_flat_map<K, std::size_t, ankerl::unordered_dense::hash<K>> b;
+        auto t0 = clk::now();
+        for (std::size_t i = 0; i < n; ++i) b[ks[i]] = i;
+        auto t1 = clk::now();
+        bbest = std::min(bbest, std::chrono::duration<double, std::nano>(t1 - t0).count() / static_cast<double>(n));
+    }
+    std::printf("%-4s n=%-8zu rehash %6.2f ns/el   build %6.2f ns/el   bad=%zu\n", name, n, best, bbest, bad);
+}
+int main(int argc, char** argv) {
+    std::size_t n = argc > 1 ? std::strtoull(argv[1], nullptr, 10) : 200000;
+    int reps = argc > 2 ? std::atoi(argv[2]) : 12;
+    run<std::uint64_t>("u64", n, reps);
+    run<std::string>("str", n, reps);
+}

--- a/handoff/2026-09-10_boost-rehash/bsplit2.cpp
+++ b/handoff/2026-09-10_boost-rehash/bsplit2.cpp
@@ -1,0 +1,35 @@
+#include <absl/container/flat_hash_map.h>
+#include <boost/unordered/unordered_flat_map.hpp>
+#include <ankerl/unordered_dense.h>
+#include <bench/workloads.h>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+using clk = std::chrono::steady_clock;
+template <typename K> struct ah : ankerl::unordered_dense::hash<K> { using is_avalanching = void; };
+template <typename K> auto keys(std::size_t n) { std::vector<K> v; v.reserve(n); for (std::size_t i = 0; i < n; ++i) v.push_back(workloads::key_source<K>::get(i * 7919 + 13)); return v; }
+template <typename M, typename K> void one(char const* name, std::vector<K> const& ks, int reps) {
+    double be = 1e30, br = 1e30;
+    for (int r = 0; r < reps; ++r) { M m; auto t0 = clk::now(); for (auto const& k : ks) m[k]; auto t1 = clk::now();
+        be = std::min(be, std::chrono::duration<double, std::nano>(t1-t0).count()/double(ks.size())); }
+    for (int r = 0; r < reps; ++r) { M m; m.reserve(ks.size()); auto t0 = clk::now(); for (auto const& k : ks) m[k]; auto t1 = clk::now();
+        br = std::min(br, std::chrono::duration<double, std::nano>(t1-t0).count()/double(ks.size())); }
+    std::printf("  %-16s from empty %7.2f   reserved %7.2f   growth %7.2f ns/el (%4.1f%%)\n", name, be, br, be-br, 100.0*(be-br)/be);
+}
+template <typename V, typename K> void row(char const* what, std::vector<K> const& ks, int reps) {
+    std::printf("%s\n", what);
+    one<ankerl::unordered_dense::map<K, V, ah<K>>>("unordered_dense", ks, reps);
+    one<boost::unordered_flat_map<K, V, ah<K>>>("boost", ks, reps);
+    one<absl::flat_hash_map<K, V, ah<K>>>("abseil", ks, reps);
+}
+int main(int argc, char** argv) {
+    workloads::tame_allocator();
+    std::size_t n = argc > 1 ? std::strtoull(argv[1], nullptr, 10) : 200000;
+    int reps = argc > 2 ? std::atoi(argv[2]) : 8;
+    auto ku = keys<std::uint64_t>(n);
+    row<std::size_t>("uint64_t key, 8 byte value", ku, reps);
+    row<workloads::big_value>("uint64_t key, 64 byte value", ku, reps);
+    row<std::size_t>("std::string key, 8 byte value", keys<std::string>(n), reps);
+}

--- a/handoff/2026-09-10_boost-rehash/rhperf.cpp
+++ b/handoff/2026-09-10_boost-rehash/rhperf.cpp
@@ -1,0 +1,30 @@
+// nothing but rehashes, so perf stat counts the growth loop and little else
+#include <boost/unordered/unordered_flat_map.hpp>
+#include <ankerl/unordered_dense.h>
+#include <bench/workloads.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+template <typename K> struct ah : ankerl::unordered_dense::hash<K> { using is_avalanching = void; };
+int main(int argc, char** argv) {
+    workloads::tame_allocator();
+    int which = argc > 1 ? std::atoi(argv[1]) : 0;
+    std::size_t n = argc > 2 ? std::strtoull(argv[2], nullptr, 10) : 1000000;
+    int reps = argc > 3 ? std::atoi(argv[3]) : 20;
+    std::vector<std::uint64_t> ks(n);
+    for (std::size_t i = 0; i < n; ++i) ks[i] = workloads::key_source<std::uint64_t>::get(i * 7919 + 13);
+    std::size_t acc = 0;
+    if (which == 0) {
+        ankerl::unordered_dense::map<std::uint64_t, std::size_t> m;
+        for (auto k : ks) m[k] = 1;
+        auto bc = m.bucket_count();
+        for (int r = 0; r < reps; ++r) { m.rehash(r % 2 ? bc : bc * 2); acc += m.bucket_count(); }
+    } else {
+        boost::unordered_flat_map<std::uint64_t, std::size_t, ah<std::uint64_t>> m;
+        for (auto k : ks) m[k] = 1;
+        auto bc = m.bucket_count();
+        for (int r = 0; r < reps; ++r) { m.rehash(r % 2 ? bc : bc * 2); acc += m.bucket_count(); }
+    }
+    std::printf("%zu\n", acc);
+}

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -33,6 +33,8 @@ place rather than being deleted, because the retraction is usually the more usef
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
 - `replace()` hashes ahead too, once the reason it could not was looked at properly
+- `insert(first, last)` sizing the table from the range: built, measured, declined
+- The paired harness has a systematic bias on `rmissstr`, about 3.6%
 - A block's prefetches should step from its start, not jump to its end
 - The other two pipelines do not want the cache gate, and the gate's own footprint model was wrong
 - Taking the hash apart once per insert instead of twice, and the shared pipeline that was not worth it
@@ -381,6 +383,75 @@ loosening the tests.
 
 `do_insert_range` and `do_visit` pipeline too and have no such gate. Measured, and neither needs
 one -- below.
+
+**`insert(first, last)` sizing the table from the range: built, measured, declined** (2026-09-11,
+issue #248, `scripts/ab/range_insert.cpp`, Ryzen 9 7950X, clang 22). Worth **2x** on the common case
+and not shipped, because every version that gets the 2x is a heuristic about data the map cannot see.
+Three attempts, each wrong in a way worth keeping.
+
+*First: `reserve(size() + std::distance(first, last))`, which is what the issue proposed.* A range is
+not its number of distinct keys. At a 99% duplicate rate it asks for **128 times** the index the map
+ends up needing -- 2097152 buckets for 9923 elements, kept for the map's lifetime -- and it is not
+even faster, because every probe then misses in a mostly empty table: **1.21** against growing.
+
+*Second: sample the head, extrapolate the fresh-key rate.* This is the one worth remembering, because
+it looked perfect. On `range_insert.cpp`'s own duplicate model it reproduced the growth bucket count
+**exactly** at every rate from 0% to 99% -- that model draws duplicates from a pool growing with the
+range, so the fresh rate is stationary. Real ranges are not. **2048 keys drawn from ten thousand come
+back 90% new**; that is the birthday bound, not a duplicate rate, and extrapolating it over a million
+elements predicts nine hundred thousand distinct keys instead of ten thousand. 64x. The unit tests
+caught it, the benchmark could not have, and the general lesson is in CLAUDE.md.
+
+*Third: read the sample as a capture-recapture.* Split the sample; if the range draws from `total`
+distinct keys and the first half caught `warmed` of them, the share of the second half that is a
+**repeat** estimates `warmed / total`, so `total = warmed * measured / again`. The statistic is the
+repeats, not the freshness, and it is informative exactly where the rate is not. At a million
+elements, buckets against the 16384 / 131072 / 1048576 actually needed:
+
+| distinct keys | first try | second try | capture-recapture |
+|---|---|---|---|
+| 10000 | 2097152 | 1048576 | **16384** |
+| 100000 | 2097152 | 2097152 | **131072** |
+| 500000 | 2097152 | 2097152 | **1048576** |
+
+0.51 of the time fully distinct, 0.48 at 70-90% distinct, neutral below half distinct, clamped so no
+estimate can exceed reserving the range's length. It works. **It was still declined**, because an
+ordered range -- every key once, then the set again -- defeats any prefix sample and no scheme fixes
+that; what is left is a hash map guessing at its caller's data with a 4x memory consequence when it
+guesses wrong. The 2x is not worth owning that.
+
+*And the mechanism is not the one the issue assumed.* The issue says growth is expensive because each
+doubling rehashes the index, and the pipelined loop also loses its sixteen in-flight prefetches.
+Neither is the cost. Reserving **only the value container** captures nearly all of the win, and
+reserving **only the buckets** is worse than not reserving at all. At a million distinct keys,
+ns per element:
+
+| | ns/element |
+|---|---|
+| no reserve | 19.6 |
+| values only | 10.4 |
+| values and buckets | 9.9 |
+| buckets only | 22.3 |
+
+So it is the value vector's geometric reallocation -- copying 16 MB repeatedly -- and the index
+rehash is nearly free beside it. That also rules out the cheap version of the idea: reserving just
+the values is *not* the safe half, since a value is 16 bytes against the index's 5.5 per slot, so
+guessing wrong there costs more, not less.
+
+*`std::distance` is only free on a random access iterator.* Over a `std::list` it walks the range a
+second time, a **1.20 loss** at a high duplicate rate. Any future attempt at this must exclude
+merely-forward ranges.
+
+What was kept: `range_insert.cpp` gained a duplicate rate, a `std::list` source and a bucket count in
+its output, which is what made all of the above visible.
+
+**The paired harness has a systematic bias on `rmissstr`, about 3.6%** (2026-09-11). It showed up as
+a 1.037-1.039 "win" in two consecutive PRs, against two different baselines, for changes whose
+mechanism could not reach a lookup at all. Running `scripts/ab/run.sh -r HEAD` on a clean tree --
+**the same header on both sides** -- reads `rmissstr` **1.036**, `buildbig` 0.983, `buildstr` 0.984
+and `hashstr` 0.872. So the candidate side of a paired run is systematically faster on those, and a
+single-digit-percent reading on them means nothing. The null run is the check, it costs one run, and
+it should be taken before believing any sub-benchmark delta under about 5%.
 
 **A block's prefetches should step from its start, not jump to its end** (2026-09-11, issue #250,
 `scripts/ab/prefetch_lines.cpp`, Ryzen 9 7950X, clang 22). Raised by a cleanup review as "a quarter

--- a/scripts/ab/range_insert.cpp
+++ b/scripts/ab/range_insert.cpp
@@ -9,7 +9,14 @@
 // round is what is timed. `reserved` builds into a map that was told its size, so growth and the
 // rehash -- which is pipelined already -- are out of the measurement and what is left is the insert.
 //
-//   argv: <loop|range> <n> [rounds] [reserved|grow]
+//   argv: <loop|range> <n> [rounds] [reserved|grow] [dup-percent] [vector|list]
+//
+// `dup-percent` is the share of the input that repeats an earlier key -- the case where reserving
+// from std::distance over-allocates, since the range is longer than the map will end up being. The
+// source container matters too: a std::list is a forward range, so std::distance over it is O(n) and
+// walks the whole thing a second time, which is the case where asking how long the range is may cost
+// more than knowing. The final bucket_count is printed so over-allocation is visible and not just
+// inferred.
 //
 // `loop` is the right control for "what does the range overload buy a caller" and the wrong one for
 // "does the ring inside it pay": it also carries the call boundary's ~15 instructions per element,
@@ -27,6 +34,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <list>
 #include <string>
 #include <vector>
 
@@ -57,16 +65,26 @@ int main(int argc, char** argv) {
     auto const n = static_cast<std::size_t>(argc > 2 ? std::strtoull(argv[2], nullptr, 10) : 200000);
     auto const rounds = static_cast<std::size_t>(argc > 3 ? std::strtoull(argv[3], nullptr, 10) : 20);
     auto const reserved = std::string(argc > 4 ? argv[4] : "grow") == "reserved";
+    auto const dup_pct = static_cast<std::size_t>(argc > 5 ? std::strtoull(argv[5], nullptr, 10) : 0);
+    auto const as_list = std::string(argc > 6 ? argv[6] : "vector") == "list";
 
     // Built once, outside the timing: what is being measured is the insert, not making the input.
     auto input = std::vector<std::pair<key_type, std::size_t>>();
     input.reserve(n);
     auto r = rng(1);
+    auto distinct = std::vector<std::uint64_t>();
     for (std::size_t i = 0; i < n; ++i) {
-        input.emplace_back(workloads::key_for<map_t>(r() >> 2U), i);
+        auto const dup = !distinct.empty() && (r() % 100) < dup_pct;
+        auto const v = dup ? distinct[static_cast<std::size_t>(r() % distinct.size())] : (r() >> 2U);
+        if (!dup) {
+            distinct.push_back(v);
+        }
+        input.emplace_back(workloads::key_for<map_t>(v), i);
     }
+    auto const listed = std::list<std::pair<key_type, std::size_t>>(input.begin(), input.end());
 
     auto acc = std::size_t{0};
+    auto buckets = std::size_t{0};
     auto const started = std::chrono::steady_clock::now();
     for (std::size_t round = 0; round < rounds; ++round) {
         auto map = map_t();
@@ -74,20 +92,33 @@ int main(int argc, char** argv) {
             map.reserve(n);
         }
         if (how == "range") {
-            map.insert(input.begin(), input.end());
+            if (as_list) {
+                map.insert(listed.begin(), listed.end());
+            } else {
+                map.insert(input.begin(), input.end());
+            }
+        } else if (as_list) {
+            for (auto const& kv : listed) {
+                map.insert(kv);
+            }
         } else {
             for (auto const& kv : input) {
                 map.insert(kv);
             }
         }
         acc += map.size();
+        buckets = map.bucket_count();
     }
     auto const elapsed = std::chrono::steady_clock::now() - started;
-    std::printf("%.3f ns/element  %s n=%zu rounds=%zu %s acc=%zu\n",
+    std::printf("%.3f ns/element  %s n=%zu rounds=%zu %s dup=%zu%% %s size=%zu buckets=%zu acc=%zu\n",
                 std::chrono::duration<double, std::nano>(elapsed).count() / static_cast<double>(n * rounds),
                 how.c_str(),
                 n,
                 rounds,
                 reserved ? "reserved" : "grow",
+                dup_pct,
+                as_list ? "list" : "vector",
+                acc / rounds,
+                buckets,
                 acc);
 }

--- a/test/unit/range_insert.cpp
+++ b/test/unit/range_insert.cpp
@@ -155,3 +155,84 @@ TEST_CASE("range_insert_initializer_list_and_from_a_copy") {
     REQUIRE(map.size() == 3U);
     REQUIRE(map.at(3) == 30);
 }
+
+// Sizing the table from the range was measured and declined -- see notes/index-design.md, "sizes the
+// table from the range". These are what that work left behind: the lengths it would have split a
+// range at are still the lengths where a sixteen-deep lookahead has edges, and inserting into a
+// populated map was not covered before.
+
+namespace {
+
+auto range_insert_key(uint64_t i) -> uint64_t {
+    return i * UINT64_C(0x9E3779B97F4A7C15);
+}
+
+using range_insert_input = std::vector<std::pair<uint64_t, uint64_t>>;
+
+// len elements drawn from `distinct` keys, at random rather than in order.
+auto range_insert_input_of(size_t len, size_t distinct) -> range_insert_input {
+    auto input = range_insert_input();
+    auto s = uint64_t{12345};
+    for (size_t i = 0; i < len; ++i) {
+        s ^= s << 13U;
+        s ^= s >> 7U;
+        s ^= s << 17U;
+        input.emplace_back(range_insert_key(static_cast<size_t>(s % distinct)), static_cast<uint64_t>(i));
+    }
+    return input;
+}
+
+} // namespace
+
+TEST_CASE("range_insert_matches_a_loop_at_many_lengths_and_duplicate_rates") {
+    for (auto const len : {size_t{1},
+                           size_t{2},
+                           size_t{3},
+                           size_t{4095},
+                           size_t{4096},
+                           size_t{4097},
+                           size_t{8191},
+                           size_t{8192},
+                           size_t{8193},
+                           size_t{12289}}) {
+        for (auto const distinct : {size_t{7}, size_t{1000}}) {
+            auto const input = range_insert_input_of(len, distinct);
+
+            auto ranged = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+            ranged.insert(input.begin(), input.end());
+            auto looped = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+            for (auto const& kv : input) {
+                looped.insert(kv);
+            }
+
+            INFO("len=" << len << " distinct=" << distinct);
+            REQUIRE(ranged.size() == looped.size());
+            // same index, not merely the same contents: a range insert that sized the table
+            // differently from a loop would be a behaviour change, and is the thing #248 declined
+            REQUIRE(ranged.bucket_count() == looped.bucket_count());
+            for (auto const& [k, v] : looped) {
+                REQUIRE(ranged.at(k) == v);
+            }
+        }
+    }
+}
+
+TEST_CASE("range_insert_into_a_populated_map") {
+    auto map = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    for (uint64_t i = 0; i < 10000; ++i) {
+        map.insert({range_insert_key(i), i});
+    }
+    auto input = range_insert_input();
+    for (uint64_t i = 0; i < 10000; ++i) {
+        // half already present, half new
+        input.emplace_back(range_insert_key(i % 2 == 0 ? i : i + 100000), i);
+    }
+    map.insert(input.begin(), input.end());
+    REQUIRE(map.size() == 15000U);
+    for (uint64_t i = 0; i < 10000; ++i) {
+        REQUIRE(map.contains(range_insert_key(i)));
+    }
+    for (uint64_t i = 1; i < 10000; i += 2) {
+        REQUIRE(map.contains(range_insert_key(i + 100000)));
+    }
+}


### PR DESCRIPTION
Closes #248. **No behaviour change.** The idea is worth 2x and is not shipped; this is the evidence and the two harness fixes that came out of it.

## Why not

#248 proposed `reserve(size() + std::distance(first, last))` for a forward range. It is worth **2x** on a build from distinct keys — the largest single win left on the bulk paths. Three versions were built and measured:

**1. The issue's version.** A range is not its number of distinct keys. At a 99% duplicate rate it asks for **128x** the index the map ends up needing — 2097152 buckets for 9923 elements, kept for the map's lifetime — and it is **1.21 slower** with it, because every probe then misses in a mostly empty table.

**2. Sample the head, extrapolate the fresh-key rate.** This looked perfect: on `range_insert.cpp`'s own duplicate model it reproduced the growth bucket count *exactly* at every rate from 0% to 99%. That model draws duplicates from a pool that grows with the range, so the fresh rate is stationary. Real ranges are not. **2048 keys drawn from ten thousand come back 90% new** — the birthday bound, not a duplicate rate — and extrapolating over a million elements predicts 900,000 distinct instead of 10,000. **64x.** The unit tests caught it; the benchmark could not have.

**3. Read the same sample as a capture-recapture.** The share of the sample's second half that is a *repeat* estimates how much of the range's key universe the first half already caught, so `total = warmed * measured / again`. Buckets at a million elements, against what is actually needed:

| distinct keys | needed | version 1 | version 2 | capture-recapture |
|---|---|---|---|---|
| 10000 | 16384 | 2097152 | 1048576 | **16384** |
| 100000 | 131072 | 2097152 | 2097152 | **131072** |
| 500000 | 1048576 | 2097152 | 2097152 | **1048576** |

0.51 fully distinct, 0.48 at 70–90% distinct, neutral below half, clamped so no estimate can exceed reserving the range's length. **It works, and it is still a hash map guessing at its caller's data** — an ordered range (every key once, then the set again) defeats any prefix sample, with a 4x memory consequence when the guess is wrong. Not worth owning for 2x.

## The issue's assumed mechanism is also wrong

#248 says growth costs because each doubling rehashes the index, and the pipelined loop loses its sixteen in-flight prefetches. Neither is the cost. At a million distinct keys:

| | ns/element |
|---|---|
| no reserve | 19.6 |
| **values only** | **10.4** |
| values and buckets | 9.9 |
| **buckets only** | **22.3** |

It is the value vector's geometric reallocation; the index rehash is nearly free beside it, and reserving only the buckets is *worse* than not reserving. That also rules out the cheap-looking version of the idea — reserving just the values is not the safe half, since a value is 16 bytes against the index's 5.5 per slot.

## A harness bias, found while checking this

`rmissstr` read 1.037–1.039 as a "win" in **two consecutive PRs against two different baselines**, for changes whose mechanism could not reach a lookup at all. A null run — `scripts/ab/run.sh -r HEAD` on a clean tree, the *same header on both sides* — reads:

```
rmissstr 1.036   buildbig 0.983   buildstr 0.984   hashstr 0.872
```

The candidate side of a paired run is systematically faster on those. One run retires anything under ~5% on them, and it is now a rule in `CLAUDE.md`.

## What this PR keeps

- `scripts/ab/range_insert.cpp`: a duplicate rate, a `std::list` source, and `bucket_count` in the output — the three things that made all of the above visible.
- Two tests, one of which pins that a range insert sizes the table *exactly* as a loop of single inserts does, which is the behaviour that was nearly changed.
- `notes/index-design.md` and `CLAUDE.md`.

805 tests green on clang release, gcc release, unity-16 and ASan+UBSan; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)