### PR TITLE
Store through the walk instead of packing a slot the store unpacks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,11 +141,10 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
   compiler upgrade or an unrelated edit to those functions can flip, and one that transfers to
   nothing else. **Instruction counts are immune to code layout, not to inlining.** Before
   *generalising* one, pin the inlining with `noinline` and check a second compiler; both take
-  minutes. Keep the win, do not build a rule on it. #254. The contrast is #260, which removed the
-  slot pack-and-unpack between `finish_erase` and `index_at`: -5.1 instructions per erase under clang
-  and -4.5 under gcc, the same seven instructions gone from both disassemblies, and the rest of the
-  binary byte-identical. Two compilers and a visible mechanism are what tell a property of the change
-  from an inlining accident.
+  minutes. Keep the win, do not build a rule on it. #254. The contrast is #260, where the same kind of
+  count did transfer: taking a slot pack-and-unpack out of `finish_erase` reads -5.1 instructions per
+  erase under clang and -4.5 under gcc, from a mechanism visible in the disassembly and with nothing
+  else in the binary changed.
 - **Do not edit a shell script while it is running.** bash re-reads the file at its old byte offset.
 
 ### Rules the workloads themselves must obey

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,11 @@ Each of these was learned by getting an answer wrong first; `notes/index-design.
   compiler upgrade or an unrelated edit to those functions can flip, and one that transfers to
   nothing else. **Instruction counts are immune to code layout, not to inlining.** Before
   *generalising* one, pin the inlining with `noinline` and check a second compiler; both take
-  minutes. Keep the win, do not build a rule on it. #254.
+  minutes. Keep the win, do not build a rule on it. #254. The contrast is #260, which removed the
+  slot pack-and-unpack between `finish_erase` and `index_at`: -5.1 instructions per erase under clang
+  and -4.5 under gcc, the same seven instructions gone from both disassemblies, and the rest of the
+  binary byte-identical. Two compilers and a visible mechanism are what tell a property of the change
+  from an inlining accident.
 - **Do not edit a shell script while it is running.** bash re-reads the file at its old byte offset.
 
 ### Rules the workloads themselves must obey

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1415,11 +1415,6 @@ public:
     [[nodiscard]] auto data() const -> block const* {
         return m_blocks.data();
     }
-    // The few places that hold a flat slot number rather than a group and a lane. slots is a power
-    // of two, so this is a shift and a mask.
-    [[nodiscard]] auto index_at(std::size_t slot) -> value_idx_type& {
-        return m_blocks[slot / slots].m_index[slot % slots];
-    }
     // Zeroes the metadata of every block and leaves the indices alone, which is what the split
     // version's single memset did: an empty slot's index is never read.
     void clear_metadata() {
@@ -2044,9 +2039,10 @@ private:
     // there and the return is a slot number -- so the useful outcome is a diagnosable abort rather
     // than a core spinning at 100% forever, which is what this did until 2026-09-11 (#254).
     //
-    // Two things the throw is not. It is not recoverable: reached from finish_erase the slot is
-    // already gone, so the table is in the state that comment describes as unusable, and the
-    // exception says what happened rather than offering to continue. And it is not a guarantee --
+    // Two things the throw is not. It is not recoverable: reached from the backfill in finish_erase
+    // -- through repoint_value, the twin below -- the slot is already gone, so the table is in the
+    // state that comment describes as unusable, and the exception says what happened rather than
+    // offering to continue. And it is not a guarantee --
     // if the mutated key's sequence happens to cross the element's real slot with a matching
     // fingerprint, a wrong-but-valid slot comes back and the counters are unwound from the wrong
     // home instead. Bounding turns a hang into a diagnosis; only `replace_key()` turns it into a
@@ -2073,6 +2069,41 @@ private:
                 auto const slot = static_cast<value_idx_type>(std::size_t{group_idx} * slots_per_group + lane);
                 if (group.m_index[lane] == value_idx) {
                     return slot;
+                }
+                lanes &= lanes - 1;
+            }
+            if (ANKERL_UNORDERED_DENSE_UNLIKELY(delta == m_group_mask))
+                ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                    on_error_key_changed();
+                }
+            group_idx = next_group(group_idx, delta);
+        }
+    }
+
+    // The same walk, for the one caller that does not want a slot number but only to overwrite the
+    // index it finds. Handing that caller a slot was worth 5.1 instructions per erase under clang and
+    // 4.5 under gcc: the loop has the group base and the lane in registers and packs them into
+    // `group_idx * slots_per_group + lane`, which the store then took straight back apart --
+    // `shl / add / mov / shr / imul $0x58 / add / and $0xf` in front of a store that is now one
+    // `mov`. Clang folds that away on the erase(iterator) path, where erase_group_slot gets the same
+    // slot, and did not fold it here (#260). Returning a pointer to the index instead of storing
+    // through it compiles to a byte-identical binary, so the choice between the two is cosmetic.
+    //
+    // Precondition, bound and exhaustion are slot_of_value's; its comment is the one to read.
+    void repoint_value(std::uint64_t mh, value_idx_type value_idx, value_idx_type new_value_idx) {
+        auto const word = fingerprint_word(mh);
+        auto group_idx = group_idx_from_hash(mh);
+        auto* groups = m_buckets.data();
+        value_idx_type delta = 0;
+        while (true) {
+            prefetch_index(groups, group_idx);
+            auto& group = groups[group_idx];
+            auto lanes = match_fingerprint(group, word);
+            while (lanes != 0) {
+                auto const lane = first_lane(lanes);
+                if (group.m_index[lane] == value_idx) {
+                    group.m_index[lane] = new_value_idx;
+                    return;
                 }
                 lanes &= lanes - 1;
             }
@@ -2435,7 +2466,7 @@ private:
             // update the value index of the moved entry
             auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
             auto const mh = mixed_hash(get_key(val));
-            m_buckets.index_at(slot_of_value(mh, values_idx_back)) = value_idx_to_remove;
+            repoint_value(mh, values_idx_back, value_idx_to_remove);
         }
         m_values.pop_back();
     }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -2039,10 +2039,10 @@ private:
     // there and the return is a slot number -- so the useful outcome is a diagnosable abort rather
     // than a core spinning at 100% forever, which is what this did until 2026-09-11 (#254).
     //
-    // Two things the throw is not. It is not recoverable: reached from the backfill in finish_erase
-    // -- through repoint_value, the twin below -- the slot is already gone, so the table is in the
-    // state that comment describes as unusable, and the exception says what happened rather than
-    // offering to continue. And it is not a guarantee --
+    // Two things the throw is not. It is not recoverable: the twin below reaches it from the backfill
+    // in finish_erase, where the slot is already gone, so the table is in the state that comment
+    // describes as unusable and the exception says what happened rather than offering to continue.
+    // And it is not a guarantee --
     // if the mutated key's sequence happens to cross the element's real slot with a matching
     // fingerprint, a wrong-but-valid slot comes back and the counters are unwound from the wrong
     // home instead. Bounding turns a hang into a diagnosis; only `replace_key()` turns it into a
@@ -2081,15 +2081,15 @@ private:
     }
 
     // The same walk, for the one caller that does not want a slot number but only to overwrite the
-    // index it finds. Handing that caller a slot was worth 5.1 instructions per erase under clang and
-    // 4.5 under gcc: the loop has the group base and the lane in registers and packs them into
-    // `group_idx * slots_per_group + lane`, which the store then took straight back apart --
-    // `shl / add / mov / shr / imul $0x58 / add / and $0xf` in front of a store that is now one
-    // `mov`. Clang folds that away on the erase(iterator) path, where erase_group_slot gets the same
-    // slot, and did not fold it here (#260). Returning a pointer to the index instead of storing
-    // through it compiles to a byte-identical binary, so the choice between the two is cosmetic.
+    // index it finds. Handing that caller a slot cost 5.1 instructions per erase under clang and 4.5
+    // under gcc: the loop has the group base and the lane in registers, packs them into `group_idx *
+    // slots_per_group + lane`, and the store then took that straight back apart. Clang folds it away
+    // on the erase(iterator) path, where erase_group_slot gets the same slot, and did not fold it
+    // here; gcc folds it at none of the sites that still pack one. notes/index-design.md has the
+    // before and after (#260).
     //
-    // Precondition, bound and exhaustion are slot_of_value's; its comment is the one to read.
+    // Precondition, bound and exhaustion are slot_of_value's; its comment is the one to read, and
+    // the half of it about the throw not being recoverable is about this function.
     void repoint_value(std::uint64_t mh, value_idx_type value_idx, value_idx_type new_value_idx) {
         auto const word = fingerprint_word(mh);
         auto group_idx = group_idx_from_hash(mh);

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -315,14 +315,17 @@ m_buckets.index_at(slot_of_value(mh, values_idx_back)) = value_idx_to_remove;
 and the two halves undo each other. `slot_of_value` has the group base and the lane in registers when
 it finds the entry, packs them into `group_idx * slots_per_group + lane`, and `index_at` -- its only
 caller -- divides that straight back into `slot / slots` and `slot % slots`. Clang folds it on the
-`erase(iterator)` path, where the slot goes to `erase_group_slot`, and did not fold it here.
+`erase(iterator)` path, where the slot goes to `erase_group_slot`, and did not fold it here. **gcc
+folds it nowhere**: `shr $0x4` and `and $0xf` are still there in `erase(iterator)`, `erase(key)` and
+the writing hit's `move_home`, which all pack a slot out of `probe_result` for a consumer that takes
+it apart again. That is the same defect at four more sites and it is #262, not this entry.
 
 `repoint_value(mh, value_idx, new_value_idx)` is the same walk storing in place, with the same
 `delta == m_group_mask` bound and the same `on_error_key_changed()` exhaustion #254 gave the original.
 `index_at` had no other caller and is gone.
 
-**The whole binary is identical apart from `finish_erase`**, which is what makes this measurable
-rather than arguable. In the tail, `shl $0x4 / add / mov / shr $0x4 / imul $0x58 / add / and $0xf`
+**The whole binary is identical apart from `finish_erase`** and the addresses that shift after it,
+which is what makes this measurable rather than arguable. In the tail, `shl $0x4 / add / mov / shr $0x4 / imul $0x58 / add / and $0xf`
 ahead of the store becomes one `mov %esi,0x18(%r11,%r14,4)`; and clang then restructures the lane
 loop, hoisting `add %rax,%r11` and `movzwl` out of it and moving `lanes &= lanes - 1` after the
 compare, so the found case -- the common one -- skips three more instructions.
@@ -346,8 +349,8 @@ direction: one header per binary against `origin/main`, clang **1.0076** (5 of 5
 **1.0019** (4 of 5).
 
 Two details worth keeping. A variant that returns `value_idx_type*` and lets the caller store through
-it compiles to a **byte-identical binary** under clang, so the choice between storing inside the walk
-and handing back a pointer is cosmetic. And #254 predicted this would lose: it found that a loop
+it compiles to a **byte-identical binary** under clang -- under gcc only the benchmark's own stack
+slots move -- so the choice between storing inside the walk and handing back a pointer is cosmetic. And #254 predicted this would lose: it found that a loop
 returning a value pays for a `[[noreturn]]` exit while `place_group`, which returns `void`, measured
 0.1-0.2 instructions per insert *worse* -- and `repoint_value` returns `void`. That prediction was
 about the wrong thing. What is removed here is not an exit, it is a pack and an unpack, and the

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -32,6 +32,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- `finish_erase` packed a slot that the store took straight back apart
 - An unbounded probe that hangs -- and the 10% speedup that came with it is an inlining artifact
 - `replace()`'s gate was re-measured on a fixed harness and kept, and the harness is the finding
 - `replace()`'s two loops walk with cursors too, and one cursor too many is slower than none
@@ -301,6 +302,58 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**`finish_erase` packed a slot that the store took straight back apart** (2026-09-11, issue #260,
+Ryzen 9 7950X, clang 22 and gcc 16, `perf stat`, single-header binaries).
+
+Every erase but the last one per table backfills: the last value moves into the hole and the slot
+pointing at it has to be repointed. That was written as
+
+```cpp
+m_buckets.index_at(slot_of_value(mh, values_idx_back)) = value_idx_to_remove;
+```
+
+and the two halves undo each other. `slot_of_value` has the group base and the lane in registers when
+it finds the entry, packs them into `group_idx * slots_per_group + lane`, and `index_at` -- its only
+caller -- divides that straight back into `slot / slots` and `slot % slots`. Clang folds it on the
+`erase(iterator)` path, where the slot goes to `erase_group_slot`, and did not fold it here.
+
+`repoint_value(mh, value_idx, new_value_idx)` is the same walk storing in place, with the same
+`delta == m_group_mask` bound and the same `on_error_key_changed()` exhaustion #254 gave the original.
+`index_at` had no other caller and is gone.
+
+**The whole binary is identical apart from `finish_erase`**, which is what makes this measurable
+rather than arguable. In the tail, `shl $0x4 / add / mov / shr $0x4 / imul $0x58 / add / and $0xf`
+ahead of the store becomes one `mov %esi,0x18(%r11,%r14,4)`; and clang then restructures the lane
+loop, hoisting `add %rax,%r11` and `movzwl` out of it and moving `lanes &= lanes - 1` after the
+compare, so the found case -- the common one -- skips three more instructions.
+
+Instructions per erase, build-only subtracted, three repeats each (they do not vary):
+
+| | 50k | 200k | 1M |
+|---|---|---|---|
+| clang, before | 119.57 | 119.43 | 117.59 |
+| clang, after | **114.50** | **114.36** | **112.58** |
+| gcc, before | | 84.95 | 83.09 |
+| gcc, after | | **80.43** | **78.58** |
+
+Time follows under gcc -- 6.04 to 5.67 ns/erase at 200k and 5.97 to 5.65 at 1M -- and under clang it
+does not: flat at 50k and 200k, and at 1M the median of nine alternating runs reads 10.44 before
+against 10.76 after, about 3% the wrong way. Loads, stores, branch misses and L1 misses per erase are
+the same to three digits there, and cycles for the *same* binary swing 51.7 to 59.4 between runs, so
+that 3% is the layout band the rest of this file keeps warning about -- everything after
+`finish_erase` sits 48 bytes lower in the candidate. The score says the same thing in the other
+direction: one header per binary against `origin/main`, clang **1.0076** (5 of 5 rounds) and gcc
+**1.0019** (4 of 5).
+
+Two details worth keeping. A variant that returns `value_idx_type*` and lets the caller store through
+it compiles to a **byte-identical binary** under clang, so the choice between storing inside the walk
+and handing back a pointer is cosmetic. And #254 predicted this would lose: it found that a loop
+returning a value pays for a `[[noreturn]]` exit while `place_group`, which returns `void`, measured
+0.1-0.2 instructions per insert *worse* -- and `repoint_value` returns `void`. That prediction was
+about the wrong thing. What is removed here is not an exit, it is a pack and an unpack, and the
+difference shows in both compilers and in the disassembly, which is how a property of the change
+tells itself apart from an inlining accident.
+
 **An unbounded probe that hangs -- and the 10% speedup that came with it is an inlining artifact**
 (2026-09-11, issue #254, Ryzen 9 7950X, clang 22 and gcc 16, `perf stat`, single-header binaries).
 **The performance half of this entry is a retraction of what it said when first written.**

--- a/scripts/mutate/bugs/invariants.txt
+++ b/scripts/mutate/bugs/invariants.txt
@@ -145,6 +145,18 @@
                 return slot;
 >>>
 
+# the backfill's search for the slot accepts any fingerprint match
+# repoint_value is the same search, walked for the value the dense move just brought into the hole,
+# and it writes rather than returns. Without the index check it overwrites the first slot sharing a
+# fingerprint: that entry now names the moved value and the moved value is reachable from nothing.
+<<<
+                if (group.m_index[lane] == value_idx) {
+                    group.m_index[lane] = new_value_idx;
+===
+                if (static_cast<void>(value_idx), true) {
+                    group.m_index[lane] = new_value_idx;
+>>>
+
 # ---------------------------------------------------------------- growth and load factor
 
 # the table never decides it is full, so it fills up completely and probes forever
@@ -302,14 +314,14 @@
 <<<
             auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
             auto const mh = mixed_hash(get_key(val));
-            m_buckets.index_at(slot_of_value(mh, values_idx_back)) = value_idx_to_remove;
+            repoint_value(mh, values_idx_back, value_idx_to_remove);
         }
         m_values.pop_back();
 ===
             m_values.pop_back();
             auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
             auto const mh = mixed_hash(get_key(val));
-            m_buckets.index_at(slot_of_value(mh, values_idx_back)) = value_idx_to_remove;
+            repoint_value(mh, values_idx_back, value_idx_to_remove);
             return;
         }
         m_values.pop_back();

--- a/test/unit/mutated_key.cpp
+++ b/test/unit/mutated_key.cpp
@@ -44,8 +44,9 @@ TEST_CASE_MAP("mutated_key_terminates_from_every_entry_point", std::string, size
 }
 
 // The other way in: the element whose key was changed is not the one being erased, it is the one the
-// backfill drags into the hole. finish_erase() looks *that* one up, so the throw comes from a call
-// the caller never made against an element the caller did not name.
+// backfill drags into the hole. finish_erase() looks *that* one up -- through repoint_value(), which
+// walks the same probe sequence under the same bound -- so the throw comes from a call the caller
+// never made against an element the caller did not name.
 TEST_CASE_MAP("mutated_key_found_by_the_backfill_terminates", std::string, size_t) {
     auto map = map_t();
     for (size_t i = 0; i < 200; ++i) {


### PR DESCRIPTION
`finish_erase` repointed the backfilled value with

```cpp
m_buckets.index_at(slot_of_value(mh, values_idx_back)) = value_idx_to_remove;
```

and the two halves undo each other. `slot_of_value` has the group base and the lane in registers when
it finds the entry, packs them into `group_idx * slots_per_group + lane`, and `index_at` -- its only
caller -- divides that straight back into `slot / slots` and `slot % slots`. Clang folds it on the
`erase(iterator)` path, where the slot goes to `erase_group_slot`, and did not fold it here. Every
erase but the last one per table backfills, so every one of them paid for it.

`repoint_value(mh, value_idx, new_value_idx)` is the same walk storing in place, with the same
`delta == m_group_mask` bound and the same `on_error_key_changed()` exhaustion #254 gave the original.
`index_at` had no other caller and is gone.

## What changed in the binary

Only `finish_erase` — the rest is identical apart from addresses. `shl $0x4 / add / mov / shr $0x4 /
imul $0x58 / add / and $0xf` ahead of the store becomes one `mov %esi,0x18(%r11,%r14,4)`, and clang
then restructures the lane loop: `add %rax,%r11` and `movzwl` hoist out, `lanes &= lanes - 1` moves
after the compare, so the found case — the common one — skips three more instructions.

## Measurements

Instructions per erase, two single-header binaries, build-only subtracted, three repeats each (they
do not vary):

| | 50k | 200k | 1M |
|---|---|---|---|
| clang, before | 119.57 | 119.43 | 117.59 |
| clang, after | **114.50** | **114.36** | **112.58** |
| gcc, before | | 84.95 | 83.09 |
| gcc, after | | **80.43** | **78.58** |

Time follows under gcc — 6.04 → 5.67 ns/erase at 200k, 5.97 → 5.65 at 1M — and under clang it does
not: flat at 50k and 200k, and at 1M the median of nine alternating runs reads 10.44 before against
10.76 after, about 3% the wrong way. Loads, stores, branch misses and L1 misses per erase are the same
to three digits there, and cycles for the *same* binary swing 51.7–59.4 between runs, so that is the
layout band — everything after `finish_erase` sits 48 bytes lower.

The score, one header per binary against `origin/main` (`scripts/ab/solo.sh`, above 1.00 means the
branch is faster): clang **1.0076** (5 of 5 rounds), gcc **1.0019** (4 of 5).

#254 predicted this would lose — it found that `place_group`, which returns `void`, measured 0.1–0.2
instructions per insert *worse* for the same treatment, and `repoint_value` returns `void` too. That
prediction was about the wrong thing: what is removed here is not an exit, it is a pack and an unpack,
and it shows in both compilers and in the disassembly. `notes/index-design.md` has the entry and
`CLAUDE.md` gains one sentence on telling those two apart.

A variant returning `value_idx_type*` for the caller to store through compiles to a **byte-identical**
binary under clang, so that choice is cosmetic.

## Verification

- 829 tests green on clang release, gcc release, ASan and unity-16
- `-fno-exceptions` (clang and gcc), `-std=c++23`, `-m32` compile clean with `-Wconversion`
- `scripts/mutate/mutate.py --diff`: 24 mutants, 96% killed, one survivor — deleting
  `prefetch_index`, which is a hint and cannot change behaviour. Six `hang` verdicts are the #254 bug
  being put back into the new copy of the walk, i.e. the bound is load-bearing here too.
- `mutated_key_found_by_the_backfill_terminates` is the test that reaches this function's exhaustion
  path; its comment now names it.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)