### PR TITLE
Fix replace_bulk's bimodality, then keep replace()'s gate where it is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,17 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
 - **A benchmark with a small per-epoch batch must advance its own randomness.** A replayed key
   sequence is learned by the branch predictor and flatters the branchiest probe by up to 2.7x. This
   mistake has been made twice, in two different tools.
+- **A benchmark that rebuilds its subject every round is measuring the allocator too, and bimodally.**
+  `replace_bulk.cpp` read 4.40, 2.85, 2.88, 4.76, 5.19, 2.76 ns/element for the *same* binary because
+  each round built a fresh map and the index allocation landed inside the clock. Replacing into the
+  same warmed map and reporting the **median round** rather than the mean took four repeats of one
+  cell from 3.32 / 3.33 / 3.31 / 3.27 (max 6.14) to 3.158 / 3.141 / 3.145 / 3.147 (max 3.92). Any
+  harness used to settle a 5–10% question needs both.
+- **A pipeline's payoff can depend on the caller's data, not only on the size.** `replace()`'s ring is
+  worth 1.5x to a `uint64_t` with no duplicates and costs 16% to one with a quarter of them, at the
+  *same* index size, because a duplicate refills its ring slot from the element read next and has no
+  distance to prefetch over. A single index threshold cannot serve both; pick it on the geomean across
+  key types and rates, and say in the comment what it gives up.
 - **Do not edit a shell script while it is running.** bash re-reads the file at its old byte offset.
 
 ### Rules the workloads themselves must obey
@@ -287,7 +298,10 @@ time, past the cache. The larger effect is the caller's: **batching the keys at 
 own `pipeline_depth` ring, and the bulk visit has chunks instead (a ring there measured 15% worse);
 sharing them costs the rehash 1.9 instructions per element and was rejected. `replace()` and
 `merge()` are gated, on **index** bytes — counting the values too was measured wrong. The two
-thresholds are **not the same**: 256 KB and 1 MB. A gate's crossover is where the ring's fixed 13–17
+thresholds are **not the same**: 256 KB and 1 MB. `replace()`'s was re-measured across both key types
+and both duplicate rates for #257 and kept: it is the best of four candidates on the geomean (0.9081
+against 0.9137 / 0.9143 / 0.9286), and it buys a 1.5x on one cell by accepting a 1.163 on its
+neighbour. A gate's crossover is where the ring's fixed 13–17
 instructions per element stop being worth the misses they hide, so it moves with what the *rest* of
 the loop costs — writing merge's walk with iterators instead of indices made it 5–11% cheaper and
 pushed its crossover two doublings up. Re-fit the constant whenever the gated loop changes; a shared

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1472,6 +1472,27 @@ private:
     // were measured against the same question and neither wants a gate at all; the visit's crossover
     // is set by the caller's hit rate, which the map does not know until it has already done a
     // chunk's worth of work. Issue #247.
+    //
+    // Re-measured on a fixed harness for #257 -- it was first fitted on `std::uint64_t` alone -- and
+    // kept. Ring over the same loop with the ring deleted, by how much index the array holds, for
+    // `std::uint64_t` and `std::string` keys at 0% and 25% duplicates:
+    //
+    //      88 KiB   1.265  1.225  1.006  1.037
+    //     176 KiB   0.833  1.194  1.156  1.033
+    //     352 KiB   0.667  1.163  1.064  1.002    <- the first size the gate opens at
+    //     704 KiB   0.632  0.999  1.039  0.987
+    //    1408 KiB   0.626  0.944  0.998  0.985
+    //    5632 KiB   0.537  0.912  0.950  0.944
+    //
+    // The four curves cross in four different places, because the ring's payoff depends on the
+    // **duplicate rate** as much as on the size: a duplicate refills its ring slot from the element
+    // that just moved into it, which is read by the very next iteration and has no distance to
+    // prefetch over. At 352 KiB the same gate is worth 1.5x to a `std::uint64_t` with no duplicates
+    // and costs 16% to one with a quarter of them, and the map cannot tell which it has until it has
+    // walked. So the constant is a compromise and is chosen as one: over all 28 cells the realised
+    // geometric mean is 0.9081 here, 0.9137 at 128 KiB, 0.9143 at 512 KiB and 0.9286 at a mebibyte.
+    // A threshold that never loses exists -- a mebibyte, worst cell 1.000 -- and costs two points of
+    // that mean. This one keeps the 1.5x and accepts a worst cell of 1.163.
     static constexpr std::size_t pipeline_min_index_bytes = std::size_t{256} << 10U;
 
     // merge()'s, and it is two doublings higher than replace()'s rather than the same number -- which

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- `replace()`'s gate was re-measured on a fixed harness and kept, and the harness is the finding
 - `replace()`'s two loops walk with cursors too, and one cursor too many is slower than none
 - `merge()`, and why it is not the loop the caller would write
 - `replace()` hashes ahead too, once the reason it could not was looked at properly
@@ -299,6 +300,65 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**`replace()`'s gate was re-measured on a fixed harness and kept, and the harness is the finding**
+(2026-09-11, issue #257, `scripts/ab/replace_bulk.cpp`, Ryzen 9 7950X, clang 22, medians of seven).
+
+`pipeline_min_index_bytes` was fitted in #249 on `map<uint64_t, size_t>` alone, and a sweep during
+#256 suggested it was too low for a string key. Re-fitting needs numbers, and the harness could not
+give them: at sixteen to a hundred thousand `uint64_t` elements the same binary read 4.40, 2.85, 2.88,
+4.76, 5.19, 2.76 ns per element between repeats.
+
+*The harness, first.* Two things caused it, and both are now fixed. The timed region contained a fresh
+index allocation, because every round built a new map -- so what the allocator had just done with the
+container copy decided what the allocation cost. And the reported number was the mean over rounds, so
+one round that faulted carried it. `replace_bulk.cpp` now replaces into the **same** map every round
+after one untimed round that allocates the index, and reports the **median round**. Four repeats of
+the same cell go from 3.32 / 3.33 / 3.31 / 3.27 with a max of 6.14 to **3.158 / 3.141 / 3.145 / 3.147**
+with a max of 3.92. `cold` restores the old behaviour, which is the right one for "what does a caller
+pay end to end" and the wrong one for "does the pipeline inside it pay".
+
+*The answer, with numbers that hold still.* Ring over the same loop with the ring deleted, by index
+size, for both key types at two duplicate rates:
+
+| index | `uint64_t` 0% | `uint64_t` 25% | `string` 0% | `string` 25% | geomean |
+|---|---|---|---|---|---|
+| 88 KiB | 1.265 | 1.225 | 1.006 | 1.037 | 1.128 |
+| 176 KiB | 0.833 | 1.194 | 1.156 | 1.033 | 1.044 |
+| **352 KiB** | **0.667** | **1.163** | **1.064** | **1.002** | **0.954** |
+| 704 KiB | 0.632 | 0.999 | 1.039 | 0.987 | 0.897 |
+| 1408 KiB | 0.626 | 0.944 | 0.998 | 0.985 | 0.873 |
+| 2816 KiB | 0.565 | 0.916 | 0.973 | 0.979 | 0.838 |
+| 5632 KiB | 0.537 | 0.912 | 0.950 | 0.944 | 0.814 |
+
+The four curves cross in four different places -- 176, 704, 1408 and 352 KiB -- and the reason is not
+the key type alone. **The ring's payoff depends on the duplicate rate**, because a duplicate refills
+its ring slot from the element that just moved into it, which the very next iteration reads: there is
+no distance to prefetch over. At 352 KiB the same gate is worth **1.5x** to a `uint64_t` with no
+duplicates and costs **16%** to one with a quarter of them. The map cannot know which it has until it
+has walked, which is the same wall #248 ran into from the other side.
+
+So the constant is a compromise and was chosen as one. Realised geometric mean over all 28 cells, and
+the worst single cell, for four candidate thresholds:
+
+| threshold | geomean | worst cell |
+|---|---|---|
+| 128 KiB | 0.9137 | 1.194 |
+| **256 KiB (kept)** | **0.9081** | 1.163 |
+| 512 KiB | 0.9143 | 1.039 |
+| 1 MiB | 0.9286 | 1.000 |
+
+**256 KiB is the best of the four on the mean**, and it is also where the combined per-size crossover
+sits: 1.044 at 176 KiB against 0.954 at 352 KiB, and the gate opens between them. A threshold that
+never loses does exist -- a mebibyte -- and costs two points of geometric mean to buy away a worst
+cell of 1.163. The issue's premise was half right: the constant *was* fitted on `uint64_t`, and the
+string loss it leaves is real, but it is one octave, at most 1.064, and it is paid for by a 1.5x on
+the neighbouring cell of the same octave.
+
+*What was considered and not built.* Making the walk count duplicates and abandon the ring when it
+sees too many. It is adaptive on data already in hand rather than a guess about data it has not seen,
+which is the distinction #248 turns on -- but it is still a threshold on the caller's data chosen by
+whoever fits it, and it would have to be fitted on the same sweep that produced the table above.
+
 **`replace()`'s two loops walk with cursors too, and one cursor too many is slower than none**
 (2026-09-11, issue #242's follow-up, `scripts/ab/replace_bulk.cpp`, Ryzen 9 7950X, clang 22, medians
 of seven, paired within each run).

--- a/scripts/ab/replace_bulk.cpp
+++ b/scripts/ab/replace_bulk.cpp
@@ -9,11 +9,25 @@
 // Sweep `n` as well as `dup-percent`: the pipeline is gated on the container outgrowing cache, and
 // on both sides of that gate the answer is different. Build with -DUDM_RB_STR for string keys.
 //
-//   argv: <n> [rounds] [dup-percent]
+//   argv: <n> [rounds] [dup-percent] [warm|cold]
+//
+// `warm` -- the default -- replaces into the *same* map every round, after one untimed round that
+// allocates the index. Without it the timed region contains a fresh index allocation whose cost
+// depends on what the allocator did with the container copy just before it, and the result is bimodal
+// between repeats: at sixteen to a hundred thousand `uint64_t` elements the same binary reads 4.40,
+// 2.85, 2.88, 4.76, 5.19, 2.76 ns per element, which is wide enough to swamp the 5-10% questions this
+// is used to answer. `range_insert.cpp` records the same effect at n = 4096. `cold` restores the
+// old behaviour, which is the right one for "what does a caller pay end to end" and the wrong one for
+// "does the pipeline inside it pay".
+//
+// What is timed per round either way is `replace()` itself: the index memset, the values move-assign
+// and the dedup walk. The per-round **median** is reported, not the mean over rounds, so that one
+// round that faulted cannot carry the number.
 #include <ankerl/unordered_dense.h>
 
 #include <bench/workloads.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -49,6 +63,7 @@ int main(int argc, char** argv) {
     auto const n = static_cast<std::size_t>(argc > 1 ? std::strtoull(argv[1], nullptr, 10) : 1000000);
     auto const rounds = static_cast<std::size_t>(argc > 2 ? std::strtoull(argv[2], nullptr, 10) : 10);
     auto const dup_pct = static_cast<std::size_t>(argc > 3 ? std::strtoull(argv[3], nullptr, 10) : 0);
+    auto const warm = std::string(argc > 4 ? argv[4] : "warm") != "cold";
 
     // Built once: `dup_pct` percent of the entries repeat an earlier key, so the dedup path is
     // exercised at a chosen rate rather than never or always.
@@ -70,20 +85,37 @@ int main(int argc, char** argv) {
     // memcpy per round against a call that takes milliseconds, which quietly pulled every ratio
     // towards 1.0 the first time this was used to compare two value sizes.
     auto acc = std::size_t{0};
-    auto el = std::chrono::steady_clock::duration{};
+    auto per_round = std::vector<double>();
+    per_round.reserve(rounds);
+    auto warm_map = map_t();
+    if (warm) {
+        // Untimed, and the only round that allocates an index: every later replace() finds one of
+        // the right size already there and keeps it.
+        auto container = container_t(source);
+        warm_map.replace(std::move(container));
+    }
     for (std::size_t round = 0; round < rounds; ++round) {
         auto container = container_t(source);
-        auto map = map_t();
+        auto cold_map = map_t();
+        auto& map = warm ? warm_map : cold_map;
+        if (warm) {
+            map.clear(); // frees the values, keeps the index; outside the clock
+        }
         auto const t0 = std::chrono::steady_clock::now();
         map.replace(std::move(container));
-        el += std::chrono::steady_clock::now() - t0;
+        auto const elapsed = std::chrono::steady_clock::now() - t0;
+        per_round.push_back(std::chrono::duration<double, std::nano>(elapsed).count() / static_cast<double>(n));
         acc += map.size();
     }
-    std::printf("%.3f ns/element  n=%zu rounds=%zu dup=%zu%% unique=%zu acc=%zu\n",
-                std::chrono::duration<double, std::nano>(el).count() / static_cast<double>(n * rounds),
+    std::sort(per_round.begin(), per_round.end());
+    std::printf("%.3f ns/element  n=%zu rounds=%zu dup=%zu%% %s unique=%zu min=%.3f max=%.3f acc=%zu\n",
+                per_round[per_round.size() / 2],
                 n,
                 rounds,
                 dup_pct,
+                warm ? "warm" : "cold",
                 distinct.size(),
+                per_round.front(),
+                per_round.back(),
                 acc);
 }


### PR DESCRIPTION
Closes #257. **No behaviour change** — one harness fix, one comment, and a recorded negative result.

#257 said `pipeline_min_index_bytes` was fitted on `uint64_t` and is too low for a string key. Settling that needs numbers, and the harness could not give them.

## The harness was the blocker

At sixteen to a hundred thousand elements the *same binary* read 4.40, 2.85, 2.88, 4.76, 5.19, 2.76 ns per element between repeats. Two causes:

- **The timed region contained a fresh index allocation.** Every round built a new map, so what the allocator had just done with the container copy decided what the allocation cost.
- **The number reported was the mean over rounds**, so one round that faulted carried it.

`replace_bulk.cpp` now replaces into the *same* map every round, after one untimed round that allocates the index, and reports the **median round**. Four repeats of one cell:

| | repeats | max round |
|---|---|---|
| before | 3.32 / 3.33 / 3.31 / 3.27 | 6.14 |
| after | 3.158 / 3.141 / 3.145 / 3.147 | 3.92 |

`cold` restores the old behaviour, which is the right one for "what does a caller pay end to end" and the wrong one for "does the pipeline inside it pay".

## With numbers that hold still, the gate stays

Ring over the same loop with the ring deleted, by index size, both key types, two duplicate rates:

| index | `uint64_t` 0% | `uint64_t` 25% | `string` 0% | `string` 25% | geomean |
|---|---|---|---|---|---|
| 88 KiB | 1.265 | 1.225 | 1.006 | 1.037 | 1.128 |
| 176 KiB | 0.833 | 1.194 | 1.156 | 1.033 | 1.044 |
| **352 KiB** | **0.667** | **1.163** | **1.064** | **1.002** | **0.954** |
| 704 KiB | 0.632 | 0.999 | 1.039 | 0.987 | 0.897 |
| 1408 KiB | 0.626 | 0.944 | 0.998 | 0.985 | 0.873 |
| 2816 KiB | 0.565 | 0.916 | 0.973 | 0.979 | 0.838 |
| 5632 KiB | 0.537 | 0.912 | 0.950 | 0.944 | 0.814 |

The four curves cross in four different places — 176, 704, 1408 and 352 KiB — and the spread is not the key type alone. **The ring's payoff depends on the duplicate rate**: a duplicate refills its ring slot from the element the very next iteration reads, so there is no distance to prefetch over. At 352 KiB the same gate is worth **1.5x** to a `uint64_t` with no duplicates and costs **16%** to one with a quarter of them, and the map cannot tell which it has until it has walked — the same wall #248 ran into from the other side.

So the constant is a compromise, and was picked as one:

| threshold | realised geomean, 28 cells | worst cell |
|---|---|---|
| 128 KiB | 0.9137 | 1.194 |
| **256 KiB (kept)** | **0.9081** | 1.163 |
| 512 KiB | 0.9143 | 1.039 |
| 1 MiB | 0.9286 | 1.000 |

256 KiB is the best of the four on the mean, and it is also where the combined per-size crossover sits — 1.044 at 176 KiB against 0.954 at 352 KiB, with the gate opening between them. A threshold that never loses does exist (a mebibyte) and costs two points of geometric mean to buy away a worst cell of 1.163.

The issue's premise was half right: the constant *was* fitted on `uint64_t`, and the string loss it leaves is real — but it is one octave, at most 1.064, and it is paid for by the 1.5x on the neighbouring cell of the same octave.

## Considered and not built

Making the walk count duplicates and abandon the ring when it sees too many. It would be adaptive on data already in hand rather than a guess about data it has not seen, which is the distinction #248 turns on — but it is still a threshold on the caller's data chosen by whoever fits it, and it would have to be fitted on the same sweep that produced the table above.

## Verification

- 817 tests pass under clang release, gcc release, ASan and the unity build at chunk size 16. The header change is comment-only.
- Two new rules in `CLAUDE.md`: a benchmark that rebuilds its subject every round measures the allocator too, and a pipeline's payoff can depend on the caller's data rather than only on the size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)