### PR TITLE
Bound slot_of_value, which was a five-line hang

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,14 +132,16 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
   *same* index size, because a duplicate refills its ring slot from the element read next and has no
   distance to prefetch over. A single index threshold cannot serve both; pick it on the geomean across
   key types and rates, and say in the comment what it gives up.
-- **An instruction count can move because you perturbed the inliner, and that is not a finding.**
-  Bounding `slot_of_value`'s `while (true)` read 133.0 → 119.5 instructions per erase under clang,
-  with a sentinel-returning bound at 136.0 — a 10% spread that looked like a real property of
-  `[[noreturn]]`. It is not. Force `slot_of_value` out of line and all three collapse to 137.0 /
-  138.0 / 137.1; build with gcc and they collapse to 85.5 / 85.1 / 84.5. The change simply landed on
-  a different clang inlining decision, which any unrelated edit can flip. **Instruction counts are
-  immune to layout, not to inlining** — before believing one, pin the inlining with `noinline` and
-  re-measure, and check a second compiler. Both controls take minutes. #254.
+- **An instruction count can move because you perturbed the inliner. That is real for the binary you
+  shipped and is not a property of the change.** Bounding `slot_of_value`'s `while (true)` reads
+  133.0 → 119.5 instructions and 0.92–0.95 of the time per erase under clang, and that does ship. It
+  is not a property of `[[noreturn]]` or of bounded loops, which is what it was first written up as:
+  force `slot_of_value` out of line and the three variants collapse to 137.0 / 138.1 / 137.1, and
+  under gcc they are 85.5 / 85.1 / 84.5. It landed on a different clang inlining decision — one a
+  compiler upgrade or an unrelated edit to those functions can flip, and one that transfers to
+  nothing else. **Instruction counts are immune to code layout, not to inlining.** Before
+  *generalising* one, pin the inlining with `noinline` and check a second compiler; both take
+  minutes. Keep the win, do not build a rule on it. #254.
 - **Do not edit a shell script while it is running.** bash re-reads the file at its old byte offset.
 
 ### Rules the workloads themselves must obey

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,13 +132,14 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
   *same* index size, because a duplicate refills its ring slot from the element read next and has no
   distance to prefetch over. A single index threshold cannot serve both; pick it on the geomean across
   key types and rates, and say in the comment what it gives up.
-- **A value-returning loop the compiler cannot prove terminates pays for it, and a `[[noreturn]]` dead
-  end is the cheapest exit to give it.** Bounding `slot_of_value`'s `while (true)` took the erase path
-  from 133.0 to 119.5 instructions per erase (#254). The same bound *returning a sentinel* measures
-  136.0 — worse than no bound. It does **not** generalise: `place_group` and the rehash's placement
-  loop got the same treatment and came back 0.1–0.2 instructions *worse* at every size, because they
-  return `void` and already had a clean exit. The shape that pays is a loop with exactly one
-  value-producing exit; anything else needs its own measurement.
+- **An instruction count can move because you perturbed the inliner, and that is not a finding.**
+  Bounding `slot_of_value`'s `while (true)` read 133.0 → 119.5 instructions per erase under clang,
+  with a sentinel-returning bound at 136.0 — a 10% spread that looked like a real property of
+  `[[noreturn]]`. It is not. Force `slot_of_value` out of line and all three collapse to 137.0 /
+  138.0 / 137.1; build with gcc and they collapse to 85.5 / 85.1 / 84.5. The change simply landed on
+  a different clang inlining decision, which any unrelated edit can flip. **Instruction counts are
+  immune to layout, not to inlining** — before believing one, pin the inlining with `noinline` and
+  re-measure, and check a second compiler. Both controls take minutes. #254.
 - **Do not edit a shell script while it is running.** bash re-reads the file at its old byte offset.
 
 ### Rules the workloads themselves must obey
@@ -296,9 +297,9 @@ reserving only the buckets is *worse* than not reserving.
 
 *Probe termination.* Every probe that searches for a key or a value is bounded; the two *placement*
 walks are not, and deliberately -- they terminate on the free-slot invariant the load factor
-maintains, which no caller can break, and bounding them measured slightly worse. The miss probe got
-its bound after a fuzz hang; `slot_of_value` got one after a five-line hang a mutable key could reach
-(#254), and it was 10% of the erase path to add it.
+maintains, which no caller can break. The miss probe got its bound after a fuzz hang; `slot_of_value`
+got one after a five-line hang a mutable key could reach (#254). The bound costs one compare on the
+next-group path and nothing on a home-group hit.
 
 *Still open.* Huge pages (22% of a large lookup, nothing asks for them).
 A built-in probe-length statistics facility like boost's. The string erase's ~50 ns second hash.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,13 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
   *same* index size, because a duplicate refills its ring slot from the element read next and has no
   distance to prefetch over. A single index threshold cannot serve both; pick it on the geomean across
   key types and rates, and say in the comment what it gives up.
+- **A value-returning loop the compiler cannot prove terminates pays for it, and a `[[noreturn]]` dead
+  end is the cheapest exit to give it.** Bounding `slot_of_value`'s `while (true)` took the erase path
+  from 133.0 to 119.5 instructions per erase (#254). The same bound *returning a sentinel* measures
+  136.0 — worse than no bound. It does **not** generalise: `place_group` and the rehash's placement
+  loop got the same treatment and came back 0.1–0.2 instructions *worse* at every size, because they
+  return `void` and already had a clean exit. The shape that pays is a loop with exactly one
+  value-producing exit; anything else needs its own measurement.
 - **Do not edit a shell script while it is running.** bash re-reads the file at its old byte offset.
 
 ### Rules the workloads themselves must obey
@@ -286,6 +293,10 @@ range defeats all of them. `reserve(size() + distance())` is 128x the index at a
 and still guesses. Note the cost is the **value vector's** reallocation, not the index rehash:
 reserving only the values gets 10.4 ns/element against 9.9 for both and 19.6 for neither, and
 reserving only the buckets is *worse* than not reserving.
+
+*Probe termination.* Every probe in the file is bounded now. The miss probe got its bound after a fuzz
+hang; `slot_of_value` got one after a five-line hang a mutable key could reach (#254), and it was 10%
+of the erase path to add it.
 
 *Still open.* Huge pages (22% of a large lookup, nothing asks for them).
 A built-in probe-length statistics facility like boost's. The string erase's ~50 ns second hash.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,9 +294,11 @@ and still guesses. Note the cost is the **value vector's** reallocation, not the
 reserving only the values gets 10.4 ns/element against 9.9 for both and 19.6 for neither, and
 reserving only the buckets is *worse* than not reserving.
 
-*Probe termination.* Every probe in the file is bounded now. The miss probe got its bound after a fuzz
-hang; `slot_of_value` got one after a five-line hang a mutable key could reach (#254), and it was 10%
-of the erase path to add it.
+*Probe termination.* Every probe that searches for a key or a value is bounded; the two *placement*
+walks are not, and deliberately -- they terminate on the free-slot invariant the load factor
+maintains, which no caller can break, and bounding them measured slightly worse. The miss probe got
+its bound after a fuzz hang; `slot_of_value` got one after a five-line hang a mutable key could reach
+(#254), and it was 10% of the erase path to add it.
 
 *Still open.* Huge pages (22% of a large lookup, nothing asks for them).
 A built-in probe-length statistics facility like boost's. The string erase's ~50 ns second hash.

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -190,6 +190,9 @@ namespace detail {
 [[noreturn]] inline ANKERL_UNORDERED_DENSE_NOINLINE void on_error_too_many_elements() {
     throw std::out_of_range("ankerl::unordered_dense::map::replace(): too many elements");
 }
+[[noreturn]] inline ANKERL_UNORDERED_DENSE_NOINLINE void on_error_key_changed() {
+    throw std::logic_error("ankerl::unordered_dense: an element's key changed after it was inserted; use replace_key()");
+}
 
 #    else
 
@@ -200,6 +203,9 @@ namespace detail {
     abort();
 }
 [[noreturn]] inline void on_error_too_many_elements() {
+    abort();
+}
+[[noreturn]] inline void on_error_key_changed() {
     abort();
 }
 
@@ -2028,8 +2034,21 @@ private:
         uncount(groups, mask, home_idx, counter, found_in);
     }
 
-    // The slot that points at a value, searched from the value's home group. Every value has one,
-    // so there is no other stopping condition.
+    // Which slot points at this value, searched from the value's home group. Its precondition is that one does, and the map's
+    // own callers always satisfy it -- but the key is *not* const here, so a caller can break it with an assignment and no
+    // cast: `it->first = x; m.erase(it);` then asks for a slot on a probe sequence the element is not on.
+    //
+    // Bounded for that, the same way the miss probe is and after the same kind of hang: `delta ==
+    // m_group_mask` means the triangular sequence has now visited every group, so there is nowhere
+    // left. Returning "not found" is not available -- every caller's contract says the element is
+    // there and the return is a slot number -- so the useful outcome is a diagnosable abort rather
+    // than a core spinning at 100% forever, which is what this did until 2026-09-11 (#254).
+    //
+    // The test is after the lane loop, so the common case -- the element is in its home group --
+    // returns before reaching it. It is not merely free: the erase path retires **13.4 fewer
+    // instructions per erase** with it than without, 133.0 to 119.5, flat across three sizes. The
+    // cause is the `[[noreturn]]` rather than the bound, and the same bound returning a sentinel
+    // instead measures 136.0 -- worse than no bound at all. See notes/index-design.md.
     [[nodiscard]] auto slot_of_value(std::uint64_t mh, value_idx_type value_idx) const -> value_idx_type {
         auto const word = fingerprint_word(mh);
         auto group_idx = group_idx_from_hash(mh);
@@ -2047,6 +2066,10 @@ private:
                 }
                 lanes &= lanes - 1;
             }
+            if (ANKERL_UNORDERED_DENSE_UNLIKELY(delta == m_group_mask))
+                ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                    on_error_key_changed();
+                }
             group_idx = next_group(group_idx, delta);
         }
     }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -2044,6 +2044,14 @@ private:
     // there and the return is a slot number -- so the useful outcome is a diagnosable abort rather
     // than a core spinning at 100% forever, which is what this did until 2026-09-11 (#254).
     //
+    // Two things the throw is not. It is not recoverable: reached from finish_erase the slot is
+    // already gone, so the table is in the state that comment describes as unusable, and the
+    // exception says what happened rather than offering to continue. And it is not a guarantee --
+    // if the mutated key's sequence happens to cross the element's real slot with a matching
+    // fingerprint, a wrong-but-valid slot comes back and the counters are unwound from the wrong
+    // home instead. Bounding turns a hang into a diagnosis; only `replace_key()` turns it into a
+    // supported operation.
+    //
     // The test is after the lane loop, so the common case -- the element is in its home group --
     // returns before reaching it. It is not merely free: the erase path retires **13.4 fewer
     // instructions per erase** with it than without, 133.0 to 119.5, flat across three sizes. The

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -2053,10 +2053,12 @@ private:
     // supported operation.
     //
     // The test is after the lane loop, so the common case -- the element is in its home group --
-    // returns before reaching it. It is not merely free: the erase path retires **13.4 fewer
-    // instructions per erase** with it than without, 133.0 to 119.5, flat across three sizes. The
-    // cause is the `[[noreturn]]` rather than the bound, and the same bound returning a sentinel
-    // instead measures 136.0 -- worse than no bound at all. See notes/index-design.md.
+    // returns without reaching it, and a group that does fall through was about to call next_group
+    // anyway: one compare, on the walking path only.
+    //
+    // It measured 10% *faster* than the unbounded version under clang, and that is an artifact, not
+    // a reason -- see notes/index-design.md. Forcing this function out of line makes the difference
+    // vanish and gcc never had it. The reason to bound the loop is that it hangs.
     [[nodiscard]] auto slot_of_value(std::uint64_t mh, value_idx_type value_idx) const -> value_idx_type {
         auto const word = fingerprint_word(mh);
         auto group_idx = group_idx_from_hash(mh);

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- An unbounded probe that hangs, and the bound that made the erase path 10% cheaper
 - `replace()`'s gate was re-measured on a fixed harness and kept, and the harness is the finding
 - `replace()`'s two loops walk with cursors too, and one cursor too many is slower than none
 - `merge()`, and why it is not the loop the caller would write
@@ -300,6 +301,75 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**An unbounded probe that hangs, and the bound that made the erase path 10% cheaper** (2026-09-11,
+issue #254, Ryzen 9 7950X, clang 22, `perf stat`, two single-header binaries).
+
+`slot_of_value()` -- "which slot points at this value", reached from `erase(it)`, `extract(it)`,
+`replace_key()` and `finish_erase` -- probed with `while (true)` and no stopping condition. Its
+precondition is that some slot does point there, and the map's own callers always satisfy it. But this
+map hands out a **mutable key**, so a caller can break it with an assignment and no cast:
+
+```cpp
+auto it = m.find("key 42");
+it->first = "something else entirely";  // compiles; README lists no-const-Key as a disadvantage
+m.erase(it);                            // ran until killed, at 100% of one core
+```
+
+Five lines, and the process never came back. It is the caller's mistake -- `replace_key()` is the
+supported way to change a key -- but every other map in this class makes it impossible to *write*,
+this one makes it compile, and what it did then was spin rather than say anything. The same shape was
+fixed once before on the miss path, after a fuzz hang that "survived every other target and 767 unit
+tests". It was found here by a benchmark's own control loop hanging: `scripts/ab/merge.cpp` moved the
+key into the destination and then called `src.erase(it)`, which is the same violation by a different
+route. With a `uint64_t` key that loop is correct, so it ran for a long time before a `std::string`
+key turned it into a hang that took ten minutes of a benchmark run to notice.
+
+The bound is `delta == m_group_mask`, the same invariant `probe_from` already uses -- the triangular
+sequence has visited every group, so there is nowhere left -- and the exhausted path calls a new
+`on_error_key_changed()`, which throws or aborts. Returning "not found" is not available: every
+caller's contract says the element is there, and the return is a slot number.
+
+*And it is 10% faster.* Instructions per erase, the erase path alone (a build-only mode subtracted),
+three repeats each, reproduced in two containers:
+
+| variant | repeats |
+|---|---|
+| unbounded `while (true)`, as shipped until now | 132.99 / 132.98 / 132.97 |
+| **bounded, exhaustion is `[[noreturn]]`** | **119.63 / 119.65 / 119.50** |
+| bounded, exhaustion returns a `0` sentinel | 136.01 / 136.00 / 136.14 |
+
+Flat across n = 50000 / 200000 / 1000000 (132.88 to 119.92, 133.17 to 119.55, 131.35 to 117.69), with
+the build phase as a control that does not move (513.90M against 513.55M instructions -- the insert
+path is untouched). Time 0.946 and 0.937 in cache, 1.013 at a million where the loop is memory-bound.
+
+**It is not the bound, it is the `[[noreturn]]`**: the sentinel variant is *worse* than no bound at
+all. A loop with one value-producing exit and one dead end is cheaper than one with two exits whose
+values have to merge, and cheaper than one the compiler cannot prove terminates.
+
+*The finding does not generalise to the insert path, which is the half worth keeping.* The header has
+two more unbounded `while (true)` loops, both placement walks looking for the first free slot:
+`place_group`, which every insert reaches, and the copy written out inside
+`fill_buckets_from_values`. Both were given the same bound and the same `[[noreturn]]` exhaustion, and
+measured the same three ways. Instructions per insert, medians of three that agreed to 0.02:
+
+| | unbounded | bounded + `[[noreturn]]` | bounded + plain exit |
+|---|---|---|---|
+| reserved, n = 50000 | 125.27 | 125.35 | 125.36 |
+| reserved, n = 200000 | 125.39 | 125.46 | 125.46 |
+| reserved, n = 1000000 | 126.30 | 126.31 | 126.32 |
+| growing, n = 50000 | 169.20 | 169.40 | 169.40 |
+| growing, n = 200000 | 169.40 | 169.59 | 169.58 |
+| growing, n = 1000000 | 190.90 | 191.08 | 191.08 |
+
+The bounded versions are **very slightly worse at every size**, by the 0.1 to 0.2 instructions the
+added compare costs, and the `[[noreturn]]` and plain-exit columns are indistinguishable. Not shipped.
+
+The difference between the two paths says what the effect actually is. `slot_of_value` **returns a
+value** and its loop had exactly one exit producing it; `place_group` returns `void` and its loop
+already had a clean `return`. So the win is not "name the impossible path `[[noreturn]]`" -- it is
+"a value-returning loop the compiler cannot prove terminates pays for it, and a dead end is the
+cheapest way to give it an exit". Applying it anywhere else needs that shape, and a measurement.
+
 **`replace()`'s gate was re-measured on a fixed harness and kept, and the harness is the finding**
 (2026-09-11, issue #257, `scripts/ab/replace_bulk.cpp`, Ryzen 9 7950X, clang 22, medians of seven).
 

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -358,6 +358,19 @@ version is the *worst* of the three by exactly the compare it adds. So the 10% i
 clang chose to inline around `slot_of_value`, and that landed better. Any unrelated edit to those
 functions can flip it back.
 
+*What is retracted is the explanation, not the speedup.* The shipped binary really is faster than
+`origin/main` under clang -- 8.765 ns against 9.233 per erase at two hundred thousand elements and
+6.924 against 7.568 at fifty thousand, medians of nine, so **0.92 to 0.95** -- and a caller building
+with clang gets that today. What they do not get is a reason it will survive the next compiler
+release, and a gcc caller gets nothing at all (85.5 against 85.1 instructions is a wash). Bank the
+win, do not build a rule on it, and do not let it justify the change: the hang does that on its own.
+
+One more caution from the same table: **instructions and time come apart here.** The `noinline`
+controls retire 137.0 / 138.1 / 137.1 instructions and take 9.718 / 9.332 / 9.240 ns -- the variant
+retiring the *most* is the fastest of the three. The erase path is partly memory-bound, so an
+instruction count settles "did the compiler emit different work", not "is it faster"; the time still
+has to be measured separately.
+
 This also re-explains the insert-path result correctly. `place_group` and the rehash's placement loop
 were given the same bound and came back 0.1-0.2 instructions per insert *worse* at every size, and
 that was written up as "they return `void`, which is a different shape". It is simpler than that:

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,7 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
-- An unbounded probe that hangs, and the bound that made the erase path 10% cheaper
+- An unbounded probe that hangs -- and the 10% speedup that came with it is an inlining artifact
 - `replace()`'s gate was re-measured on a fixed harness and kept, and the harness is the finding
 - `replace()`'s two loops walk with cursors too, and one cursor too many is slower than none
 - `merge()`, and why it is not the loop the caller would write
@@ -301,8 +301,9 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
-**An unbounded probe that hangs, and the bound that made the erase path 10% cheaper** (2026-09-11,
-issue #254, Ryzen 9 7950X, clang 22, `perf stat`, two single-header binaries).
+**An unbounded probe that hangs -- and the 10% speedup that came with it is an inlining artifact**
+(2026-09-11, issue #254, Ryzen 9 7950X, clang 22 and gcc 16, `perf stat`, single-header binaries).
+**The performance half of this entry is a retraction of what it said when first written.**
 
 `slot_of_value()` -- "which slot points at this value", reached from `erase(it)`, `extract(it)`,
 `replace_key()` and `finish_erase` -- probed with `while (true)` and no stopping condition. Its
@@ -320,55 +321,52 @@ supported way to change a key -- but every other map in this class makes it impo
 this one makes it compile, and what it did then was spin rather than say anything. The same shape was
 fixed once before on the miss path, after a fuzz hang that "survived every other target and 767 unit
 tests". It was found here by a benchmark's own control loop hanging: `scripts/ab/merge.cpp` moved the
-key into the destination and then called `src.erase(it)`, which is the same violation by a different
-route. With a `uint64_t` key that loop is correct, so it ran for a long time before a `std::string`
-key turned it into a hang that took ten minutes of a benchmark run to notice.
+key into the destination and then called `src.erase(it)`, the same violation by a different route,
+correct for a `uint64_t` key and a hang for a `std::string` one.
 
-The bound is `delta == m_group_mask`, the same invariant `probe_from` already uses -- the triangular
-sequence has visited every group, so there is nowhere left -- and the exhausted path calls a new
-`on_error_key_changed()`, which throws or aborts. Returning "not found" is not available: every
-caller's contract says the element is there, and the return is a slot number.
+The bound is `delta == m_group_mask`, the same invariant `probe_from` uses, and the exhausted path
+calls `on_error_key_changed()`, which throws or aborts. Returning "not found" is not available: every
+caller's contract says the element is there, and the return is a slot number. **That is the whole
+justification, and it is enough.**
 
-*And it is 10% faster.* Instructions per erase, the erase path alone (a build-only mode subtracted),
-three repeats each, reproduced in two containers:
+*What was claimed, and why it was wrong.* The bound also measured 10% faster, and this entry
+originally explained why. Instructions per erase, the erase path alone, three repeats, reproduced in
+two containers:
 
-| variant | repeats |
+| variant | clang, as written |
 |---|---|
-| unbounded `while (true)`, as shipped until now | 132.99 / 132.98 / 132.97 |
-| **bounded, exhaustion is `[[noreturn]]`** | **119.63 / 119.65 / 119.50** |
+| unbounded `while (true)` | 132.99 / 132.98 / 132.97 |
+| bounded, exhaustion is `[[noreturn]]` | 119.63 / 119.65 / 119.50 |
 | bounded, exhaustion returns a `0` sentinel | 136.01 / 136.00 / 136.14 |
 
-Flat across n = 50000 / 200000 / 1000000 (132.88 to 119.92, 133.17 to 119.55, 131.35 to 117.69), with
-the build phase as a control that does not move (513.90M against 513.55M instructions -- the insert
-path is untouched). Time 0.946 and 0.937 in cache, 1.013 at a million where the loop is memory-bound.
+Those numbers are real and reproduce. The *explanation* attached to them -- that a loop with one
+value-producing exit and a dead end is cheaper than one the compiler cannot prove terminates -- was
+invented to fit them, and it does not survive its own first test: the unbounded version already had
+exactly one value-producing exit, so "fewer exits to merge" cannot separate it from the `[[noreturn]]`
+one. Two controls, neither of which was run before the claim went into `CLAUDE.md` as a rule:
 
-**It is not the bound, it is the `[[noreturn]]`**: the sentinel variant is *worse* than no bound at
-all. A loop with one value-producing exit and one dead end is cheaper than one with two exits whose
-values have to merge, and cheaper than one the compiler cannot prove terminates.
-
-*The finding does not generalise to the insert path, which is the half worth keeping.* The header has
-two more unbounded `while (true)` loops, both placement walks looking for the first free slot:
-`place_group`, which every insert reaches, and the copy written out inside
-`fill_buckets_from_values`. Both were given the same bound and the same `[[noreturn]]` exhaustion, and
-measured the same three ways. Instructions per insert, medians of three that agreed to 0.02:
-
-| | unbounded | bounded + `[[noreturn]]` | bounded + plain exit |
+| control | unbounded | `[[noreturn]]` | sentinel |
 |---|---|---|---|
-| reserved, n = 50000 | 125.27 | 125.35 | 125.36 |
-| reserved, n = 200000 | 125.39 | 125.46 | 125.46 |
-| reserved, n = 1000000 | 126.30 | 126.31 | 126.32 |
-| growing, n = 50000 | 169.20 | 169.40 | 169.40 |
-| growing, n = 200000 | 169.40 | 169.59 | 169.58 |
-| growing, n = 1000000 | 190.90 | 191.08 | 191.08 |
+| clang, as written | 132.95 | 119.54 | 136.11 |
+| clang, `slot_of_value` forced `noinline` | 137.05 | 138.10 | 137.05 |
+| gcc, normal inlining | 85.49 | 85.06 | 84.52 |
 
-The bounded versions are **very slightly worse at every size**, by the 0.1 to 0.2 instructions the
-added compare costs, and the `[[noreturn]]` and plain-exit columns are indistinguishable. Not shipped.
+**Pin the inlining and the effect disappears. Change compiler and it never existed.** All three
+variants are within one instruction of each other in both controls, and in both the `[[noreturn]]`
+version is the *worst* of the three by exactly the compare it adds. So the 10% is not a property of
+`[[noreturn]]`, or of bounded loops, or of anything transferable: adding the cold call changed what
+clang chose to inline around `slot_of_value`, and that landed better. Any unrelated edit to those
+functions can flip it back.
 
-The difference between the two paths says what the effect actually is. `slot_of_value` **returns a
-value** and its loop had exactly one exit producing it; `place_group` returns `void` and its loop
-already had a clean `return`. So the win is not "name the impossible path `[[noreturn]]`" -- it is
-"a value-returning loop the compiler cannot prove terminates pays for it, and a dead end is the
-cheapest way to give it an exit". Applying it anywhere else needs that shape, and a measurement.
+This also re-explains the insert-path result correctly. `place_group` and the rehash's placement loop
+were given the same bound and came back 0.1-0.2 instructions per insert *worse* at every size, and
+that was written up as "they return `void`, which is a different shape". It is simpler than that:
+bounding them did not move clang's inlining, so all that was left was the cost of the compare -- which
+is exactly what the two controls above show is the honest baseline everywhere.
+
+*The rule that came out of it*, now in `CLAUDE.md`: an instruction count is immune to code layout but
+**not** to inlining. Before believing one, force the function out of line and re-measure, and check a
+second compiler. Both take minutes, and either would have caught this.
 
 **`replace()`'s gate was re-measured on a fixed harness and kept, and the harness is the finding**
 (2026-09-11, issue #257, `scripts/ab/replace_bulk.cpp`, Ryzen 9 7950X, clang 22, medians of seven).

--- a/test/meson.build
+++ b/test/meson.build
@@ -41,6 +41,7 @@ test_sources = [
     'unit/erase_if.cpp',
     'unit/erase_churn.cpp',
     'unit/merge.cpp',
+    'unit/mutated_key.cpp',
     'unit/move_home.cpp',
     'unit/probe_split.cpp',
     'unit/range_insert.cpp',

--- a/test/unit/erase_churn.cpp
+++ b/test/unit/erase_churn.cpp
@@ -70,4 +70,13 @@ TEST_CASE("erase_churn_keeps_every_live_key_findable") {
             REQUIRE(map.find(gone) == map.end());
         }
     }
+
+    // Then empty it one element at a time by *iterator*, which reaches slot_of_value through
+    // locate() rather than through the backfill the erases above all went via. That probe is bounded
+    // (#254), and a table churned this long at this load is where its bound would fire spuriously if
+    // it were going to: elements here sit further from home than a freshly built table's ever do.
+    while (!map.empty()) {
+        map.erase(map.begin());
+    }
+    REQUIRE(map.size() == 0U);
 }

--- a/test/unit/mutated_key.cpp
+++ b/test/unit/mutated_key.cpp
@@ -1,0 +1,110 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+// This map hands out a mutable key -- README calls "no `const Key` in `std::pair<Key, Value>`" a
+// disadvantage, and `replace_key()` exists so that changing one is a supported operation. What is not
+// supported is changing it behind the map's back and then asking the map to find the element again:
+// every erase-shaped path looks the element up by hashing the key it can see, and after an assignment
+// that hash names a probe sequence the element is not on.
+//
+// Until 2026-09-11 what happened then was that `slot_of_value` walked that sequence for ever at 100%
+// of a core (#254). It is bounded now, so the outcome is diagnosable. The tests below are about the
+// termination, not about the exception type: what they would catch is the bound coming off again.
+
+#if ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()
+
+namespace {
+
+auto mutated_key_map() -> ankerl::unordered_dense::map<std::string, int> {
+    auto map = ankerl::unordered_dense::map<std::string, int>();
+    for (int i = 0; i < 200; ++i) {
+        map.try_emplace("key " + std::to_string(i), i);
+    }
+    return map;
+}
+
+} // namespace
+
+TEST_CASE("mutated_key_erase_by_iterator_terminates") {
+    auto map = mutated_key_map();
+    auto it = map.find("key 42");
+    REQUIRE(it != map.end());
+    it->first = "a key that hashes somewhere else entirely";
+    REQUIRE_THROWS_AS(map.erase(it), std::logic_error);
+}
+
+TEST_CASE("mutated_key_extract_by_iterator_terminates") {
+    auto map = mutated_key_map();
+    auto it = map.find("key 7");
+    REQUIRE(it != map.end());
+    it->first = "a key that hashes somewhere else entirely";
+    REQUIRE_THROWS_AS(map.extract(it), std::logic_error);
+}
+
+TEST_CASE("mutated_key_replace_key_terminates") {
+    auto map = mutated_key_map();
+    auto it = map.find("key 99");
+    REQUIRE(it != map.end());
+    it->first = "a key that hashes somewhere else entirely";
+    REQUIRE_THROWS_AS(map.replace_key(it, "something new"), std::logic_error);
+}
+
+// The other way in: the element whose key was changed is not the one being erased, it is the one the
+// backfill drags into the hole. finish_erase() looks *that* one up, so the throw comes from a call
+// the caller never made against an element the caller did not name.
+TEST_CASE("mutated_key_found_by_the_backfill_terminates") {
+    auto map = mutated_key_map();
+    auto last = map.end() - 1;
+    last->first = "a key that hashes somewhere else entirely";
+    auto victim = map.begin();
+    REQUIRE(victim != last);
+    REQUIRE_THROWS_AS(map.erase(victim), std::logic_error);
+}
+
+// A table of exactly one group, where the bound is `delta == 0` and fires on the first pass: the
+// smallest index is four groups today, so this is the shape the bound's own edge takes.
+TEST_CASE("mutated_key_in_a_tiny_table_terminates") {
+    auto map = ankerl::unordered_dense::map<uint64_t, int>();
+    for (uint64_t i = 0; i < 3; ++i) {
+        map.try_emplace(i * UINT64_C(0x9E3779B97F4A7C15), static_cast<int>(i));
+    }
+    auto it = map.begin();
+    it->first = ~it->first;
+    REQUIRE_THROWS_AS(map.erase(it), std::logic_error);
+}
+
+// And the bound must not fire on anything legitimate: a table churned until elements are sitting well
+// past their home groups, then emptied one element at a time.
+TEST_CASE("mutated_key_bound_never_fires_on_a_churned_table") {
+    auto map = ankerl::unordered_dense::map<uint64_t, uint64_t>();
+    auto state = UINT64_C(0x9E3779B97F4A7C15);
+    auto next = [&state] {
+        state += UINT64_C(0x9E3779B97F4A7C15);
+        auto z = state;
+        z = (z ^ (z >> 30U)) * UINT64_C(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27U)) * UINT64_C(0x94D049BB133111EB);
+        return z ^ (z >> 31U);
+    };
+    map.reserve(1000);
+    while (map.size() < 1000) {
+        auto const key = next();
+        map.try_emplace(key, ~key);
+    }
+    for (size_t round = 0; round < 20000; ++round) {
+        auto const gone = map.begin()->first;
+        REQUIRE(map.erase(gone) == 1U);
+        auto const fresh = next();
+        map.try_emplace(fresh, ~fresh);
+    }
+    while (!map.empty()) {
+        map.erase(map.begin());
+    }
+    REQUIRE(map.empty());
+}
+
+#endif

--- a/test/unit/mutated_key.cpp
+++ b/test/unit/mutated_key.cpp
@@ -2,7 +2,8 @@
 
 #include <app/doctest.h>
 
-#include <cstdint>
+#include <cstddef> // for size_t
+#include <cstdint> // for uint64_t
 #include <stdexcept>
 #include <string>
 
@@ -13,52 +14,43 @@
 // that hash names a probe sequence the element is not on.
 //
 // Until 2026-09-11 what happened then was that `slot_of_value` walked that sequence for ever at 100%
-// of a core (#254). It is bounded now, so the outcome is diagnosable. The tests below are about the
-// termination, not about the exception type: what they would catch is the bound coming off again.
+// of a core (#254). It is bounded now, so the outcome is diagnosable, and these pin both halves: that
+// it comes back at all, and that it comes back as `std::logic_error` rather than by some other route.
+//
+// Over all four container shapes, which is not decoration: `m_group_mask` -- the right-hand side of
+// the new bound -- is `value_idx_type`, a `std::uint32_t` for the default group and a `std::size_t`
+// for `big_map`'s `group_big`, so only `TEST_CASE_MAP` exercises the bound at both widths.
 
-#if ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()
-
-namespace {
-
-auto mutated_key_map() -> ankerl::unordered_dense::map<std::string, int> {
-    auto map = ankerl::unordered_dense::map<std::string, int>();
-    for (int i = 0; i < 200; ++i) {
+TEST_CASE_MAP("mutated_key_terminates_from_every_entry_point", std::string, size_t) {
+    auto map = map_t();
+    for (size_t i = 0; i < 200; ++i) {
         map.try_emplace("key " + std::to_string(i), i);
     }
-    return map;
-}
-
-} // namespace
-
-TEST_CASE("mutated_key_erase_by_iterator_terminates") {
-    auto map = mutated_key_map();
     auto it = map.find("key 42");
     REQUIRE(it != map.end());
     it->first = "a key that hashes somewhere else entirely";
-    REQUIRE_THROWS_AS(map.erase(it), std::logic_error);
-}
 
-TEST_CASE("mutated_key_extract_by_iterator_terminates") {
-    auto map = mutated_key_map();
-    auto it = map.find("key 7");
-    REQUIRE(it != map.end());
-    it->first = "a key that hashes somewhere else entirely";
-    REQUIRE_THROWS_AS(map.extract(it), std::logic_error);
-}
-
-TEST_CASE("mutated_key_replace_key_terminates") {
-    auto map = mutated_key_map();
-    auto it = map.find("key 99");
-    REQUIRE(it != map.end());
-    it->first = "a key that hashes somewhere else entirely";
-    REQUIRE_THROWS_AS(map.replace_key(it, "something new"), std::logic_error);
+    // One clobbered key, every path that then looks it up again. doctest re-runs the body per
+    // subcase, so each gets its own map.
+    SUBCASE("erase") {
+        REQUIRE_THROWS_AS(map.erase(it), std::logic_error);
+    }
+    SUBCASE("extract") {
+        REQUIRE_THROWS_AS(map.extract(it), std::logic_error);
+    }
+    SUBCASE("replace_key") {
+        REQUIRE_THROWS_AS(map.replace_key(it, "something new"), std::logic_error);
+    }
 }
 
 // The other way in: the element whose key was changed is not the one being erased, it is the one the
 // backfill drags into the hole. finish_erase() looks *that* one up, so the throw comes from a call
 // the caller never made against an element the caller did not name.
-TEST_CASE("mutated_key_found_by_the_backfill_terminates") {
-    auto map = mutated_key_map();
+TEST_CASE_MAP("mutated_key_found_by_the_backfill_terminates", std::string, size_t) {
+    auto map = map_t();
+    for (size_t i = 0; i < 200; ++i) {
+        map.try_emplace("key " + std::to_string(i), i);
+    }
     auto last = map.end() - 1;
     last->first = "a key that hashes somewhere else entirely";
     auto victim = map.begin();
@@ -66,45 +58,16 @@ TEST_CASE("mutated_key_found_by_the_backfill_terminates") {
     REQUIRE_THROWS_AS(map.erase(victim), std::logic_error);
 }
 
-// A table of exactly one group, where the bound is `delta == 0` and fires on the first pass: the
-// smallest index is four groups today, so this is the shape the bound's own edge takes.
-TEST_CASE("mutated_key_in_a_tiny_table_terminates") {
-    auto map = ankerl::unordered_dense::map<uint64_t, int>();
+// The smallest index there is: `initial_shifts` is 64 - 2, so four groups, and the bound fires after
+// four passes rather than after a long walk. It never reaches `delta == 0`, which is the edge the
+// miss probe's own comment says is unreachable for the same reason.
+TEST_CASE_MAP("mutated_key_in_the_smallest_table_terminates", uint64_t, int) {
+    auto map = map_t();
     for (uint64_t i = 0; i < 3; ++i) {
         map.try_emplace(i * UINT64_C(0x9E3779B97F4A7C15), static_cast<int>(i));
     }
+    REQUIRE(map.bucket_count() == 64U); // four groups of sixteen
     auto it = map.begin();
     it->first = ~it->first;
     REQUIRE_THROWS_AS(map.erase(it), std::logic_error);
 }
-
-// And the bound must not fire on anything legitimate: a table churned until elements are sitting well
-// past their home groups, then emptied one element at a time.
-TEST_CASE("mutated_key_bound_never_fires_on_a_churned_table") {
-    auto map = ankerl::unordered_dense::map<uint64_t, uint64_t>();
-    auto state = UINT64_C(0x9E3779B97F4A7C15);
-    auto next = [&state] {
-        state += UINT64_C(0x9E3779B97F4A7C15);
-        auto z = state;
-        z = (z ^ (z >> 30U)) * UINT64_C(0xBF58476D1CE4E5B9);
-        z = (z ^ (z >> 27U)) * UINT64_C(0x94D049BB133111EB);
-        return z ^ (z >> 31U);
-    };
-    map.reserve(1000);
-    while (map.size() < 1000) {
-        auto const key = next();
-        map.try_emplace(key, ~key);
-    }
-    for (size_t round = 0; round < 20000; ++round) {
-        auto const gone = map.begin()->first;
-        REQUIRE(map.erase(gone) == 1U);
-        auto const fresh = next();
-        map.try_emplace(fresh, ~fresh);
-    }
-    while (!map.empty()) {
-        map.erase(map.begin());
-    }
-    REQUIRE(map.empty());
-}
-
-#endif


### PR DESCRIPTION
Closes #254.

`slot_of_value()` — "which slot points at this value", reached from `erase(it)`, `extract(it)`, `replace_key()` and `finish_erase` — probed with `while (true)` and no stopping condition. Its precondition is that some slot does point there, and the map's own callers always satisfy it. But this map hands out a **mutable key**, so a caller can break it with an assignment and no cast:

```cpp
auto it = m.find("key 42");
it->first = "something else entirely";  // compiles; README lists no-const-Key as a disadvantage
m.erase(it);                            // ran until killed, at 100% of one core
```

On `origin/main` that reproducer exits 124 (timed out); on this branch it exits 134 with a named `std::logic_error`.

It is the caller's mistake — `replace_key()` is the supported way to change a key — but every other map in this class makes it impossible to *write*, this one makes it compile, and what it did then was spin rather than say anything. The same shape was fixed once before on the miss path, after a fuzz hang that "survived every other target and 767 unit tests". It surfaced here because `scripts/ab/merge.cpp`'s own control loop moved the key into the destination and then called `src.erase(it)` — the same violation by a different route, correct for a `uint64_t` key, a hang for a `std::string` one.

The bound is `delta == m_group_mask`, the invariant `probe_from` already uses, with the exhausted path calling a new `on_error_key_changed()`. Returning "not found" is not available: every caller's contract says the element is there, and the return is a slot number.

## About the "10% faster" this PR used to claim

It measured 133.0 → 119.5 instructions per erase, and I wrote an explanation for it. **The explanation was wrong and the third commit retracts it.**

| control | unbounded | `[[noreturn]]` | sentinel |
|---|---|---|---|
| clang, as written | 132.95 | 119.54 | 136.11 |
| clang, `slot_of_value` forced `noinline` | 137.05 | 138.10 | 137.05 |
| gcc, normal inlining | 85.49 | 85.06 | 84.52 |

Pin the inlining and the effect disappears; change compiler and it never existed. In both controls all three variants are within one instruction, and the `[[noreturn]]` one is the *worst* by exactly the compare it adds. The 10% was clang landing on a different inlining decision around `slot_of_value` — something any unrelated edit can flip. The numbers stay in `notes/index-design.md` because they reproduce, labelled as the artifact they are.

**So the justification for this PR is the hang, and only the hang.** The cost is one compare on the walking path and nothing on a home-group hit.

The rule that came out of it, now in `CLAUDE.md` in place of the wrong one: an instruction count is immune to code layout but **not** to inlining — pin the inlining with `noinline` and check a second compiler before believing one. Either control takes minutes and either would have caught this.

It also re-explains the insert-path result correctly. `place_group` and the rehash's placement loop got the same bound and came back 0.1–0.2 instructions per insert *worse*, which I had written up as "they return `void`, a different shape". Simpler: bounding them did not move clang's inlining, so all that was left was the compare — the honest baseline the controls show everywhere.

## Verification

- 829 tests pass on clang release, gcc release, ASan and unity-16; `-fno-exceptions` (clang and gcc), `-std=c++23` and `-m32` compile clean.
- `test/unit/mutated_key.cpp` runs over all four shapes `TEST_CASE_MAP` covers. That is not decoration: `m_group_mask` — the right-hand side of the new bound — is `value_idx_type`, a `uint32_t` for the default group and a `size_t` for `big_map`'s `group_big`, so only the macro exercises the bound at both widths. Cases: `erase(it)`, `extract(it)`, `replace_key()`, the element found by the *backfill* rather than named by the caller, and the smallest possible index (four groups, asserted).
- The false-positive guard lives in `erase_churn.cpp`, which already churns 200000 rounds at load 0.79 with the index never rebuilt; it gained a three-line drain *by iterator*, which reaches `slot_of_value` through `locate()` rather than the backfill.
- Mutation on the diff: **100% killed, 0 survived**. One verdict is `hung` — the bug itself being put back.
- Paired score against `origin/main`, 8 epochs: geomean 0.9961 over 17 workloads. Given the above, read that as "nothing regressed", not as a win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)