### PR TITLE
Walk replace()'s two loops with cursors as well

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,5 +305,14 @@ plain loop back.
 **Walk a value container with iterators, never with an index, in any loop that also places
 elements.** `fill_buckets_from_values` records why — a `uint8_t` fingerprint store may alias the
 container's data pointer, so an indexed read reloads it after every placement, and that is a store-
-to-load chain per element (10.43 → 2.74 ns/insert there). `merge()`'s walk was written with indices
-first and cost 0.89–0.95 for it; `do_insert_range` and the rehash were already iterator-based.
+to-load chain per element (10.43 → 2.74 ns/insert there). `merge()`'s walk cost 0.89–0.95 for being
+written with indices first; `replace()`'s two loops cost 0.68–0.98 over 24 cells. All four loops that
+place are cursor-based now, `do_visit` indexes randomly from the probe and cannot be, and for a
+**string** key the win shows up as cycles with the instruction count flat — there the reload is not
+extra work, it is a latency in front of the next hash.
+
+**But hold one cursor fewer than feels natural: ask the container its `size()`.** `replace()`'s first
+cursor version also held `last` and tested `last - read`. It retired two *fewer* instructions per
+element and took **3.5% more cycles**, reproducibly — a fourth live value across a loop holding three
+ring arrays, and it cannot be decremented on a pop because `std::deque::pop_back` invalidates the
+past-the-end iterator, so it needs an `end()` after every one.

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -2555,18 +2555,38 @@ private:
         auto ring_home = std::array<value_idx_type, pipeline_depth>{};
         auto ring_block = std::array<typename bucket_container_type::block const*, pipeline_depth>{};
 
+        // Cursors for the elements, a counter for the index, and both are needed: place_group wants
+        // the index, and reading m_values[value_idx] to get the element wants the container's data
+        // pointer back after every placement, because placing stores a fingerprint and a
+        // std::uint8_t store may alias that pointer. fill_buckets_from_values has the full argument
+        // and the measurement. The counter costs an increment in a register; re-deriving it from
+        // `read - first` would be a divide by the element size on any value type whose size is not a
+        // power of two.
+        //
+        // Two cursors, and deliberately not a third for the end. Holding `last` as well and testing
+        // `last - read` was built and measured and is the slower of the two -- 3.83 ns against 3.54
+        // at two hundred thousand elements with no duplicates -- because it costs a register across a
+        // loop that already holds three ring arrays, and because it cannot simply be decremented on a
+        // pop: std::deque::pop_back invalidates the past-the-end iterator and a deque is a value
+        // container this map supports, so it would need an m_values.end() after every duplicate. The
+        // container's own size() answers the same question for nothing.
+        auto const first = m_values.begin();
+        auto read = first;                  // element value_idx
+        auto look = first + pipeline_depth; // element value_idx + pipeline_depth
+
         // Hashes and decomposes, but does not ask for the block: the caller decides that, because
         // the one refill that happens on a duplicate is read by the very next iteration and has no
         // distance to run.
-        auto fetch = [&](std::size_t slot, std::size_t at) {
-            auto const mh = mixed_hash(get_key(m_values[at]));
+        auto fetch = [&](std::size_t slot, value_type const& value) {
+            auto const mh = mixed_hash(get_key(value));
             ring_word[slot] = fingerprint_word(mh);
             ring_home[slot] = group_idx_from_hash(mh);
             ring_block[slot] = groups + std::size_t{ring_home[slot]};
         };
 
-        for (auto i = std::size_t{}; i < pipeline_depth; ++i) {
-            fetch(i, i);
+        auto prime = first;
+        for (auto i = std::size_t{}; i < pipeline_depth; ++i, ++prime) {
+            fetch(i, *prime);
             prefetch_block(ring_block[i]);
         }
         while (m_values.size() > value_idx + pipeline_depth + 1) {
@@ -2576,21 +2596,23 @@ private:
             auto const home_idx = ring_home[slot];
             // The group is handed over rather than looked up: this loop asked for it
             // pipeline_depth elements ago, so the probe must not ask again.
-            if (probe_at_home(get_key(m_values[value_idx]), word, counter, *ring_block[slot], home_idx).found) {
+            if (probe_at_home(get_key(*read), word, counter, *ring_block[slot], home_idx).found) {
                 // The slot the duplicate vacated is refilled from the element that just moved into
                 // it -- read by the very next iteration, so there is no distance to prefetch over.
-                // value_idx is below the last element here, by the loop's own condition, so the
-                // plain loop's self-move guard cannot be needed.
-                m_values[value_idx] = std::move(m_values.back());
+                // `read` is below the last element here, by the loop's own condition, so the plain
+                // loop's self-move guard cannot be needed.
+                *read = std::move(m_values.back());
                 m_values.pop_back();
-                fetch(slot, value_idx);
+                fetch(slot, *read);
             } else {
                 place_group(word, counter, home_idx, static_cast<value_idx_type>(value_idx));
-                // The slot holding element value_idx is the one value_idx + pipeline_depth goes
-                // into, and the loop's own condition says that element exists. There is no separate
-                // lookahead cursor because it would never hold anything but this sum.
-                fetch(slot, value_idx + pipeline_depth);
+                // The slot holding this element is the one `look` goes into, and the loop's own
+                // condition says that element exists. `look` moves only here, so it stays exactly
+                // pipeline_depth ahead of `read`.
+                fetch(slot, *look);
+                ++look;
                 prefetch_block(ring_block[slot]);
+                ++read;
                 ++value_idx;
             }
         }
@@ -3349,17 +3371,22 @@ public:
         }
 
         // loop until we reach the end of the container. duplicated entries will be replaced with back().
+        // On a cursor rather than m_values[value_idx], for the reason do_replace_pipelined gives: the
+        // placement below stores a fingerprint, and an indexed read after it has to load the
+        // container's data pointer back before it can form the next element's address.
+        auto read = m_values.begin() + static_cast<difference_type>(value_idx);
         while (value_idx != m_values.size()) {
-            auto const& key = get_key(m_values[value_idx]);
+            auto const& key = get_key(*read);
             auto const mh = mixed_hash(key);
             auto r = probe(key, mh);
             if (r.found) {
                 if (value_idx != m_values.size() - 1) {
-                    m_values[value_idx] = std::move(m_values.back());
+                    *read = std::move(m_values.back());
                 }
                 m_values.pop_back();
             } else {
                 place_group(mh, static_cast<value_idx_type>(value_idx));
+                ++read;
                 ++value_idx;
             }
         }

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- `replace()`'s two loops walk with cursors too, and one cursor too many is slower than none
 - `merge()`, and why it is not the loop the caller would write
 - `replace()` hashes ahead too, once the reason it could not was looked at properly
 - `insert(first, last)` sizing the table from the range: built, measured, declined
@@ -298,6 +299,59 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**`replace()`'s two loops walk with cursors too, and one cursor too many is slower than none**
+(2026-09-11, issue #242's follow-up, `scripts/ab/replace_bulk.cpp`, Ryzen 9 7950X, clang 22, medians
+of seven, paired within each run).
+
+`merge()`'s walk was 0.89-0.95 for holding its elements in cursors instead of indexing them, so the
+same question was put to every other bulk loop in the file. Only two of them have the shape: a
+sequential walk over `m_values` interleaved with placements that store fingerprints. `do_visit`
+indexes, but from the probe -- a random index, with no cursor to hold -- and it never places.
+`fill_buckets_from_values` and `do_insert_range` were already iterator-based.
+
+The two are `do_replace_pipelined` and the plain loop `replace()` finishes with. Cursor over indexed,
+all 24 cells:
+
+| n | dup 0% | 25% | 75% | | n | dup 0% | 25% | 75% |
+|---|---|---|---|---|---|---|---|---|
+| `uint64_t` 8000 | 0.684 | 0.982 | 0.948 | | `std::string` 8000 | 0.902 | 0.937 | 0.935 |
+| 32000 | 0.956 | 0.933 | 0.812 | | 32000 | 0.879 | 0.952 | 0.960 |
+| 200000 | 0.957 | 0.945 | 0.873 | | 200000 | 0.886 | 0.955 | 0.964 |
+| 2000000 | 0.962 | 0.972 | 0.890 | | 2000000 | 0.933 | 0.976 | 0.958 |
+
+(The 0.684 is not a 1.46x: at eight thousand elements the *indexed* binary is bimodal between repeats
+-- 4.40, 2.85, 2.88, 4.76, 5.19, 2.76 -- where the cursor one is tight at 2.39-2.65. The round
+rebuilds the container and the allocator does not do the same thing twice, which `range_insert.cpp`
+records at the same sizes. The cursor version being the *stable* one is the finding there.)
+
+Instructions and cycles, both down in every cell measured: 80.93 to 79.92 instructions and 20.47 to
+19.01 cycles per element at 32000 with no duplicates, 74.76 to 69.99 and 34.51 to 30.22 at 200000 at
+a 75% duplicate rate. For a **string** key the instruction count does not move at all (487.48 to
+487.21) and the cycles do, 176.23 to 170.57 -- which is the mechanism seen from the other side: there
+the reload is not extra work, it is a memory latency sitting on the critical path in front of the next
+hash.
+
+*One cursor too many is worse than none.* The first version held `read`, `look` **and** `last`, and
+tested `last - read > pipeline_depth + 1` instead of asking the container its size. It retired two
+fewer instructions per element than the indexed loop and took **3.5% more cycles** for it -- 3.83 ns
+against 3.54 for the two-cursor version at two hundred thousand elements with no duplicates, and 1.03
+to 1.04 against the indexed loop it was supposed to beat, reproducibly over nine repeats. Two reasons,
+both worth keeping: `last` is a fourth live value across a loop already holding three ring arrays, and
+it cannot be decremented on a pop, because `std::deque::pop_back` invalidates the past-the-end
+iterator and a deque is a value container this map supports -- so it needs an `m_values.end()` after
+every duplicate. `size()` answers the same question for nothing. A variant holding only `read` and
+indexing the lookahead was measured too and is between the two (3.77).
+
+*`replace()`'s gate was not re-fitted, and the reason is that its gap is older than this.* Re-fitting
+after the loop gets cheaper is the rule `merge()` established, so it was tried. The `uint64_t` side of
+that sweep is unusable -- the same bimodality as above, ratios of 0.885, 0.654, 1.005, 0.688 at
+neighbouring sizes -- and the string side is clean and says the ring *loses* 2 to 10% from 176 KiB of
+index to 1408 KiB. That band was then measured on `origin/main` as well, with the indexed loops:
+**1.116 / 1.043 / 1.072 / 0.988 there against 1.072 / 1.051 / 1.021 / 0.992 here**, i.e. the same
+band, very slightly better. So it is not something the cursors introduced: `pipeline_min_index_bytes`
+was fitted on `uint64_t` in #249 and is too low for a key whose hash is long. Filed separately rather
+than changed on a sweep this noisy.
+
 **`merge()`, and why it is not the loop the caller would write** (2026-09-11, issue #242,
 `scripts/ab/merge.cpp`, Ryzen 9 7950X, clang 22, medians of five, both maps rebuilt from the same
 input every round and only the merge inside the clock).


### PR DESCRIPTION
Follow-up to #255. `merge()`'s walk was 0.89–0.95 for holding its elements in cursors instead of indexing them, so I put the same question to every other bulk loop in the header.

| loop | sequential walk over `m_values`? | places (stores fingerprints)? | verdict |
|---|---|---|---|
| `fill_buckets_from_values` | yes | yes | already iterators — it is where the rule is written down |
| `do_insert_range` | over the caller's range | yes | already iterators |
| `do_replace_pipelined` | yes | yes | **changed** |
| `replace()`'s plain tail | yes | yes | **changed** |
| `do_visit` | no — a random index from the probe | no, read-only | not applicable |

## Result

Cursor over indexed, medians of seven, paired within each run, **24 of 24 cells a win**:

| n | `uint64_t` dup 0% / 25% / 75% | `std::string` dup 0% / 25% / 75% |
|---|---|---|
| 8000 | 0.684 / 0.982 / 0.948 | 0.902 / 0.937 / 0.935 |
| 32000 | 0.956 / 0.933 / 0.812 | 0.879 / 0.952 / 0.960 |
| 200000 | 0.957 / 0.945 / 0.873 | 0.886 / 0.955 / 0.964 |
| 2000000 | 0.962 / 0.972 / 0.890 | 0.933 / 0.976 / 0.958 |

The 0.684 is not a 1.46x: at eight thousand elements the *indexed* binary is bimodal between repeats (4.40, 2.85, 2.88, 4.76, 5.19, 2.76) where the cursor one is tight at 2.39–2.65. The round rebuilds the container and the allocator does not do the same thing twice, which `range_insert.cpp` records at the same sizes. The cursor version being the stable one is the finding there.

Instructions **and** cycles fall in every cell measured — 80.93 → 79.92 instructions and 20.47 → 19.01 cycles per element at 32000 with no duplicates; 74.76 → 69.99 and 34.51 → 30.22 at 200000 at 75% duplicates. For a string key the instruction count does not move at all (487.48 → 487.21) and the cycles do (176.23 → 170.57), which is the mechanism from the other side: there the reload is not extra work, it is a memory latency sitting in front of the next hash.

## One cursor too many is worse than none

The first version also held `last` and tested `last - read` instead of asking the container its `size()`. It retired **two fewer instructions per element and took 3.5% more cycles** for it, reproducibly over nine repeats — 1.03–1.04 against the very indexed loop it was meant to beat. Two reasons, both now in `CLAUDE.md`: `last` is a fourth live value across a loop already holding three ring arrays, and it cannot be decremented on a pop, because `std::deque::pop_back` invalidates the past-the-end iterator and a deque is a value container this map supports — so it would need an `m_values.end()` after every duplicate.

## What is deliberately not in here

`replace()`'s pipeline gate is not re-fitted, even though "re-fit the constant whenever the gated loop changes" is the rule #255 established. The `uint64_t` side of that sweep is unusable — the same bimodality as above, ratios of 0.885, 0.654, 1.005, 0.688 at neighbouring sizes — and the string side is clean and says the ring *loses* 2–10% from 176 KiB of index to 1408 KiB. I then measured that band on `origin/main` with the indexed loops: **1.116 / 1.043 / 1.072 / 0.988 there against 1.072 / 1.051 / 1.021 / 0.992 here**. Same band, marginally better. So it is not something the cursors introduced — `pipeline_min_index_bytes` was fitted on `uint64_t` in #249 and is too low for a key whose hash is long. Filed separately.

## Verification

- 817 tests pass under clang release, gcc release, ASan and the unity build at chunk size 16; `-fno-exceptions` (clang and gcc), `-std=c++23` and `-m32` compile clean.
- Mutation on the diff: 32 mutants, **100% killed**, 16 by a test and the rest rejected by the compiler.
- Evidence in `notes/index-design.md`; harness is the existing `scripts/ab/replace_bulk.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)