### PR TITLE
Add merge(), which repairs the source once instead of per element

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,9 +286,12 @@ time, past the cache. The larger effect is the caller's: **batching the keys at 
 *The five pipelines.* The rehash, the range insert, `replace()`'s dedup and `merge()` each have their
 own `pipeline_depth` ring, and the bulk visit has chunks instead (a ring there measured 15% worse);
 sharing them costs the rehash 1.9 instructions per element and was rejected. `replace()` and
-`merge()` are gated, on **index** bytes — counting the values too was measured wrong, and both
-crossovers land within a doubling of the same 256 KB, which is what says that number is the cache's
-and not either loop's. The range insert is slightly
+`merge()` are gated, on **index** bytes — counting the values too was measured wrong. The two
+thresholds are **not the same**: 256 KB and 1 MB. A gate's crossover is where the ring's fixed 13–17
+instructions per element stop being worth the misses they hide, so it moves with what the *rest* of
+the loop costs — writing merge's walk with iterators instead of indices made it 5–11% cheaper and
+pushed its crossover two doublings up. Re-fit the constant whenever the gated loop changes; a shared
+one costs 7–12% in an octave. The range insert is slightly
 negative below a few thousand elements and a clear win above; the visit loses 8% only when every key
 hits a map below ~16k, where the same map at a 50% hit rate wins 11%, so its axis is the caller's
 hit rate. The rehash is the one that has never been measured below cache. #247, #242.
@@ -297,4 +300,10 @@ hit rate. The rehash is the one that has never been measured below cache. #247, 
 first version read the gate per element; the ungated case then came back 10% slower than the same
 loop with the ring deleted, because a perfectly predicted branch is not free when a ring, a lambda
 and a live array hang off it. Two instantiations of one body (`walk(std::true_type{})`) get the
-plain loop back to within 1.5%.
+plain loop back.
+
+**Walk a value container with iterators, never with an index, in any loop that also places
+elements.** `fill_buckets_from_values` records why — a `uint8_t` fingerprint store may alias the
+container's data pointer, so an indexed read reloads it after every placement, and that is a store-
+to-load chain per element (10.43 → 2.74 ns/insert there). `merge()`'s walk was written with indices
+first and cost 0.89–0.95 for it; `do_insert_range` and the rehash were already iterator-based.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,10 +283,18 @@ A built-in probe-length statistics facility like boost's. The string erase's ~50
 time, past the cache. The larger effect is the caller's: **batching the keys at all is 1.5x**, and a
 `prefetch(key)` API that was credited with that was reverted the same day it shipped.
 
-*The four pipelines.* The rehash, the range insert and `replace()`'s dedup each have their own
-`pipeline_depth` ring, and the bulk visit has chunks instead (a ring there measured 15% worse);
-sharing them costs the rehash 1.9 instructions per element and was rejected. Only `replace()` is
-gated, on **index** bytes — counting the values too was measured wrong. The range insert is slightly
+*The five pipelines.* The rehash, the range insert, `replace()`'s dedup and `merge()` each have their
+own `pipeline_depth` ring, and the bulk visit has chunks instead (a ring there measured 15% worse);
+sharing them costs the rehash 1.9 instructions per element and was rejected. `replace()` and
+`merge()` are gated, on **index** bytes — counting the values too was measured wrong, and both
+crossovers land within a doubling of the same 256 KB, which is what says that number is the cache's
+and not either loop's. The range insert is slightly
 negative below a few thousand elements and a clear win above; the visit loses 8% only when every key
 hits a map below ~16k, where the same map at a 50% hit rate wins 11%, so its axis is the caller's
-hit rate. The rehash is the one that has never been measured below cache. #247.
+hit rate. The rehash is the one that has never been measured below cache. #247, #242.
+
+**A gate that is a runtime branch inside the loop costs nearly everything it saves.** `merge()`'s
+first version read the gate per element; the ungated case then came back 10% slower than the same
+loop with the ring deleted, because a perfectly predicted branch is not free when a ring, a lambda
+and a live array hang off it. Two instantiations of one body (`walk(std::true_type{})`) get the
+plain loop back to within 1.5%.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Additionally, there are `ankerl::unordered_dense::segmented_map` and `ankerl::un
     - [3.3.5. `auto replace(value_container_type&& container)`](#335-auto-replacevalue_container_type-container)
     - [3.3.6. `auto hash_for(K const& key) const -> precomputed_hash`](#336-auto-hash_fork-const-key-const---precomputed_hash)
     - [3.3.7. `auto visit(FwdIt first, FwdIt last, F f) -> size_t`](#337-auto-visitfwdit-first-fwdit-last-f-f---size_t)
+    - [3.3.8. `void merge(map& source)`](#338-void-mergemap-source)
   - [3.4. Custom Container Types](#34-custom-container-types)
   - [3.5. Custom Bucket Types](#35-custom-bucket-types)
     - [3.5.1. `ankerl::unordered_dense::bucket_type::group`](#351-ankerlunordered_densebucket_typegroup)
@@ -430,6 +431,27 @@ for (auto const& k : batch) { auto it = map.find(k); }
 ```
 
 That is a property of loops and memory parallelism rather than of this map, and it is the larger of the two effects. `visit` is what is left on top once the loop is already shaped that way.
+
+#### 3.3.8. `void merge(map& source)`
+
+This is the standard container's `merge`, with the guarantees a container without nodes can give. Every element of `source` whose key is not here already moves over, and the rest stay behind. An element whose key is already here is **not** overwritten -- the value already in this map wins, as with `insert` and `try_emplace`. `source` may hash and compare differently; the keys that move are re-hashed with this map's hasher. Both an lvalue and an rvalue `source` are accepted, and an rvalue one is still only emptied of what moved.
+
+```cpp
+auto a = ankerl::unordered_dense::map<std::string, int>{{"x", 1}, {"y", 2}};
+auto b = ankerl::unordered_dense::map<std::string, int>{{"y", 20}, {"z", 30}};
+a.merge(b);
+// a is {"x", 1}, {"y", 2}, {"z", 30}   -- "y" was already in a, so a's value stayed
+// b is {"y", 20}                       -- and so did b's
+```
+
+Two things differ from `std::unordered_map::merge`, and both follow from the elements living in a vector rather than in nodes:
+
+* **Iterators and references into either container are invalidated.** A node-based merge splices nodes, so references to the elements that move stay valid. Here an element that moves is move-constructed into the destination's vector, which may reallocate.
+* **The source's order changes.** Every element taken out of the middle of it leaves a gap that the elements behind it close. `erase()` already reorders for the same reason.
+
+`a.merge(a)` has no effect. If an operation throws -- a hash, a key comparison, or an element's move -- both containers are left valid and usable, `source` keeps everything not yet taken, and the one element that was being moved at the time may be lost.
+
+`merge` is worth using over the loop it replaces: about **2x** when the two maps mostly do not overlap, which is what a merge is usually for.
 
 ### 3.4. Custom Container Types
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1453,10 +1453,11 @@ private:
                   "a group is sixteen fingerprints, matched as one vector or two words, and eight counters, picked by "
                   "the low three bits of the fingerprint");
 
-    // How far ahead the four loops that pipeline look: the rehash, the range insert, the bulk
-    // visit and replace()'s dedup. The visit uses it as a chunk size rather than a ring depth. It is a count of memory
-    // accesses that has to fit inside what the core keeps outstanding, which is about two dozen on a Zen 4 -- not a property
-    // of the map, and every size from 8 to 32 measured within 2% of this one. Boost's bulk visit uses the same number.
+    // How far ahead the five loops that pipeline look: the rehash, the range insert, the bulk
+    // visit, replace()'s dedup and merge()'s walk. The visit uses it as a chunk size rather than a ring depth. It is a count
+    // of memory accesses that has to fit inside what the core keeps outstanding, which is about two dozen on a Zen 4 -- not a
+    // property of the map, and every size from 8 to 32 measured within 2% of this one. Boost's bulk visit uses the same
+    // number.
     static constexpr std::size_t pipeline_depth = 16;
 
     // Below this much *index*, a pipeline costs more than it saves: the ring round trip is about 13
@@ -1467,10 +1468,11 @@ private:
     // a 1032 byte value the footprint model opens the gate at ten thousand elements, where the
     // pipeline is a **14% loss**. Both value sizes cross over at the same index size instead.
     //
-    // See replace(), the only caller, for the sweep. The range insert and the bulk visit were
-    // measured against the same question and neither wants a gate; the visit's crossover is set by
-    // the caller's hit rate, which the map does not know until it has already done a chunk's worth
-    // of work. Issue #247.
+    // Two callers, replace() and merge(), each with its own sweep beside it; they were measured
+    // separately and landed on the same number, which is what says it belongs to the cache and not to
+    // either loop. The range insert and the bulk visit were measured against the same question and
+    // neither wants a gate; the visit's crossover is set by the caller's hit rate, which the map does
+    // not know until it has already done a chunk's worth of work. Issues #247 and #242.
     static constexpr std::size_t pipeline_min_index_bytes = std::size_t{256} << 10U;
 
     static constexpr std::uint8_t initial_shifts = 64 - 2; // 2^(64-m_shifts) groups
@@ -1508,6 +1510,22 @@ public:
 
 private:
     using value_idx_type = typename Bucket::value_idx_type;
+
+    // merge(source) takes the source apart and puts it back together: it compacts the elements that
+    // stay behind and rebuilds the index over them once, neither of which the public API can
+    // express. The standard lets the source differ in its hash and its key_equal, so it is a
+    // different instantiation of this same template and not otherwise a friend of it.
+    // Wider than the need -- every table is a friend of every other, where merge wants only the ones
+    // holding the same value type in the same container -- and C++17 has no way to say less: a friend
+    // template cannot constrain its own argument list.
+    template <class, class, class, class, class, class, bool>
+    friend class table;
+
+    // What merge() accepts: this table with another hash or another key_equal, which is the pair the
+    // standard allows to differ. Everything else has to match, because the elements move out of one
+    // container and into the other.
+    template <class H2, class KE2>
+    using sibling_table = table<Key, T, H2, KE2, AllocatorOrContainer, Bucket, IsSegmented>;
 
     static_assert(std::is_trivially_destructible_v<Bucket>, "assert there's no need to call destructor / std::destroy");
     static_assert(std::is_trivially_copyable_v<Bucket>, "assert we can just memset / memcpy");
@@ -2012,6 +2030,14 @@ private:
     // in slots, which is what the bucket interface counts in
     [[nodiscard]] static constexpr auto calc_num_buckets(std::uint8_t shifts) -> std::size_t {
         return calc_num_groups(shifts) * slots_per_group;
+    }
+
+    // Whether a bulk loop over an index of this shape is worth pipelining; see
+    // pipeline_min_index_bytes for the measurement. One reader for the threshold, so that the two
+    // gated loops cannot drift apart -- they differ in *which* index they ask about, which is the
+    // shifts they pass, and in nothing else.
+    [[nodiscard]] static constexpr auto wants_pipeline(std::uint8_t shifts) -> bool {
+        return calc_num_groups(shifts) * sizeof(typename bucket_container_type::block) > pipeline_min_index_bytes;
     }
 
     [[nodiscard]] constexpr auto calc_shifts_for_size(std::size_t s) const -> std::uint8_t {
@@ -2591,6 +2617,191 @@ private:
         place_element_at(word, counter, home_idx, std::forward<V>(value));
     }
 
+    // Closes the gaps a merge left behind, on the table it took them out of: compacts everything
+    // from `from` on down onto `keep`, drops the tail that is now moved-from, and rebuilds the index
+    // once over what is left. Called on the *source*, which is why it pairs with
+    // fill_buckets_from_values rather than living beside do_merge.
+    //
+    // That one rebuild is the point of the whole design. The loop a caller could write instead --
+    // try_emplace here, erase(it) there -- repairs the index once per element taken, and each repair
+    // is a second hash of the key leaving plus a third of the element the backfill drags into its
+    // place. Over a source that mostly does not overlap, that is most of the work.
+    void drop_tail_and_reindex(std::size_t keep) {
+        auto const n = m_values.size();
+        if (keep == n) {
+            // nothing was taken, so the index still describes the values exactly
+            return;
+        }
+        // Counted rather than "while size() > keep": the compaction above does not change the size,
+        // so the count is known, and the container is only required to have pop_back -- vector's
+        // resize(n) would need the value type to be default constructible, which nothing else here
+        // asks of it, and segmented_vector has no erase(first, last) to take a range out with.
+        for (auto k = n; k > keep; --k) {
+            m_values.pop_back();
+        }
+        clear_buckets();
+        fill_buckets_from_values();
+    }
+
+    // As above for the path that has gaps to close first. Kept apart from it because the walk's
+    // normal exit has none by construction, and folding the two would inline a compaction loop that
+    // can never run into the merge's hot path.
+    void compact_and_reindex(std::size_t keep, std::size_t from) {
+        auto const n = m_values.size();
+        for (auto i = from; i < n; ++i, ++keep) {
+            if (keep != i) {
+                m_values[keep] = std::move(m_values[i]);
+            }
+        }
+        drop_tail_and_reindex(keep);
+    }
+
+    // The engine behind merge(). One pass over the source's values, taking every element whose key
+    // is not here already and compacting the ones left behind down over the gaps.
+    //
+    // Compaction rather than the backfill erase() does, because the two have opposite best cases and
+    // this one's best case is the common one: a merge of sources that barely overlap takes nearly
+    // every element, so there is nearly nothing left to compact, where a backfill moves one element
+    // for every element it takes.
+    //
+    // The probe and the placement are written out here rather than calling do_insert_hashed, and the
+    // reason is the repair below. A throw out of the probe -- the hash, or the key compare -- leaves
+    // the source's element untouched, and a throw out of the placement leaves a husk the source must
+    // not keep, because a moved-from key can collide with a key that is still there and the source
+    // would then hold two elements that compare equal. Inside do_insert_hashed that boundary is not
+    // visible from outside.
+    template <typename Source>
+    void do_merge(Source& source) {
+        if constexpr (std::is_same_v<Source, table>) {
+            // "if (this == &source) there are no effects", which is worth honouring for its own sake
+            // and not only because the walk below would be reading a container it is emptying
+            if (this == &source) {
+                return;
+            }
+        }
+        if (source.empty()) {
+            // Ahead of allocate_buckets_if_none() and load-bearing there: without it, merging an
+            // empty source into a default constructed map allocates that map an index it never asked
+            // for. do_erase_key owns its own emptiness check for the same reason.
+            return;
+        }
+        allocate_buckets_if_none();
+        auto& src_values = source.m_values;
+        auto const n = src_values.size();
+        auto keep = std::size_t{0};
+        // The first element the source still owns, which is the one thing the repair below needs to
+        // know and the one thing an exception cannot tell it: a throw out of the probe leaves this
+        // element untouched and the source keeps it, a throw out of the placement leaves a husk it
+        // must drop. Advancing it *before* the placement rather than after the iteration is what says
+        // which, and it costs the loop nothing because it is the loop counter.
+        auto i = std::size_t{0};
+
+        // Hashed ahead of where it is placing, the same ring the range insert uses and for the same
+        // reason -- the source's elements are all in hand, so the hash of a later one can be computed
+        // while this one waits for its block. The compaction underneath cannot disturb it: the only
+        // writes go to keep, which never passes i, and the ring reads at i + pipeline_depth.
+        //
+        // Gated, like replace()'s ring and unlike the range insert's, because the loss below the
+        // crossover is not inside the noise here. Medians of five, ring over the same loop with the
+        // ring taken out, at no overlap / half / nine tenths: 1.09 / 1.10 / 1.14 at a source of a
+        // thousand, 1.07 / 1.11 / 1.11 at four thousand, 1.01 / 1.05 / 1.06 at sixteen thousand,
+        // then 0.91 / 0.94 / 0.97 at sixty-four thousand, 0.83 / 0.82 / 0.89 at a quarter million and
+        // 0.80 / 0.70 / 0.73 at two million. So the crossover is within a doubling of the 256 KB
+        // replace() measured, on a loop with a different body -- which is what says that number
+        // belongs to the cache and not to either loop. The gate opens at the low end of that window,
+        // which costs 2-3% in the one octave between; a constant of merge's own would be fitting
+        // noise.
+        //
+        // Measured against the index the destination will end up with rather than the one it has:
+        // every source element is new until the probe says otherwise, so this bounds it from above,
+        // and reading today's index instead gets the case the ring is most for -- a large source into
+        // a small map, where nothing is in cache and everything moves -- exactly wrong.
+        auto const pipelined = wants_pipeline(calc_shifts_for_size(size() + n));
+        auto ring = std::array<std::uint64_t, pipeline_depth>{};
+        // The group array is handed in rather than read here: it has to be read fresh once per
+        // element, because placing one may grow the index and move it, but the prefetch and the probe
+        // that follows it are separated by nothing that can grow it -- so once, not twice.
+        auto const fetch = [&](typename bucket_container_type::block const* groups, std::size_t slot, std::size_t at) -> void {
+            auto const mh = mixed_hash(get_key(src_values[at]));
+            ring[slot] = mh;
+            prefetch_block(groups, std::size_t{group_idx_from_hash(mh)});
+        };
+        if (pipelined) {
+            auto const* const groups = m_buckets.data();
+            for (auto s = std::size_t{0}; s < pipeline_depth && s < n; ++s) {
+                // Outside the repair below on purpose: nothing has been moved yet, so a hash that
+                // throws here leaves the source exactly as it was.
+                fetch(groups, s, s);
+            }
+        }
+
+        // Two loops out of one body rather than one loop with the gate inside it. A runtime branch
+        // is the obvious way to write this and costs the gated-off case nearly the whole difference
+        // the gate was there to save -- 5.09 ns at four thousand elements and half of them
+        // overlapping, against 4.63 for the same loop with the ring taken out. A perfectly predicted
+        // branch is not free when a ring, a lambda and an array hang off it and the loop has to keep
+        // them live. Two instantiations read 1.02 / 1.01 / 0.99 of the ringless loop there, and
+        // 1.05 / 0.96 / 1.00 at a thousand.
+        auto const walk = [&](auto is_pipelined) -> void {
+            while (i < n) {
+                auto& value = src_values[i];
+                auto const* const groups = m_buckets.data();
+                auto mh = std::uint64_t{};
+                if constexpr (decltype(is_pipelined)::value) {
+                    // this element's hash out of the ring before the slot it frees is refilled
+                    auto const slot = i % pipeline_depth;
+                    mh = ring[slot];
+                    if (i + pipeline_depth < n) {
+                        fetch(groups, slot, i + pipeline_depth);
+                    }
+                } else {
+                    mh = mixed_hash(get_key(value));
+                }
+                // taken apart once for both halves, exactly as do_insert_hashed does it
+                auto const word = fingerprint_word(mh);
+                auto const counter = word & 7U;
+                auto const home_idx = group_idx_from_hash(mh);
+                auto const r = probe_at_home(get_key(value), word, counter, groups[home_idx], home_idx);
+                if (r.found) {
+                    // Stays behind. merge() is a writing operation, so a hit here pays for its own
+                    // drift the same way one inside try_emplace does.
+                    move_home(r.slot, mh);
+                    if (keep != i) {
+                        src_values[keep] = std::move(value);
+                    }
+                    ++keep;
+                    ++i;
+                    continue;
+                }
+                ++i; // this one is leaving, however the placement below ends
+                place_element_at(word, counter, home_idx, std::move(value));
+            }
+        };
+
+        auto const walk_either = [&]() -> void {
+            if (pipelined) {
+                walk(std::true_type{});
+            } else {
+                walk(std::false_type{});
+            }
+        };
+        if constexpr (ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()) {
+            try {
+                walk_either();
+            } catch (...) {
+                // The source's index stopped describing its values at the first element taken, and
+                // the source is a container the caller still owns and did not hand over. Putting it
+                // back together is what keeps the throw at the basic guarantee instead of leaving a
+                // map whose next lookup reads an index into elements that have gone.
+                source.compact_and_reindex(keep, i);
+                throw;
+            }
+        } else {
+            walk_either();
+        }
+        source.drop_tail_and_reindex(keep);
+    }
+
     template <typename K, typename... Args>
     auto do_try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
         allocate_buckets_if_none();
@@ -3105,8 +3316,9 @@ public:
         // pipeline_min_bytes. Getting it wrong in the safe direction (a machine with more L2) costs
         // at most that 1.20x on one octave of sizes; omitting the gate costs it on every size below
         // a quarter million.
-        auto const index_bytes = (std::size_t{m_group_mask} + 1) * sizeof(typename bucket_container_type::block);
-        if (m_values.size() > pipeline_depth + 1 && index_bytes > pipeline_min_index_bytes) {
+        // m_shifts describes the array that was just allocated or kept above, so this is the index
+        // the dedup will actually run against.
+        if (m_values.size() > pipeline_depth + 1 && wants_pipeline(m_shifts)) {
             do_replace_pipelined(value_idx);
         }
 
@@ -3411,6 +3623,26 @@ public:
         swap(m_hash, other.m_hash);
         swap(m_equal, other.m_equal);
         swap(m_shifts, other.m_shifts);
+    }
+
+    // Every element of source whose key is not here already moves over; the rest stay behind. The
+    // source may hash and compare differently -- that is the overload std::unordered_map has, and
+    // the keys are re-hashed with this table's hasher on the way in.
+    //
+    // Two differences from the standard's merge are worth knowing, and both follow from the elements
+    // living in a vector rather than in nodes. References and iterators into *either* table are
+    // invalidated, where a node splice preserves the ones into the elements it moves; and the
+    // source's order changes, because every element taken out of the middle of it leaves a gap that
+    // the elements behind it close. erase() already carries both, and this is the same mechanism.
+    template <class H2, class KE2>
+    void merge(sibling_table<H2, KE2>& source) {
+        do_merge(source);
+    }
+
+    template <class H2, class KE2>
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+    void merge(sibling_table<H2, KE2>&& source) {
+        merge(source);
     }
 
     // lookup /////////////////////////////////////////////////////////////////

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1468,12 +1468,27 @@ private:
     // a 1032 byte value the footprint model opens the gate at ten thousand elements, where the
     // pipeline is a **14% loss**. Both value sizes cross over at the same index size instead.
     //
-    // Two callers, replace() and merge(), each with its own sweep beside it; they were measured
-    // separately and landed on the same number, which is what says it belongs to the cache and not to
-    // either loop. The range insert and the bulk visit were measured against the same question and
-    // neither wants a gate; the visit's crossover is set by the caller's hit rate, which the map does
-    // not know until it has already done a chunk's worth of work. Issues #247 and #242.
+    // replace()'s threshold; see the sweep beside its only use. The range insert and the bulk visit
+    // were measured against the same question and neither wants a gate at all; the visit's crossover
+    // is set by the caller's hit rate, which the map does not know until it has already done a
+    // chunk's worth of work. Issue #247.
     static constexpr std::size_t pipeline_min_index_bytes = std::size_t{256} << 10U;
+
+    // merge()'s, and it is two doublings higher than replace()'s rather than the same number -- which
+    // was the first guess, and wrong. A gate's crossover is where the ring's fixed cost per element
+    // stops being worth the misses it hides, so it moves with what the *rest* of the loop costs, and
+    // merge's walk is cheaper per element than replace()'s dedup. Measured on this loop, ring over
+    // the same loop with the ring deleted, at no overlap / half / nine tenths of it duplicated:
+    //
+    //     352 KiB of index   1.068 / 1.119 / 1.086   a clear loss
+    //     704 KiB            1.019 / 1.043 / 1.031 and 0.994 / 1.014 / 1.050 at two load factors
+    //    1408 KiB            0.966 / 0.988 / 0.986 and 0.927 / 0.968 / 1.005
+    //    2816 KiB            0.921 / 0.926 / 0.956
+    //     22 MiB             0.812 / 0.749 / 0.769
+    //
+    // The index doubles, so anything inside (704 KiB, 1408 KiB] switches at the same places; a
+    // mebibyte sits in the middle of that window with a doubling of margin either side. Issue #242.
+    static constexpr std::size_t merge_min_index_bytes = std::size_t{1} << 20U;
 
     static constexpr std::uint8_t initial_shifts = 64 - 2; // 2^(64-m_shifts) groups
     static constexpr float default_max_load_factor = 0.8F;
@@ -2032,12 +2047,11 @@ private:
         return calc_num_groups(shifts) * slots_per_group;
     }
 
-    // Whether a bulk loop over an index of this shape is worth pipelining; see
-    // pipeline_min_index_bytes for the measurement. One reader for the threshold, so that the two
-    // gated loops cannot drift apart -- they differ in *which* index they ask about, which is the
-    // shifts they pass, and in nothing else.
-    [[nodiscard]] static constexpr auto wants_pipeline(std::uint8_t shifts) -> bool {
-        return calc_num_groups(shifts) * sizeof(typename bucket_container_type::block) > pipeline_min_index_bytes;
+    // How much index an array with these shifts is, which is what both pipeline gates are measured
+    // against. One spelling of the quantity; the threshold is the gated loop's own, because the two
+    // do not have the same one.
+    [[nodiscard]] static constexpr auto index_bytes_for(std::uint8_t shifts) -> std::size_t {
+        return calc_num_groups(shifts) * sizeof(typename bucket_container_type::block);
     }
 
     [[nodiscard]] constexpr auto calc_shifts_for_size(std::size_t s) const -> std::uint8_t {
@@ -2688,50 +2702,61 @@ private:
         allocate_buckets_if_none();
         auto& src_values = source.m_values;
         auto const n = src_values.size();
-        auto keep = std::size_t{0};
-        // The first element the source still owns, which is the one thing the repair below needs to
-        // know and the one thing an exception cannot tell it: a throw out of the probe leaves this
-        // element untouched and the source keeps it, a throw out of the placement leaves a husk it
-        // must drop. Advancing it *before* the placement rather than after the iteration is what says
-        // which, and it costs the loop nothing because it is the loop counter.
-        auto i = std::size_t{0};
+        // Three cursors rather than three indices, and it is the same reason fill_buckets_from_values
+        // gives at length: placing an element stores a fingerprint, a std::uint8_t store may alias any
+        // object at all including the container's own data pointer, so every indexed read after a
+        // placement has to load that pointer back before it can even form the next element's address.
+        // An iterator is already the address. Worth 0.89 to 0.95 of the indexed loop in cache (four
+        // thousand elements, no overlap / half / nine tenths: 0.92 / 0.89 / 0.91) and 0.95 to 1.00
+        // above it, 26 of 27 cells, and 2 to 4.5 fewer instructions retired per element at every size.
+        //
+        // The source never changes size while the walk runs -- the repair at the end is what shrinks
+        // it -- so all three stay valid, and the destination's growth cannot reach them.
+        auto const first = src_values.begin();
+        auto const last = src_values.end();
+        auto read = first;  // the element being handled; also what the repair calls `from`
+        auto write = first; // where the next survivor goes; also what the repair calls `keep`
+        auto look = first;  // the element being hashed ahead
+        // `read` is the first element the source still owns, which is the one thing the repair below
+        // needs to know and the one thing an exception cannot tell it: a throw out of the probe leaves
+        // this element untouched and the source keeps it, a throw out of the placement leaves a husk
+        // it must drop. Advancing it *before* the placement rather than after the iteration is what
+        // says which, and it costs the loop nothing because it is the loop's own cursor.
 
         // Hashed ahead of where it is placing, the same ring the range insert uses and for the same
         // reason -- the source's elements are all in hand, so the hash of a later one can be computed
         // while this one waits for its block. The compaction underneath cannot disturb it: the only
-        // writes go to keep, which never passes i, and the ring reads at i + pipeline_depth.
+        // writes go to `write`, which never passes `read`, and the ring reads at `look`, which is
+        // pipeline_depth ahead of it.
         //
         // Gated, like replace()'s ring and unlike the range insert's, because the loss below the
-        // crossover is not inside the noise here. Medians of five, ring over the same loop with the
-        // ring taken out, at no overlap / half / nine tenths: 1.09 / 1.10 / 1.14 at a source of a
-        // thousand, 1.07 / 1.11 / 1.11 at four thousand, 1.01 / 1.05 / 1.06 at sixteen thousand,
-        // then 0.91 / 0.94 / 0.97 at sixty-four thousand, 0.83 / 0.82 / 0.89 at a quarter million and
-        // 0.80 / 0.70 / 0.73 at two million. So the crossover is within a doubling of the 256 KB
-        // replace() measured, on a loop with a different body -- which is what says that number
-        // belongs to the cache and not to either loop. The gate opens at the low end of that window,
-        // which costs 2-3% in the one octave between; a constant of merge's own would be fitting
-        // noise.
+        // crossover is not inside the noise: 1.10 / 1.19 / 1.14 of the ringless loop at a source of a
+        // thousand elements, at no overlap / half / nine tenths. See merge_min_index_bytes for where
+        // the crossover is and why it is not replace()'s number. With the gate in, the same
+        // comparison reads 0.97 / 0.97 / 1.00 there and 0.81 / 0.75 / 0.77 at two million: the worst
+        // cell anywhere on the sweep is 1.009.
         //
         // Measured against the index the destination will end up with rather than the one it has:
         // every source element is new until the probe says otherwise, so this bounds it from above,
         // and reading today's index instead gets the case the ring is most for -- a large source into
         // a small map, where nothing is in cache and everything moves -- exactly wrong.
-        auto const pipelined = wants_pipeline(calc_shifts_for_size(size() + n));
+        auto const pipelined = index_bytes_for(calc_shifts_for_size(size() + n)) > merge_min_index_bytes;
         auto ring = std::array<std::uint64_t, pipeline_depth>{};
         // The group array is handed in rather than read here: it has to be read fresh once per
         // element, because placing one may grow the index and move it, but the prefetch and the probe
         // that follows it are separated by nothing that can grow it -- so once, not twice.
-        auto const fetch = [&](typename bucket_container_type::block const* groups, std::size_t slot, std::size_t at) -> void {
-            auto const mh = mixed_hash(get_key(src_values[at]));
+        auto const fetch =
+            [&](typename bucket_container_type::block const* groups, std::size_t slot, value_type const& value) -> void {
+            auto const mh = mixed_hash(get_key(value));
             ring[slot] = mh;
             prefetch_block(groups, std::size_t{group_idx_from_hash(mh)});
         };
         if (pipelined) {
             auto const* const groups = m_buckets.data();
-            for (auto s = std::size_t{0}; s < pipeline_depth && s < n; ++s) {
+            for (auto s = std::size_t{0}; s < pipeline_depth && look != last; ++s, ++look) {
                 // Outside the repair below on purpose: nothing has been moved yet, so a hash that
                 // throws here leaves the source exactly as it was.
-                fetch(groups, s, s);
+                fetch(groups, s, *look);
             }
         }
 
@@ -2740,20 +2765,21 @@ private:
         // the gate was there to save -- 5.09 ns at four thousand elements and half of them
         // overlapping, against 4.63 for the same loop with the ring taken out. A perfectly predicted
         // branch is not free when a ring, a lambda and an array hang off it and the loop has to keep
-        // them live. Two instantiations read 1.02 / 1.01 / 0.99 of the ringless loop there, and
-        // 1.05 / 0.96 / 1.00 at a thousand.
+        // them live.
         auto const walk = [&](auto is_pipelined) -> void {
-            while (i < n) {
-                auto& value = src_values[i];
+            auto slot = std::size_t{0};
+            while (read != last) {
+                auto& value = *read;
                 auto const* const groups = m_buckets.data();
                 auto mh = std::uint64_t{};
                 if constexpr (decltype(is_pipelined)::value) {
                     // this element's hash out of the ring before the slot it frees is refilled
-                    auto const slot = i % pipeline_depth;
                     mh = ring[slot];
-                    if (i + pipeline_depth < n) {
-                        fetch(groups, slot, i + pipeline_depth);
+                    if (look != last) {
+                        fetch(groups, slot, *look);
+                        ++look;
                     }
+                    slot = (slot + 1) % pipeline_depth;
                 } else {
                     mh = mixed_hash(get_key(value));
                 }
@@ -2766,14 +2792,14 @@ private:
                     // Stays behind. merge() is a writing operation, so a hit here pays for its own
                     // drift the same way one inside try_emplace does.
                     move_home(r.slot, mh);
-                    if (keep != i) {
-                        src_values[keep] = std::move(value);
+                    if (write != read) {
+                        *write = std::move(value);
                     }
-                    ++keep;
-                    ++i;
+                    ++write;
+                    ++read;
                     continue;
                 }
-                ++i; // this one is leaving, however the placement below ends
+                ++read; // this one is leaving, however the placement below ends
                 place_element_at(word, counter, home_idx, std::move(value));
             }
         };
@@ -2793,13 +2819,13 @@ private:
                 // the source is a container the caller still owns and did not hand over. Putting it
                 // back together is what keeps the throw at the basic guarantee instead of leaving a
                 // map whose next lookup reads an index into elements that have gone.
-                source.compact_and_reindex(keep, i);
+                source.compact_and_reindex(static_cast<std::size_t>(write - first), static_cast<std::size_t>(read - first));
                 throw;
             }
         } else {
             walk_either();
         }
-        source.drop_tail_and_reindex(keep);
+        source.drop_tail_and_reindex(static_cast<std::size_t>(write - first));
     }
 
     template <typename K, typename... Args>
@@ -3318,7 +3344,7 @@ public:
         // a quarter million.
         // m_shifts describes the array that was just allocated or kept above, so this is the index
         // the dedup will actually run against.
-        if (m_values.size() > pipeline_depth + 1 && wants_pipeline(m_shifts)) {
+        if (m_values.size() > pipeline_depth + 1 && index_bytes_for(m_shifts) > pipeline_min_index_bytes) {
             do_replace_pipelined(value_idx);
         }
 

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -323,18 +323,18 @@ Ratios, shipped over the caller's loop, at overlaps 0 / 25 / 50 / 75 / 90 / 100%
 
 | source | 0% | 25% | 50% | 75% | 90% | 100% |
 |---|---|---|---|---|---|---|
-| `uint64_t`, 4000 | 0.504 | 0.596 | 0.634 | 0.922 | **1.228** | 1.031 |
-| `uint64_t`, 64000 | 0.412 | 0.493 | 0.512 | 0.735 | 0.992 | 0.943 |
-| `uint64_t`, 1000000 | 0.511 | 0.575 | 0.510 | 0.604 | 0.750 | 0.749 |
-| `std::string`, 4000 | 0.464 | | 0.615 | | **1.113** | |
-| `std::string`, 64000 | 0.443 | | 0.542 | | 0.916 | |
-| `std::string`, 500000 | 0.551 | | 0.611 | | 0.826 | |
+| `uint64_t`, 4000 | 0.453 | 0.546 | 0.551 | 0.811 | **1.077** | 0.901 |
+| `uint64_t`, 64000 | 0.413 | 0.487 | 0.495 | 0.689 | 0.917 | 0.879 |
+| `uint64_t`, 1000000 | 0.506 | 0.569 | 0.498 | 0.597 | 0.733 | 0.713 |
+| `std::string`, 4000 | 0.459 | | 0.576 | | **1.053** | |
+| `std::string`, 64000 | 0.431 | | 0.526 | | 0.878 | |
+| `std::string`, 500000 | 0.556 | | 0.609 | | 0.825 | |
 
-So **2x to 2.4x where a merge normally is** -- two sets that mostly do not overlap -- and one corner
-where it loses: a small table whose source is nine tenths duplicates of it. That corner is exactly the
-backfill's best case and the compaction's worst, and it closes on its own as the map grows (1.23 at
-four thousand, 0.99 at sixty-four thousand, 0.75 at a million), because above cache the loop's second
-and third hash cost more than a rebuild does.
+So **1.8x to 2.4x where a merge normally is** -- two sets that mostly do not overlap -- and one corner
+where it still loses: a small table whose source is nine tenths duplicates of it, by 5 to 8%. That
+corner is exactly the backfill's best case and the compaction's worst, and it closes on its own as the
+map grows (1.08 at four thousand, 0.92 at sixty-four thousand, 0.73 at a million), because above cache
+the loop's second and third hash cost more than a rebuild does.
 
 It is not fixed, and the reason is worth keeping: choosing between the two strategies needs the
 overlap, and the overlap is not known until the probes that measure it have been paid. A pre-pass that
@@ -342,36 +342,49 @@ probes without moving would have to carry every element's hash into the second p
 anything -- eight bytes of scratch per source element -- or hash the taken elements twice, which is
 the common case paying for the rare one.
 
-*The ring.* The walk is the fifth `pipeline_depth` ring in the file, hashing sixteen elements ahead
-of the one it places, and it is gated on index bytes like `replace()`'s. Three binaries built from the
-same header -- ring deleted, ring always, ring gated -- alternated, medians of five, at overlaps
-0 / 50 / 90%:
+*The ring, and the gate's constant is not `replace()`'s.* The walk is the fifth `pipeline_depth` ring
+in the file, hashing sixteen elements ahead of the one it places, and it is gated on index bytes the
+way `replace()`'s is -- but **two doublings higher**, which was got wrong first. Three binaries built
+from the same header -- ring deleted, ring always, ring gated -- alternated, medians of five, at
+overlaps 0 / 50 / 90%:
 
-| source | ring / no ring | gated / no ring |
-|---|---|---|
-| 1000 | 1.09 / 1.10 / 1.14 | 1.05 / 0.96 / 1.00 |
-| 4000 | 1.07 / 1.11 / 1.11 | 1.02 / 1.01 / 0.99 |
-| 16000 | 1.01 / 1.05 / 1.06 | 0.98 / 1.03 / 1.03 |
-| 64000 | 0.91 / 0.94 / 0.97 | 0.89 / 0.91 / 0.95 |
-| 256000 | 0.83 / 0.82 / 0.89 | 0.83 / 0.81 / 0.88 |
-| 2000000 | 0.80 / 0.70 / 0.73 | 0.80 / 0.72 / 0.74 |
+| source | end index | ring / no ring | gated / no ring |
+|---|---|---|---|
+| 1000 | 22 KiB | 1.10 / 1.19 / 1.14 | 0.97 / 0.97 / 1.00 |
+| 16000 | 352 KiB | 1.07 / 1.12 / 1.09 | 0.99 / 1.01 / 1.00 |
+| 32000 | 704 KiB | 1.02 / 1.06 / 1.02 | 0.99 / 1.01 / 0.99 |
+| 64000 | 1408 KiB | 0.96 / 0.98 / 0.99 | 0.96 / 0.99 / 0.98 |
+| 128000 | 2816 KiB | 0.92 / 0.92 / 0.97 | 0.92 / 0.92 / 0.97 |
+| 2000000 | 44 MiB | 0.81 / 0.74 / 0.77 | 0.81 / 0.75 / 0.77 |
 
-The crossover is **within a doubling of the 256 KB of index `replace()` measured**, on a loop with a
-different body -- which is the evidence that the constant belongs to the cache and not to either loop.
-It is not exactly the same: the gate opens at sixteen thousand elements a side, where the ring is
-still 1 to 6% down, and does not pay until sixty-four thousand. That octave costs 2-3%, and a constant
-of `merge`'s own to recover it would be fitting one measurement at the resolution this file books as
-layout luck. The gate reads the index the destination will *end* with,
-`calc_shifts_for_size(size() + source.size())`, and not the one it has: the case the ring is most for
-is a large source going into a small map, where the index it has says nothing about the one the walk
-will run against.
+The crossover is at **704 KiB to 1408 KiB of index**, not `replace()`'s 256 KB, and the first version
+of this entry claimed otherwise on a reading taken before the walk was written with cursors. The
+correction is the useful part: a gate's crossover is where the ring's fixed 13-17 instructions per
+element stop being worth the misses they hide, so it moves with what the *rest* of the loop costs --
+and making the ringless loop 5 to 11% cheaper pushed `merge`'s crossover two doublings up. A shared
+constant would now cost 7 to 12% in the octave at 352 KiB. `merge_min_index_bytes` is a mebibyte, in
+the middle of the window with a doubling of margin on each side, and with the gate in, the worst cell
+anywhere on the sweep is **1.009**.
+
+The gate reads the index the destination will *end* with,
+`index_bytes_for(calc_shifts_for_size(size() + source.size()))`, and not the one it has: the case the
+ring is most for is a large source going into a small map, where the index it has says nothing about
+the one the walk will run against.
+
+*Three cursors, not three indices.* The walk holds `read`, `write` and `look` as iterators. Indexing
+`src_values[i]` is the trap `fill_buckets_from_values` records at length -- placing an element stores
+a fingerprint, a `std::uint8_t` store may alias the container's own data pointer, and every indexed
+read after a placement therefore has to load that pointer back before it can form the next address.
+Alternated against the indexed version of the same loop: **0.89 to 0.95 in cache** (0.92 / 0.89 / 0.91
+at four thousand elements) and 0.95 to 1.00 above it, 26 of 27 cells at or below 1.00, and 2.0 to 4.5
+fewer instructions retired per element at every size. It was written with indices first and the
+review caught it.
 
 *The gate has to be two loops, not a branch.* Written the obvious way -- the gate read per element --
 the gated-off sizes came back at 4.80 ns against 4.53 for the same loop with the ring deleted, losing
 5 to 10% at every size below the crossover, which is most of what the gate was there to save. A
 perfectly predicted branch is not free when a ring, a lambda and an array hang off it and the loop has
-to keep them live. `walk(std::true_type{})` against `walk(std::false_type{})` is the column above,
-within 5% of the ringless loop and on both sides of it.
+to keep them live. `walk(std::true_type{})` against `walk(std::false_type{})` is the column above.
 
 *`reserve(size() + source.size())` was measured and declined*, which is #248's answer arrived at from
 the other direction. The bound is exact -- a merge cannot end up larger than that -- and it is still a
@@ -383,21 +396,21 @@ the map cannot tell apart from it, on top of holding an index and a value vector
 the map ended up needing. Growth doubling is the right answer here for the same reason it is in
 `insert(first, last)`.
 
-*Mutation.* 95 mutants over the diff, **87% killed**, 55 of them by a test. The first run killed only 62%
+*Mutation.* 113 mutants over the whole change, **84% killed**, 55 of them by a test. The first run killed only 62%
 and said why: nothing reached the pipelined half of the walk, because the whole test file was below
 the 256 KB gate -- `delete: walk(std::true_type{})` survived. A test whose *destination* carries the
 size and whose source is nought to forty elements long turns the ring on cheaply and puts an edge on
 the priming loop at the same time. The rest of the gap was the exception repair: a moved-from
 `merge_bomb` that keeps its value makes "the source kept a husk" invisible, so the bomb now marks what
 it moved from, and a throwing *key compare* was added because the move bomb can only ever produce the
-drop-it case and never the keep-it one. The twelve that survive are all one class -- behaviour-identical
-by construction, so no correctness test can see them: seven are the arithmetic of the two pipeline
-gates (`wants_pipeline` and its two callers), one is `move_home`, which only moves an element back
-towards its home group, one is the `-fno-exceptions` arm that the test build does not compile, and two
-are early exits whose only effect is to skip work that would have produced the same answer. The
-self-merge guard is one of those, and the reason is worth knowing: without it the walk finds every key
-in itself, keeps every element, and rebuilds nothing, so it is O(n) of wasted probing rather than a
-wrong answer.
+drop-it case and never the keep-it one. The eighteen that survive are all one class -- behaviour-identical by
+construction, so no correctness test can see them, and nothing in the walk itself is among them.
+Fourteen are the two pipeline gates: their thresholds, `index_bytes_for`'s multiply, and the two
+comparisons. One is `move_home`, which only moves an element back towards its home group. One is the
+`-fno-exceptions` arm that the test build does not compile. Two are early exits whose only effect is
+to skip work that would have produced the same answer -- the self-merge guard is one, and the reason
+is worth knowing: without it the walk finds every key in itself, keeps every element and rebuilds
+nothing, so it is O(n) of wasted probing rather than a wrong answer.
 
 *What the source keeps.* References and iterators into either map are invalidated, and the source's
 order changes -- every element taken out of the middle leaves a gap the elements behind it close.

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- `merge()`, and why it is not the loop the caller would write
 - `replace()` hashes ahead too, once the reason it could not was looked at properly
 - `insert(first, last)` sizing the table from the range: built, measured, declined
 - The paired harness has a systematic bias on `rmissstr`, about 3.6%
@@ -297,6 +298,112 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**`merge()`, and why it is not the loop the caller would write** (2026-09-11, issue #242,
+`scripts/ab/merge.cpp`, Ryzen 9 7950X, clang 22, medians of five, both maps rebuilt from the same
+input every round and only the merge inside the clock).
+
+The standard specifies `merge` on nodes: it splices them, so references to the elements that move
+stay valid and nothing is copied. A dense map has no nodes, so every element that moves is
+move-constructed into the destination's vector and every element that leaves has to come out of one.
+What was left to decide is how the *source* is repaired, and the two candidates have opposite best
+cases.
+
+*The loop a caller writes* -- `try_emplace` here, `erase(it)` there -- repairs the source's index once
+per element taken. Each repair is a second hash of the key leaving and a third of whichever element
+the backfill drags into the hole, so it costs work per element that **goes**. It also cannot move the
+key out: `erase(it)` hashes the key to find the slot pointing at it, so a loop that moves the key into
+the destination first hands `erase()` a moved-from key, and that probe does not terminate (#254). The
+hand-written version therefore copies every key it takes.
+
+*What shipped* walks the source once, compacts the elements that stay behind down over the gaps the
+taken ones leave, and rebuilds the source's index once at the end. It costs work per element that
+**stays**.
+
+Ratios, shipped over the caller's loop, at overlaps 0 / 25 / 50 / 75 / 90 / 100%:
+
+| source | 0% | 25% | 50% | 75% | 90% | 100% |
+|---|---|---|---|---|---|---|
+| `uint64_t`, 4000 | 0.504 | 0.596 | 0.634 | 0.922 | **1.228** | 1.031 |
+| `uint64_t`, 64000 | 0.412 | 0.493 | 0.512 | 0.735 | 0.992 | 0.943 |
+| `uint64_t`, 1000000 | 0.511 | 0.575 | 0.510 | 0.604 | 0.750 | 0.749 |
+| `std::string`, 4000 | 0.464 | | 0.615 | | **1.113** | |
+| `std::string`, 64000 | 0.443 | | 0.542 | | 0.916 | |
+| `std::string`, 500000 | 0.551 | | 0.611 | | 0.826 | |
+
+So **2x to 2.4x where a merge normally is** -- two sets that mostly do not overlap -- and one corner
+where it loses: a small table whose source is nine tenths duplicates of it. That corner is exactly the
+backfill's best case and the compaction's worst, and it closes on its own as the map grows (1.23 at
+four thousand, 0.99 at sixty-four thousand, 0.75 at a million), because above cache the loop's second
+and third hash cost more than a rebuild does.
+
+It is not fixed, and the reason is worth keeping: choosing between the two strategies needs the
+overlap, and the overlap is not known until the probes that measure it have been paid. A pre-pass that
+probes without moving would have to carry every element's hash into the second pass to be worth
+anything -- eight bytes of scratch per source element -- or hash the taken elements twice, which is
+the common case paying for the rare one.
+
+*The ring.* The walk is the fifth `pipeline_depth` ring in the file, hashing sixteen elements ahead
+of the one it places, and it is gated on index bytes like `replace()`'s. Three binaries built from the
+same header -- ring deleted, ring always, ring gated -- alternated, medians of five, at overlaps
+0 / 50 / 90%:
+
+| source | ring / no ring | gated / no ring |
+|---|---|---|
+| 1000 | 1.09 / 1.10 / 1.14 | 1.05 / 0.96 / 1.00 |
+| 4000 | 1.07 / 1.11 / 1.11 | 1.02 / 1.01 / 0.99 |
+| 16000 | 1.01 / 1.05 / 1.06 | 0.98 / 1.03 / 1.03 |
+| 64000 | 0.91 / 0.94 / 0.97 | 0.89 / 0.91 / 0.95 |
+| 256000 | 0.83 / 0.82 / 0.89 | 0.83 / 0.81 / 0.88 |
+| 2000000 | 0.80 / 0.70 / 0.73 | 0.80 / 0.72 / 0.74 |
+
+The crossover is **within a doubling of the 256 KB of index `replace()` measured**, on a loop with a
+different body -- which is the evidence that the constant belongs to the cache and not to either loop.
+It is not exactly the same: the gate opens at sixteen thousand elements a side, where the ring is
+still 1 to 6% down, and does not pay until sixty-four thousand. That octave costs 2-3%, and a constant
+of `merge`'s own to recover it would be fitting one measurement at the resolution this file books as
+layout luck. The gate reads the index the destination will *end* with,
+`calc_shifts_for_size(size() + source.size())`, and not the one it has: the case the ring is most for
+is a large source going into a small map, where the index it has says nothing about the one the walk
+will run against.
+
+*The gate has to be two loops, not a branch.* Written the obvious way -- the gate read per element --
+the gated-off sizes came back at 4.80 ns against 4.53 for the same loop with the ring deleted, losing
+5 to 10% at every size below the crossover, which is most of what the gate was there to save. A
+perfectly predicted branch is not free when a ring, a lambda and an array hang off it and the loop has
+to keep them live. `walk(std::true_type{})` against `walk(std::false_type{})` is the column above,
+within 5% of the ringless loop and on both sides of it.
+
+*`reserve(size() + source.size())` was measured and declined*, which is #248's answer arrived at from
+the other direction. The bound is exact -- a merge cannot end up larger than that -- and it is still a
+guess, because what it is really predicting is the *overlap*. Reserved over not, at overlaps 0 / 50 /
+100%: 0.837 / 1.257 / 1.604 at sixty-four thousand `uint64_t`, 0.707 / 1.066 / 1.606 at half a
+million, 0.818 / 1.244 / 1.618 at sixty-four thousand strings and 0.870 / 1.103 / **2.629** at half a
+million strings. So it buys 13-30% in the case that needs it least and costs up to 2.6x in the case
+the map cannot tell apart from it, on top of holding an index and a value vector up to twice the size
+the map ended up needing. Growth doubling is the right answer here for the same reason it is in
+`insert(first, last)`.
+
+*Mutation.* 95 mutants over the diff, **87% killed**, 55 of them by a test. The first run killed only 62%
+and said why: nothing reached the pipelined half of the walk, because the whole test file was below
+the 256 KB gate -- `delete: walk(std::true_type{})` survived. A test whose *destination* carries the
+size and whose source is nought to forty elements long turns the ring on cheaply and puts an edge on
+the priming loop at the same time. The rest of the gap was the exception repair: a moved-from
+`merge_bomb` that keeps its value makes "the source kept a husk" invisible, so the bomb now marks what
+it moved from, and a throwing *key compare* was added because the move bomb can only ever produce the
+drop-it case and never the keep-it one. The twelve that survive are all one class -- behaviour-identical
+by construction, so no correctness test can see them: seven are the arithmetic of the two pipeline
+gates (`wants_pipeline` and its two callers), one is `move_home`, which only moves an element back
+towards its home group, one is the `-fno-exceptions` arm that the test build does not compile, and two
+are early exits whose only effect is to skip work that would have produced the same answer. The
+self-merge guard is one of those, and the reason is worth knowing: without it the walk finds every key
+in itself, keeps every element, and rebuilds nothing, so it is O(n) of wasted probing rather than a
+wrong answer.
+
+*What the source keeps.* References and iterators into either map are invalidated, and the source's
+order changes -- every element taken out of the middle leaves a gap the elements behind it close.
+Both are `erase()`'s existing behaviour and both are in `README.md` 3.3.8 rather than left to be
+discovered.
+
 **`replace()` hashes ahead too, once the reason it could not was looked at properly** (2026-09-11,
 issue #244 item 4, asked as "would it be simpler going from back to front"). It was the last bulk
 build path with no lookahead, and the obstacle looked structural: removing a duplicate pulls

--- a/scripts/ab/merge.cpp
+++ b/scripts/ab/merge.cpp
@@ -1,0 +1,103 @@
+// What merge() is worth over the loop a caller would otherwise write.
+//
+// `loop` is that loop: try_emplace here, and on success erase(it) there. It is correct, and it pays
+// the source's index twice for every element it takes -- a second hash of the key leaving, and a
+// third of whichever element the backfill drags into the hole. `merge` takes the same elements and
+// repairs the source once at the end instead, by compacting what stayed behind and rebuilding its
+// index over that.
+//
+// The two maps are rebuilt from the same inputs every round because a merge consumes both of them;
+// only the merge itself is inside the clock. The overlap is the axis that matters: at 0% every
+// element moves and the source ends empty, at 100% nothing moves and both versions do the same
+// probes and no writes at all.
+//
+//   argv: <loop|merge> <n> [rounds] [overlap-percent] [reserve]
+//
+// `reserve` calls reserve(size() + source.size()) before the merge, inside the clock: the merge
+// cannot end up larger than that, and it is the only thing about the result the map knows before it
+// has probed for it.
+//
+// n is the source's size; the destination is built to the same size. Built by hand;
+// -DUDM_MERGE_STR swaps the key for a std::string, which is where re-hashing a key twice costs the
+// most.
+#include <ankerl/unordered_dense.h>
+
+#include <bench/workloads.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+#if defined(UDM_MERGE_STR)
+using key_type = std::string;
+#else
+using key_type = std::uint64_t;
+#endif
+using map_t = ankerl::unordered_dense::map<key_type, std::size_t>;
+
+auto fill(std::vector<std::pair<key_type, std::size_t>> const& from) -> map_t {
+    auto map = map_t();
+    map.insert(from.begin(), from.end());
+    return map;
+}
+} // namespace
+
+int main(int argc, char** argv) {
+    workloads::tame_allocator();
+    auto const how = std::string(argc > 1 ? argv[1] : "merge");
+    auto const n = static_cast<std::size_t>(argc > 2 ? std::strtoull(argv[2], nullptr, 10) : 200000);
+    auto const rounds = static_cast<std::size_t>(argc > 3 ? std::strtoull(argv[3], nullptr, 10) : 20);
+    auto const overlap_pct = static_cast<std::size_t>(argc > 4 ? std::strtoull(argv[4], nullptr, 10) : 0);
+    auto const with_reserve = std::string(argc > 5 ? argv[5] : "") == "reserve";
+
+    // Two key ranges that share exactly overlap_pct of the source: the destination holds
+    // [0, n), the source [n - shared, 2n - shared).
+    auto const shared = n * overlap_pct / 100;
+    auto dest_input = std::vector<std::pair<key_type, std::size_t>>();
+    auto src_input = std::vector<std::pair<key_type, std::size_t>>();
+    for (std::size_t i = 0; i < n; ++i) {
+        dest_input.emplace_back(workloads::key_for<map_t>(i * UINT64_C(0x9E3779B97F4A7C15)), i);
+        src_input.emplace_back(workloads::key_for<map_t>((i + n - shared) * UINT64_C(0x9E3779B97F4A7C15)), i);
+    }
+
+    auto acc = std::size_t{0};
+    auto elapsed = std::chrono::steady_clock::duration{};
+    for (std::size_t round = 0; round < rounds; ++round) {
+        auto dest = fill(dest_input);
+        auto src = fill(src_input);
+
+        auto const started = std::chrono::steady_clock::now();
+        if (with_reserve) {
+            dest.reserve(dest.size() + src.size());
+        }
+        if (how == "merge") {
+            dest.merge(src);
+        } else {
+            for (auto it = src.begin(); it != src.end();) {
+                // The key is copied, not moved, and it has to be: erase(it) hashes the key to find
+                // the slot pointing at it, so a caller that moves the key out first hands erase() a
+                // moved-from key and the probe for a slot that is not on that sequence does not
+                // return. Which is a cost of writing this by hand -- one copy of every key taken --
+                // and the only way around it is extract(it), which hashes the key a third time.
+                if (dest.try_emplace(it->first, std::move(it->second)).second) {
+                    it = src.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
+        elapsed += std::chrono::steady_clock::now() - started;
+        acc += dest.size() * 3 + src.size();
+    }
+    std::printf("%.3f ns/element  %s n=%zu rounds=%zu overlap=%zu%% acc=%zu\n",
+                std::chrono::duration<double, std::nano>(elapsed).count() / static_cast<double>(n * rounds),
+                how.c_str(),
+                n,
+                rounds,
+                overlap_pct,
+                acc / rounds);
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -40,6 +40,7 @@ test_sources = [
     'unit/equal_range.cpp',
     'unit/erase_if.cpp',
     'unit/erase_churn.cpp',
+    'unit/merge.cpp',
     'unit/move_home.cpp',
     'unit/probe_split.cpp',
     'unit/range_insert.cpp',

--- a/test/unit/merge.cpp
+++ b/test/unit/merge.cpp
@@ -1,0 +1,498 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+// merge(source) is the standard's operation on a container that has no nodes: every element of the
+// source whose key is not here already moves over, and the rest stay behind. What can be checked
+// against std::unordered_map is exactly that -- which elements ended where -- and the part the
+// standard does not have to worry about is that the source is *still a map* afterwards, since every
+// element taken out of the middle of it leaves a gap that something else has to close.
+
+namespace {
+
+auto merge_key(size_t i) -> uint64_t {
+    // scrambled, because sequential small integers never collide in the top bits the index uses
+    return static_cast<uint64_t>(i + 1) * UINT64_C(0x9E3779B97F4A7C15);
+}
+
+// Distinguishable per source, so "the element already here wins" is visible in the value and not
+// only in the key.
+auto merge_val(size_t i, int side) -> uint64_t {
+    return static_cast<uint64_t>(i) * 2 + static_cast<uint64_t>(side);
+}
+
+template <typename Map>
+auto merge_sorted(Map const& map) -> std::vector<std::pair<uint64_t, uint64_t>> {
+    auto out = std::vector<std::pair<uint64_t, uint64_t>>(map.begin(), map.end());
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
+// Builds the same two maps twice -- once as the map under test, once as std::unordered_map -- merges
+// both, and requires that the two ended up with the same elements on both sides. Then asks the
+// merged-from map the questions only a rebuilt index can answer.
+template <typename Dest, typename Src = Dest>
+void merge_matches_std(std::vector<size_t> const& dest_ids, std::vector<size_t> const& src_ids) {
+    auto dest = Dest();
+    auto src = Src();
+    auto ref_dest = std::unordered_map<uint64_t, uint64_t>();
+    auto ref_src = std::unordered_map<uint64_t, uint64_t>();
+    for (auto const id : dest_ids) {
+        dest.try_emplace(merge_key(id), merge_val(id, 1));
+        ref_dest.try_emplace(merge_key(id), merge_val(id, 1));
+    }
+    for (auto const id : src_ids) {
+        src.try_emplace(merge_key(id), merge_val(id, 0));
+        ref_src.try_emplace(merge_key(id), merge_val(id, 0));
+    }
+
+    dest.merge(src);
+    ref_dest.merge(ref_src);
+
+    REQUIRE(merge_sorted(dest) == merge_sorted(ref_dest));
+    REQUIRE(merge_sorted(src) == merge_sorted(ref_src));
+
+    // The source lost elements out of the middle of its value container, so its whole index had to
+    // be rebuilt. Every survivor has to be findable and every key that left has to miss -- an index
+    // still pointing at where an element used to be would answer both of those wrong.
+    REQUIRE(src.size() == ref_src.size());
+    for (auto const& [key, value] : ref_src) {
+        auto it = src.find(key);
+        REQUIRE(it != src.end());
+        REQUIRE(it->second == value);
+    }
+    for (auto const id : src_ids) {
+        if (ref_src.count(merge_key(id)) == 0) {
+            REQUIRE(src.find(merge_key(id)) == src.end());
+        }
+    }
+
+    // and it still takes new work: an insert probes the rebuilt index, an erase unwinds it again
+    auto const before = src.size();
+    src.try_emplace(merge_key(1000000), 7);
+    REQUIRE(src.size() == before + 1);
+    REQUIRE(src.at(merge_key(1000000)) == 7U);
+    REQUIRE(src.erase(merge_key(1000000)) == 1U);
+    REQUIRE(src.size() == before);
+    for (auto const& [key, value] : ref_src) {
+        REQUIRE(src.at(key) == value);
+    }
+}
+
+auto merge_ids(size_t first, size_t count) -> std::vector<size_t> {
+    auto out = std::vector<size_t>();
+    for (size_t i = 0; i < count; ++i) {
+        out.push_back(first + i);
+    }
+    return out;
+}
+
+} // namespace
+
+// Over all four container shapes TEST_CASE_MAP covers, which is not decoration here: deque_map's
+// values are not contiguous, and the compaction indexes and pops them; big_map indexes with 64 bits.
+TEST_CASE_MAP("merge_against_std_unordered_map", uint64_t, uint64_t) {
+    // Every source length up to past two lookahead windows, at three overlaps: none, every second
+    // one, and all of them. The lengths matter because the elements that stay behind are compacted
+    // down over the gaps the ones that left made, and where the first gap falls decides how much of
+    // that loop runs at all.
+    for (size_t len = 0; len <= 40; ++len) {
+        merge_matches_std<map_t>(merge_ids(1000, len), merge_ids(0, len)); // disjoint
+        merge_matches_std<map_t>(merge_ids(0, len), merge_ids(0, len));    // identical
+        auto every_second = std::vector<size_t>();
+        for (size_t i = 0; i < len; i += 2) {
+            every_second.push_back(i);
+        }
+        merge_matches_std<map_t>(every_second, merge_ids(0, len));
+    }
+
+    // A source that ends where the destination begins, so the first elements move and the last stay
+    // -- and the other way around, so the compaction starts at the very first element.
+    merge_matches_std<map_t>(merge_ids(500, 500), merge_ids(0, 1000));
+    merge_matches_std<map_t>(merge_ids(0, 500), merge_ids(0, 1000));
+
+    // Enough to grow the destination several times while the merge is running, and enough that the
+    // source's rebuilt index is not a single group.
+    merge_matches_std<map_t>(merge_ids(4000, 1000), merge_ids(0, 5000));
+    merge_matches_std<map_t>(merge_ids(0, 5000), merge_ids(0, 5000));
+    merge_matches_std<map_t>({}, merge_ids(0, 5000));
+}
+
+// The walk hashes sixteen elements ahead of the one it places, and only above a measured amount of
+// index -- 256 KB, which is about 38000 elements between the two maps. Everything above is below that
+// line and never runs the ring at all: without this, deleting the pipelined half of the walk is a
+// mutation no test notices.
+//
+// The destination is what carries the size, so the *source* can be short: a source of nought to forty
+// with the ring switched on is what puts an edge on the priming loop, which primes min(16, n), and on
+// the refill's "is there an element sixteen further along".
+TEST_CASE("merge_reaches_the_pipelined_walk") {
+    // not `map_t`: TEST_CASE_MAP above declares one at namespace scope
+    using piped_map = ankerl::unordered_dense::map<uint64_t, uint64_t>;
+
+    auto const big = merge_ids(0, 40000);
+    for (size_t len : {size_t{0}, size_t{1}, size_t{2}, size_t{15}, size_t{16}, size_t{17}, size_t{31}, size_t{33}}) {
+        merge_matches_std<piped_map>(big, merge_ids(40000, len)); // nothing overlaps
+        merge_matches_std<piped_map>(big, merge_ids(39990, len)); // the first few do
+    }
+
+    // and a source long enough to run the ring in its steady state, half of it already there
+    merge_matches_std<piped_map>(big, merge_ids(20000, 40000));
+    merge_matches_std<piped_map>(big, merge_ids(40000, 40000));
+    merge_matches_std<piped_map>(big, big);
+}
+
+TEST_CASE("merge_with_an_empty_map_on_either_side") {
+    auto empty = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    REQUIRE(empty.bucket_count() == 0U);
+
+    auto full = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    for (size_t i = 0; i < 100; ++i) {
+        full.try_emplace(merge_key(i), merge_val(i, 0));
+    }
+
+    // an empty source leaves everything alone, and must not allocate an index for a map that has
+    // none
+    full.merge(empty);
+    REQUIRE(full.size() == 100U);
+    REQUIRE(empty.empty());
+    REQUIRE(empty.bucket_count() == 0U);
+
+    // Both of them empty, which is the case that says the early exit is an exit and not just a walk
+    // over nothing: a merge that reaches the walk allocates the destination's index on the way in,
+    // and a default constructed map that has been merged into must still have allocated nothing.
+    auto untouched = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    untouched.merge(empty);
+    REQUIRE(untouched.bucket_count() == 0U);
+    REQUIRE(untouched.empty());
+
+    // into a map that has never allocated: every element moves, and the destination has to allocate
+    // on the way
+    auto fresh = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    fresh.merge(full);
+    REQUIRE(fresh.size() == 100U);
+    REQUIRE(full.empty());
+    REQUIRE(full.begin() == full.end());
+    for (size_t i = 0; i < 100; ++i) {
+        REQUIRE(fresh.at(merge_key(i)) == merge_val(i, 0));
+        REQUIRE(full.find(merge_key(i)) == full.end());
+    }
+
+    // the emptied source is still a map
+    full.try_emplace(merge_key(0), 5);
+    REQUIRE(full.size() == 1U);
+    REQUIRE(full.at(merge_key(0)) == 5U);
+}
+
+TEST_CASE("merge_of_a_map_into_itself_has_no_effect") {
+    auto map = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    for (size_t i = 0; i < 200; ++i) {
+        map.try_emplace(merge_key(i), merge_val(i, 0));
+    }
+    auto const before = merge_sorted(map);
+
+    map.merge(map);
+    REQUIRE(map.size() == 200U);
+    REQUIRE(merge_sorted(map) == before);
+
+    map.merge(std::move(map)); // NOLINT(clang-diagnostic-self-move,bugprone-use-after-move)
+    REQUIRE(map.size() == 200U);
+    REQUIRE(merge_sorted(map) == before);
+}
+
+TEST_CASE("merge_takes_an_rvalue_source") {
+    auto dest = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    for (size_t i = 0; i < 50; ++i) {
+        dest.try_emplace(merge_key(i), merge_val(i, 1));
+    }
+    auto src = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    for (size_t i = 25; i < 75; ++i) {
+        src.try_emplace(merge_key(i), merge_val(i, 0));
+    }
+
+    dest.merge(std::move(src));
+    REQUIRE(dest.size() == 75U);
+    // an rvalue source is still only emptied of what moved; the standard's merge does not clear it
+    REQUIRE(src.size() == 25U); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+    for (size_t i = 0; i < 25; ++i) {
+        REQUIRE(src.find(merge_key(i)) == src.end());
+    }
+    for (size_t i = 25; i < 50; ++i) {
+        REQUIRE(src.at(merge_key(i)) == merge_val(i, 0)); // stayed behind, dest had it already
+        REQUIRE(dest.at(merge_key(i)) == merge_val(i, 1));
+    }
+    for (size_t i = 50; i < 75; ++i) {
+        REQUIRE(dest.at(merge_key(i)) == merge_val(i, 0));
+    }
+}
+
+// The standard's overload takes a source that hashes and compares differently, and re-hashes the
+// keys with the destination's hasher on the way in. Here that is a different instantiation of the
+// same class template.
+TEST_CASE("merge_from_a_map_hashed_differently") {
+    struct odd_hash {
+        auto operator()(uint64_t key) const noexcept -> uint64_t {
+            return key ^ UINT64_C(0x1234567890abcdef); // not avalanching, deliberately
+        }
+    };
+
+    using dest_t = ankerl::unordered_dense::map<uint64_t, uint64_t>;
+    using src_t = ankerl::unordered_dense::map<uint64_t, uint64_t, odd_hash>;
+    merge_matches_std<dest_t, src_t>(merge_ids(0, 300), merge_ids(200, 300));
+    merge_matches_std<src_t, dest_t>(merge_ids(0, 300), merge_ids(200, 300));
+}
+
+TEST_CASE("merge_a_set_and_the_segmented_containers") {
+    auto s1 = ankerl::unordered_dense::set<std::string>();
+    auto s2 = ankerl::unordered_dense::set<std::string>();
+    for (size_t i = 0; i < 500; ++i) {
+        s1.insert("key " + std::to_string(i));
+    }
+    for (size_t i = 250; i < 750; ++i) {
+        s2.insert("key " + std::to_string(i));
+    }
+    s1.merge(s2);
+    REQUIRE(s1.size() == 750U);
+    REQUIRE(s2.size() == 250U);
+    for (size_t i = 250; i < 500; ++i) {
+        REQUIRE(s2.count("key " + std::to_string(i)) == 1U);
+    }
+    for (size_t i = 500; i < 750; ++i) {
+        REQUIRE(s2.count("key " + std::to_string(i)) == 0U);
+        REQUIRE(s1.count("key " + std::to_string(i)) == 1U);
+    }
+
+    merge_matches_std<ankerl::unordered_dense::segmented_map<uint64_t, uint64_t>>(merge_ids(0, 700), merge_ids(500, 700));
+
+    auto ss1 = ankerl::unordered_dense::segmented_set<uint64_t>();
+    auto ss2 = ankerl::unordered_dense::segmented_set<uint64_t>();
+    for (size_t i = 0; i < 1000; ++i) {
+        ss1.insert(merge_key(i));
+        ss2.insert(merge_key(i + 500));
+    }
+    ss1.merge(std::move(ss2));
+    REQUIRE(ss1.size() == 1500U);
+    REQUIRE(ss2.size() == 500U); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+    for (size_t i = 500; i < 1000; ++i) {
+        REQUIRE(ss2.count(merge_key(i)) == 1U);
+    }
+    for (size_t i = 1000; i < 1500; ++i) {
+        REQUIRE(ss2.count(merge_key(i)) == 0U);
+    }
+}
+
+namespace {
+
+// A key whose move constructor throws when armed. merge() moves the source's elements into the
+// destination's container, so a throw there catches the source half taken apart: some of its
+// elements have gone, its index no longer describes the ones that are left, and the caller still
+// owns it.
+struct merge_bomb {
+    static constexpr int s_moved_from = -1;
+
+    int m_value = 0;
+    static inline bool s_armed = false; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    merge_bomb() = default;
+
+    explicit merge_bomb(int value)
+        : m_value(value) {}
+
+    merge_bomb(merge_bomb const& other) = default;
+
+    // Marks what it moved from, which is what makes "the source kept a husk" something a test can
+    // see: a real moving type leaves something behind that is not a valid key, and an int that
+    // copies itself would let the map hold the element twice and look fine.
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    merge_bomb(merge_bomb&& other) noexcept(false)
+        : m_value(other.m_value) {
+        other.m_value = s_moved_from;
+        if (s_armed) {
+            throw std::runtime_error("boom");
+        }
+    }
+
+    auto operator=(merge_bomb const& other) -> merge_bomb& = default;
+
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    auto operator=(merge_bomb&& other) noexcept(false) -> merge_bomb& {
+        m_value = other.m_value;
+        return *this;
+    }
+
+    ~merge_bomb() = default;
+
+    auto operator==(merge_bomb const& other) const -> bool {
+        return m_value == other.m_value;
+    }
+};
+
+struct merge_bomb_hash {
+    using is_avalanching = void;
+    auto operator()(merge_bomb const& b) const noexcept -> uint64_t {
+        return ankerl::unordered_dense::hash<int>{}(b.m_value);
+    }
+};
+
+// Everything the map says about itself has to agree: what size() claims, what iterating finds, and
+// what the index can look up. A merge that gave up halfway and left the index behind fails the third
+// of those while passing the first two.
+template <typename Map>
+void merge_check_consistent(Map const& map) {
+    REQUIRE(static_cast<size_t>(std::distance(map.begin(), map.end())) == map.size());
+
+    auto findable = size_t();
+    auto distinct = std::unordered_set<int>();
+    for (int i = 0; i < 200; ++i) {
+        if (map.find(merge_bomb{i}) != map.end()) {
+            ++findable;
+            distinct.insert(i);
+        }
+    }
+    REQUIRE(findable == map.size());
+    REQUIRE(distinct.size() == map.size()); // no key survived twice, which a kept husk would do
+}
+
+} // namespace
+
+TEST_CASE("merge_survives_a_throwing_move") {
+    using bomb_map = ankerl::unordered_dense::map<merge_bomb, int, merge_bomb_hash>;
+
+    auto dest = bomb_map();
+    auto src = bomb_map();
+    for (int i = 0; i < 40; ++i) {
+        dest.try_emplace(merge_bomb{i}, i);
+    }
+    for (int i = 20; i < 80; ++i) {
+        src.try_emplace(merge_bomb{i}, i);
+    }
+
+    merge_bomb::s_armed = true;
+    REQUIRE_THROWS_AS(dest.merge(src), std::runtime_error);
+    merge_bomb::s_armed = false;
+
+    // The element whose move threw is half moved and belongs to nobody: the destination never
+    // finished building it and the source must not keep what is left, because a moved-from key is
+    // not a key. Keeping it is the mistake this checks for, and it is invisible unless a moved-from
+    // bomb says so.
+    REQUIRE(src.find(merge_bomb{merge_bomb::s_moved_from}) == src.end());
+    REQUIRE(dest.find(merge_bomb{merge_bomb::s_moved_from}) == dest.end());
+
+    // Both halves are still maps. How far the merge got is not fixed -- the throw lands on the first
+    // element that had to move, wherever the source happens to keep it -- so what is checked is the
+    // invariant, plus that the two together still hold every key exactly once.
+    merge_check_consistent(dest);
+    merge_check_consistent(src);
+    auto lost = 0;
+    for (int i = 0; i < 80; ++i) {
+        auto const in_dest = dest.find(merge_bomb{i}) != dest.end();
+        auto const in_src = src.find(merge_bomb{i}) != src.end();
+        if (i < 20) {
+            REQUIRE(in_dest);
+            REQUIRE(!in_src);
+        } else if (i < 40) {
+            REQUIRE(in_dest);
+            REQUIRE(in_src); // an element the destination already had never moves
+        } else {
+            // in exactly one of them, unless it is the one whose move threw, which is gone
+            REQUIRE(!(in_dest && in_src));
+            if (!in_dest && !in_src) {
+                ++lost;
+            }
+        }
+    }
+    // and exactly one is gone, not two: the repair drops the element whose move had begun and has no
+    // licence to drop the one behind it
+    REQUIRE(lost == 1);
+
+    // and both still work
+    src.try_emplace(merge_bomb{123}, 123);
+    dest.try_emplace(merge_bomb{124}, 124);
+    merge_check_consistent(dest);
+    merge_check_consistent(src);
+
+    // finishing the job with the bomb disarmed leaves the source with what the destination had
+    dest.merge(src);
+    merge_check_consistent(dest);
+    merge_check_consistent(src);
+    for (auto const& entry : src) {
+        REQUIRE(dest.find(entry.first) != dest.end());
+    }
+}
+
+namespace {
+
+// A key compare that throws on the nth call. The other half of the repair: a throw out of the *probe*
+// happens before anything has been moved, so the source's element is untouched and has to stay --
+// where a throw out of the placement leaves a husk that has to go. The merge cannot tell which from
+// the exception, so it tracks it, and this is what says the tracking works in the direction the bomb
+// above does not reach.
+struct merge_bomb_equal {
+    static inline int s_countdown = -1; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    auto operator()(merge_bomb const& a, merge_bomb const& b) const -> bool {
+        if (s_countdown >= 0 && s_countdown-- == 0) {
+            throw std::runtime_error("compare");
+        }
+        return a.m_value == b.m_value;
+    }
+};
+
+} // namespace
+
+TEST_CASE("merge_survives_a_throwing_key_compare") {
+    using compare_bomb_map = ankerl::unordered_dense::map<merge_bomb, int, merge_bomb_hash, merge_bomb_equal>;
+
+    // Every count of compares up to a few, so the throw lands at different places in the walk:
+    // before the first element is taken, between two takes, and after the compaction has started.
+    for (int nth = 0; nth < 12; ++nth) {
+        auto dest = compare_bomb_map();
+        auto src = compare_bomb_map();
+        for (int i = 0; i < 40; ++i) {
+            dest.try_emplace(merge_bomb{i}, i);
+        }
+        // Alternating, so that takes and compares interleave: the nth compare then lands after n/2
+        // elements have already been moved out and the compaction is running.
+        for (int i = 0; i < 20; ++i) {
+            src.try_emplace(merge_bomb{20 + i}, i);  // already in dest: one compare, stays
+            src.try_emplace(merge_bomb{100 + i}, i); // not in dest: taken, no compare
+        }
+
+        merge_bomb_equal::s_countdown = nth;
+        REQUIRE_THROWS_AS(dest.merge(src), std::runtime_error);
+        merge_bomb_equal::s_countdown = -1;
+
+        // The throw came out of a compare, so nothing was half moved and nothing may be lost: every
+        // key that went in is still in one map or the other, and neither holds a moved-from one.
+        auto seen = std::unordered_set<int>();
+        for (auto const& entry : dest) {
+            seen.insert(entry.first.m_value);
+        }
+        for (auto const& entry : src) {
+            seen.insert(entry.first.m_value);
+        }
+        REQUIRE(seen.size() == 60U);
+        REQUIRE(seen.count(merge_bomb::s_moved_from) == 0U);
+
+        for (int i = 0; i < 20; ++i) {
+            // the shared keys are in both, wherever the throw landed
+            REQUIRE(dest.find(merge_bomb{20 + i}) != dest.end());
+            REQUIRE(src.find(merge_bomb{20 + i}) != src.end());
+            // and each key of the source's own is in exactly one of them
+            auto const in_dest = dest.find(merge_bomb{100 + i}) != dest.end();
+            auto const in_src = src.find(merge_bomb{100 + i}) != src.end();
+            REQUIRE(in_dest != in_src);
+        }
+        merge_check_consistent(src);
+    }
+}

--- a/test/unit/merge.cpp
+++ b/test/unit/merge.cpp
@@ -129,27 +129,26 @@ TEST_CASE_MAP("merge_against_std_unordered_map", uint64_t, uint64_t) {
 }
 
 // The walk hashes sixteen elements ahead of the one it places, and only above a measured amount of
-// index -- 256 KB, which is about 38000 elements between the two maps. Everything above is below that
-// line and never runs the ring at all: without this, deleting the pipelined half of the walk is a
-// mutation no test notices.
+// index -- merge_min_index_bytes, a mebibyte, which the two maps reach together at about 105000
+// elements. Everything above is below that line and never runs the ring at all: without this,
+// deleting the pipelined half of the walk is a mutation no test notices.
 //
-// The destination is what carries the size, so the *source* can be short: a source of nought to forty
-// with the ring switched on is what puts an edge on the priming loop, which primes min(16, n), and on
-// the refill's "is there an element sixteen further along".
+// The destination is what carries the size, so the *source* can be short: a source of nought to
+// thirty-three with the ring switched on is what puts an edge on the priming loop, which primes
+// min(16, n), and on the refill's "is there an element sixteen further along".
 TEST_CASE("merge_reaches_the_pipelined_walk") {
     // not `map_t`: TEST_CASE_MAP above declares one at namespace scope
     using piped_map = ankerl::unordered_dense::map<uint64_t, uint64_t>;
 
-    auto const big = merge_ids(0, 40000);
-    for (size_t len : {size_t{0}, size_t{1}, size_t{2}, size_t{15}, size_t{16}, size_t{17}, size_t{31}, size_t{33}}) {
-        merge_matches_std<piped_map>(big, merge_ids(40000, len)); // nothing overlaps
-        merge_matches_std<piped_map>(big, merge_ids(39990, len)); // the first few do
+    auto const big = merge_ids(0, 110000);
+    for (size_t len : {size_t{0}, size_t{1}, size_t{15}, size_t{16}, size_t{17}, size_t{33}}) {
+        merge_matches_std<piped_map>(big, merge_ids(110000, len)); // nothing overlaps
+        merge_matches_std<piped_map>(big, merge_ids(109990, len)); // the first few do
     }
 
     // and a source long enough to run the ring in its steady state, half of it already there
-    merge_matches_std<piped_map>(big, merge_ids(20000, 40000));
-    merge_matches_std<piped_map>(big, merge_ids(40000, 40000));
-    merge_matches_std<piped_map>(big, big);
+    merge_matches_std<piped_map>(big, merge_ids(55000, 110000));
+    merge_matches_std<piped_map>(big, merge_ids(110000, 110000));
 }
 
 TEST_CASE("merge_with_an_empty_map_on_either_side") {


### PR DESCRIPTION
Closes #242.

`std::unordered_map::merge` splices nodes. A dense map has none, so every element that moves is move-constructed into the destination's vector and every element that leaves has to come out of one. What was left to decide is how the *source* is repaired, and the two candidates have opposite best cases.

- **The loop a caller writes** — `try_emplace` here, `erase(it)` there — repairs the source's index once per element taken. Each repair is a second hash of the key leaving plus a third of whichever element the backfill drags into the hole, so it costs work per element that **goes**.
- **What this ships** walks the source once, compacts the elements that stay behind down over the gaps, and rebuilds the source's index once at the end. It costs work per element that **stays**.

Ratios, shipped over the caller's loop, medians of five, only the merge inside the clock:

| source | 0% overlap | 25% | 50% | 75% | 90% | 100% |
|---|---|---|---|---|---|---|
| `uint64_t`, 4000 | 0.453 | 0.546 | 0.551 | 0.811 | **1.077** | 0.901 |
| `uint64_t`, 64000 | 0.413 | 0.487 | 0.495 | 0.689 | 0.917 | 0.879 |
| `uint64_t`, 1000000 | 0.506 | 0.569 | 0.498 | 0.597 | 0.733 | 0.713 |
| `std::string`, 4000 | 0.459 | | 0.576 | | **1.053** | |
| `std::string`, 64000 | 0.431 | | 0.526 | | 0.878 | |
| `std::string`, 500000 | 0.556 | | 0.609 | | 0.825 | |

1.8x to 2.4x where a merge normally is, and one corner where it still loses by 5–8%: a small table whose source is nine tenths duplicates of it. That corner is the backfill's best case and the compaction's worst, and it closes on its own as the map grows. Choosing between the two strategies needs the overlap, and the overlap is not known until the probes that measure it have been paid.

## Two corrections that came out of review, in the second commit

**Cursors, not indices.** `fill_buckets_from_values` records at length why a loop that places elements must not index its value container: placing stores a fingerprint, a `uint8_t` store may alias the container's own data pointer, so every indexed read after a placement reloads that pointer before it can form the next address. The walk was written with indices. Holding `read`, `write` and `look` as cursors is **0.89–0.95 in cache**, 0.95–1.00 above it, 26 of 27 cells at or below 1.00, and 2–4.5 fewer instructions retired per element at every size.

**The gate's constant is not `replace()`'s.** That speedup moved the crossover, which is the part worth keeping: a gate's crossover is where the ring's fixed 13–17 instructions per element stop being worth the misses they hide, so it moves with what the *rest* of the loop costs. Ring over the same loop with the ring deleted, on the shipped walk:

| end index | ring / no ring (0/50/90% overlap) | gated / no ring |
|---|---|---|
| 22 KiB | 1.10 / 1.19 / 1.14 | 0.97 / 0.97 / 1.00 |
| 352 KiB | 1.07 / 1.12 / 1.09 | 0.99 / 1.01 / 1.00 |
| 704 KiB | 1.02 / 1.06 / 1.02 | 0.99 / 1.01 / 0.99 |
| 1408 KiB | 0.96 / 0.98 / 0.99 | 0.96 / 0.99 / 0.98 |
| 2816 KiB | 0.92 / 0.92 / 0.97 | 0.92 / 0.92 / 0.97 |
| 44 MiB | 0.81 / 0.74 / 0.77 | 0.81 / 0.75 / 0.77 |

`merge_min_index_bytes` is a mebibyte — two doublings above `replace()`'s 256 KB, in the middle of the crossover window with a doubling of margin either side. Keeping the shared constant would cost 7–12% in the octave at 352 KiB. `index_bytes_for()` is the one spelling of the quantity both gates measure. Worst cell anywhere on the sweep with the gate in: **1.009**.

Also learned: the gate has to be **two instantiations of the body, not a branch inside it** — read per element it costs the gated-off case nearly the whole difference it was there to save, because a predicted branch is not free when a ring, a lambda and a live array hang off it. And the gate must read the index the destination will **end** with, or the case the ring is most for — a large source into a small map — is exactly the one it switches off.

## reserve, measured and declined

`reserve(size() + source.size())`: 0.71–0.87 at no overlap, but 1.06–**2.63** when the maps overlap, plus an index and a value vector up to twice the size the map ends up needing. The bound is exact; what it is really predicting is the overlap. #248's answer, reached from the other direction.

## Contract

README 3.3.8 states it: iterators and references into **either** container are invalidated, the source's order changes, `a.merge(a)` has no effect, the value already in the destination wins, and a throw leaves both containers valid with at most the one element in flight lost. The repair runs on the way out and tracks whether that element was still the source's — a throw from the probe leaves it intact and the source keeps it; a throw from the placement leaves a husk the source must drop, because a moved-from key can compare equal to one still present.

## Verification

- 817 tests pass under clang release, gcc release, ASan and the unity build at chunk size 16; `-fno-exceptions` (clang and gcc), `-std=c++23` and `-m32` compile clean.
- The contract test runs over all four shapes `TEST_CASE_MAP` covers, including `deque_map` (non-contiguous values, which the compaction walks and pops) and `big_map` (64-bit indices).
- Mutation over the whole change: 113 mutants, **84% killed**, 55 by a test. The first run killed 62% and said why — the whole test file was below the gate, so the pipelined half of the walk was never reached. All 18 survivors are behaviour-identical by construction and none is in the walk: fourteen are the two gates' thresholds and comparisons, then `move_home`, the `-fno-exceptions` arm, and two early exits that only skip work.
- No effect on `bench_quick_overall_udm`: `merge` is a member template, so nothing in the score instantiates it.

Evidence and the declined alternatives are in `notes/index-design.md`; `scripts/ab/merge.cpp` is the harness.

Found along the way and filed separately as #254: `slot_of_value()` probes unbounded, so a caller who mutates a key through the map's own mutable iterator and then calls `erase(it)` gets a hang. It is what hung the benchmark's control loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)