### PR TITLE
Add an opt-in huge page allocator, and measure it across the size axis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,9 +347,13 @@ session did find is below the code.
 measured by running one binary twice with `GLIBC_TUNABLES=glibc.malloc.hugetlb=1` on and off; 22%
 of a lookup past L3. The old line here said the score could not see them; it was measuring hits on a
 warm map, the one shape that overlaps its translations. Nothing in the header can ask for a page
-size. An opt-in allocator can (#231), and so can a user's environment; both are worth documenting.
+size. An opt-in allocator can, and so can a user's environment; both are documented in README 3.8.
+`huge_page_allocator` (#231) puts blocks of 2 MB and up on their own huge pages: `build` 1.5-1.7x
+from 200000 entries, `churn` 1.33x at 800000, lookups 1.14x at 4M, **nothing at 50000** because
+no block there is 2 MB -- the score's churn gain needs the heap-wide route, which shares extents.
+A string's body is `malloc`ed outside any allocator the map holds and stays on 4 KB pages.
 
-*Still open.* The opt-in huge page allocator itself (#231).
+*Still open.* Nothing measured and unclaimed; #231's size sweep is in the notes.
 A built-in probe-length statistics facility like boost's. The string erase's ~50 ns second hash.
 
 *Bulk lookups.* `visit(first, last, f)` is 1.07-1.14x over the same batch looked up one key at a

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Additionally, there are `ankerl::unordered_dense::segmented_map` and `ankerl::un
     - [3.5.2. `ankerl::unordered_dense::bucket_type::group_big`](#352-ankerlunordered_densebucket_typegroup_big)
   - [3.6. Disabling the Vector Probe](#36-disabling-the-vector-probe)
   - [3.7. LLDB Data Formatters](#37-lldb-data-formatters)
+  - [3.8. Huge Pages](#38-huge-pages)
 - [4. `segmented_map` and `segmented_set`](#4-segmented_map-and-segmented_set)
 - [5. Design](#5-design)
   - [5.1. Inserts](#51-inserts)
@@ -527,6 +528,55 @@ script unordered_dense.NAME_CHILDREN_BY_KEY = False
 
 Custom value containers (see [3.4](#34-custom-container-types)) fall back to whatever LLDB itself can display for
 them.
+
+### 3.8. Huge Pages
+
+A lookup touches two or three random addresses -- the group's block, the value it points at, and for a string key its body -- and on 4 KB pages each of them is an address translation. A first-level data TLB holds on the order of 64-96 entries, a few hundred KB, so any table larger than that pays an L2 TLB lookup per access, and on a dependent chain that lookup is latency. Measured on this library's own scored benchmark by running the same binary with its heap on 2 MB pages: **2.6% (gcc) to 3.6% (clang) over the whole score, 5-8% on churn and on random finds at 50000 entries, and 22% of a lookup past the last-level cache**. Nothing asks for huge pages by default, and on the common Linux setting (`/sys/kernel/mm/transparent_hugepage/enabled` = `madvise`) nothing gets them without asking. There are two ways to ask.
+
+**The environment, for the whole process.** glibc 2.35 and later can `madvise` its heap for you:
+
+```sh
+GLIBC_TUNABLES=glibc.malloc.hugetlb=1 ./your_program
+```
+
+This is what the numbers above were measured with, and it is the route that helps *small* tables too, because neighbouring blocks share a 2 MB extent on the heap. Setting the THP mode to `always` does the same for every process on the machine.
+
+**The allocator, for one map.** `include/ankerl/huge_page_allocator.h` is a separate header (it needs `<sys/mman.h>`) with an allocator that puts every block of 2 MB and up on its own 2 MB-aligned, `MADV_HUGEPAGE`d mapping and leaves smaller ones to `std::allocator`:
+
+```cpp
+#include <ankerl/huge_page_allocator.h>
+
+using map_t = ankerl::unordered_dense::map<uint64_t, uint64_t,
+                                           ankerl::unordered_dense::hash<uint64_t>,
+                                           std::equal_to<uint64_t>,
+                                           ankerl::unordered_dense::huge_page_allocator<std::pair<uint64_t, uint64_t>>>;
+```
+
+Both the index and the values get it, since the index rebinds the value allocator. What it is worth, ns per operation with `std::allocator` and with this one, on the scored workloads at sizes the score does not run (clang, Ryzen 9 7950X; gcc within a few percent of the same ratios):
+
+| | 200000 | 800000 | 4000000 |
+|---|---|---|---|
+| build from empty, `uint64_t` | 20.4 → 13.3 (**1.53x**) | 22.1 → 12.8 (**1.73x**) | 38.4 → 24.6 (**1.56x**) |
+| build from empty, `std::string` | 71.9 → 63.6 (1.13x) | 85.5 → 68.6 (1.25x) | 121.8 → 94.4 (1.29x) |
+| churn at a fixed size, `uint64_t` | 12.7 → 12.3 (1.03x) | 16.1 → 12.1 (**1.33x**) | 53.7 → 49.4 (1.09x) |
+| random find, 50% hits, `uint64_t` | 5.49 → 5.45 | 6.50 → 6.21 (1.05x) | 16.3 → 14.3 (1.14x) |
+
+A build gains more than the TLB explains: a vector that doubles faults in every new block, and on 2 MB pages that is 512 times fewer faults. It is not specific to this map -- `boost::unordered_flat_map` on the same allocator gains 1.5-1.9x on integer builds and 1.62x on churning 64 byte values, where its single region holds the values inline -- so it changes nothing about which map is ahead where; the full table is in `notes/index-design.md`. Two things to know:
+
+* **It only helps once the blocks themselves reach 2 MB**, which is the index from about 370000 entries and the values from `2 MB / sizeof(value_type)` entries. A huge page is 2 MB whole, and an allocator that owns only its own blocks has no neighbour to share one with -- that is what the environment route has and this one does not. Below that size, use the environment.
+* **Every block is rounded up to 2 MB, and the rounding is resident memory**, because touching one byte of an `MADV_HUGEPAGE`d extent populates all of it. The map doubles both regions, so the loss is at most half a doubling step per region, while that region sits between doublings. The threshold is the second template parameter (`huge_page_allocator<T, 4 << 20>`), and it cannot go below 2 MB.
+
+**With `segmented_vector`, size the segment for the page.** A segmented map never reallocates its values, so a segment on a huge page has no rounding loss to amortize and no copy to pay. The segment size is chosen through the container slot rather than the `segmented_map` alias:
+
+```cpp
+ankerl::unordered_dense::map<K, V, ankerl::unordered_dense::hash<K>, std::equal_to<K>,
+    ankerl::unordered_dense::segmented_vector<std::pair<K, V>,
+        ankerl::unordered_dense::huge_page_allocator<std::pair<K, V>>, 16 << 20>>
+```
+
+A segment holds a power of two of elements, rounded *down* to fit the byte size, so a 2 MB segment is exactly one huge page for a 16 byte pair and 1.28 MB -- below the threshold, no huge page -- for a 40 byte one. 16 MB segments bound that rounding at 2 MB each for any element size, and are the setting to use unless `sizeof(value_type)` is a power of two. Measured at 800000 entries, ns per operation, `std::vector` on `std::allocator` / segmented on this allocator with 16 MB segments: build `uint64_t` 22.0 / 14.7, `std::string` 85.6 / **63.3**, 64 byte values 77.1 / **20.5**; churn `uint64_t` 16.1 / 14.5, `std::string` 101.0 / 95.6. The segmented container costs 10-20% on lookups and churn for its extra indirection, and huge pages do not take that back; on builds it is the fastest thing here, because it neither copies nor faults.
+
+On Windows and macOS the class exists with the same interface and forwards everything to `std::allocator`; `huge_page_allocator<T>::uses_huge_pages` says which you got. `scripts/ab/huge_pages.sh` measures it across sizes and workloads, and the measurements are in `notes/index-design.md`.
 
 ## 4. `segmented_map` and `segmented_set`
 

--- a/include/ankerl/huge_page_allocator.h
+++ b/include/ankerl/huge_page_allocator.h
@@ -1,0 +1,211 @@
+///////////////////////// ankerl::unordered_dense::huge_page_allocator /////////////////////////
+
+// An opt-in allocator that puts large blocks on transparent huge pages.
+// Version 5.0.0
+// https://github.com/martinus/unordered_dense
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022 Martin Leitner-Ankerl <martin.ankerl@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef ANKERL_UNORDERED_DENSE_HUGE_PAGE_ALLOCATOR_H
+#define ANKERL_UNORDERED_DENSE_HUGE_PAGE_ALLOCATOR_H
+
+// A separate header rather than a section of unordered_dense.h, because it needs <sys/mman.h>.
+#include "unordered_dense.h" // for the version namespace and ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS
+
+#include <cstddef>     // for size_t, ptrdiff_t
+#include <cstdint>     // for uintptr_t
+#include <cstdlib>     // for abort
+#include <memory>      // for allocator
+#include <new>         // for bad_alloc
+#include <type_traits> // for true_type
+
+#if defined(__linux__) && defined(__has_include)
+#    if __has_include(<sys/mman.h>)
+#        include <sys/mman.h>                              // for mmap, munmap, madvise, MADV_HUGEPAGE
+#        define ANKERL_UNORDERED_DENSE_HAS_MADV_HUGEPAGE 1 // NOLINT(cppcoreguidelines-macro-usage)
+#    endif
+#endif
+#if !defined(ANKERL_UNORDERED_DENSE_HAS_MADV_HUGEPAGE)
+#    define ANKERL_UNORDERED_DENSE_HAS_MADV_HUGEPAGE 0 // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+
+namespace ankerl::unordered_dense {
+inline namespace ANKERL_UNORDERED_DENSE_NAMESPACE {
+
+// What it is for. This map touches two or three regions per operation -- the group block, the
+// value it points at, and a string's body -- and every one of them is a random address, so on 4 KB
+// pages every one is an address translation. Zen 4's first-level data TLB holds 72 entries: 288 KB.
+// Any table larger than that pays an L2 TLB lookup per access, and on a dependent chain -- probe,
+// then value, then an erase's second walk -- that lookup is latency. Measured on the scored
+// benchmark by running the same binary with the heap on 2 MB pages: 2.6% under gcc and 3.6% under
+// clang over all fifteen workloads, 5-8% on churn and on the 50% find at 50000 entries, and 22% of
+// a lookup past the last-level cache (notes/index-design.md, "The score runs on 4 KB pages").
+//
+// What it does. An allocation of at least `Threshold` bytes is `mmap`ed on its own, aligned to 2 MB
+// and rounded up to a multiple of it, and `madvise(MADV_HUGEPAGE)`d, which is what asks the kernel
+// for huge pages when `/sys/kernel/mm/transparent_hugepage/enabled` is `madvise` -- the default on
+// most distributions, and the mode under which a map on `std::allocator` never sees one. Smaller
+// allocations go to `std::allocator<T>`. Hand it to the map as the allocator and both regions get
+// it, since the index rebinds the value allocator:
+//
+//     ankerl::unordered_dense::map<K, V, ankerl::unordered_dense::hash<K>, std::equal_to<K>,
+//                                  ankerl::unordered_dense::huge_page_allocator<std::pair<K, V>>>
+//
+// What it cannot do, and it is the reason the threshold cannot go below 2 MB. Huge pages are 2 MB
+// each, whole: a 360 KB index cannot be on one by itself. The score's 50000-entry tables got theirs
+// from glibc, which `madvise`s the *heap* so that neighbouring small blocks share an extent
+// (`GLIBC_TUNABLES=glibc.malloc.hugetlb=1`, glibc 2.35 and later) -- an allocator that owns only its
+// own blocks has no neighbour to share with. So this pays off once the blocks themselves are 2 MB:
+// an index of about 370000 entries and up, a `std::vector` of values from 2 MB / sizeof(value_type)
+// entries and up. Below that, the environment route is the one that works, and README says so.
+//
+// What it costs. Every block is rounded up to 2 MB, and under `MADV_HUGEPAGE` touching one byte of
+// an aligned 2 MB extent populates all of it, so the rounding is resident memory, not just address
+// space: a 2.1 MB block occupies 4 MB. The map doubles both of its regions, so at most half of one
+// doubling step is lost per region, and only while that region is between doublings. It also means
+// a block below the threshold is never rounded, which is what the threshold is for.
+//
+// Where it is a plain std::allocator. Anywhere without <sys/mman.h> and MADV_HUGEPAGE, which is
+// Windows and macOS: the class exists with the same interface, `uses_huge_pages` is false, and
+// everything is forwarded, so code written against it compiles everywhere and is only faster where
+// the kernel can help. Windows has VirtualAlloc with MEM_LARGE_PAGES, which needs the
+// SeLockMemoryPrivilege that an ordinary process does not have, and macOS has superpages through
+// its own mmap flags; neither is asked for here.
+//
+// The allocator is stateless, so instances compare equal, a container copy takes its own, and
+// propagation is never a question. The threshold is a template parameter for that reason -- a
+// runtime member would make instances differ and make every propagation trait matter.
+template <class T, std::size_t Threshold = (std::size_t{2} << 20U)>
+class huge_page_allocator {
+public:
+    static constexpr std::size_t huge_page_size = std::size_t{2} << 20U;
+    static constexpr std::size_t threshold = Threshold;
+    static constexpr bool uses_huge_pages = ANKERL_UNORDERED_DENSE_HAS_MADV_HUGEPAGE != 0;
+    static_assert(Threshold >= huge_page_size, "a block below one huge page cannot be on a huge page of its own");
+
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using propagate_on_container_move_assignment = std::true_type;
+    using is_always_equal = std::true_type;
+
+    template <class U>
+    struct rebind {
+        using other = huge_page_allocator<U, Threshold>;
+    };
+
+    constexpr huge_page_allocator() noexcept = default;
+
+    template <class U>
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    constexpr huge_page_allocator(huge_page_allocator<U, Threshold> const& /*other*/) noexcept {}
+
+    [[nodiscard]] auto allocate(std::size_t n) -> T* {
+        if (!is_huge(n)) {
+            return std::allocator<T>{}.allocate(n);
+        }
+#if ANKERL_UNORDERED_DENSE_HAS_MADV_HUGEPAGE
+        return static_cast<T*>(map_huge(rounded_bytes(n)));
+#else
+        return std::allocator<T>{}.allocate(n);
+#endif
+    }
+
+    void deallocate(T* p, std::size_t n) noexcept {
+        if (!is_huge(n)) {
+            std::allocator<T>{}.deallocate(p, n);
+            return;
+        }
+#if ANKERL_UNORDERED_DENSE_HAS_MADV_HUGEPAGE
+        ::munmap(static_cast<void*>(p), rounded_bytes(n));
+#else
+        std::allocator<T>{}.deallocate(p, n);
+#endif
+    }
+
+    template <class U, std::size_t Th>
+    [[nodiscard]] friend constexpr auto operator==(huge_page_allocator const& /*a*/,
+                                                   huge_page_allocator<U, Th> const& /*b*/) noexcept -> bool {
+        return Threshold == Th;
+    }
+    template <class U, std::size_t Th>
+    [[nodiscard]] friend constexpr auto operator!=(huge_page_allocator const& a, huge_page_allocator<U, Th> const& b) noexcept
+        -> bool {
+        return !(a == b);
+    }
+
+    // Whether a request for n objects takes the huge page path. Deallocate has to make exactly the
+    // same decision from the same n, which is why it is a pure function of n and the types.
+    [[nodiscard]] static constexpr auto is_huge(std::size_t n) noexcept -> bool {
+        return uses_huge_pages && n >= Threshold / sizeof(T) && n * sizeof(T) >= Threshold;
+    }
+
+private:
+    [[nodiscard]] static constexpr auto rounded_bytes(std::size_t n) noexcept -> std::size_t {
+        auto const bytes = n * sizeof(T);
+        return (bytes + huge_page_size - 1) / huge_page_size * huge_page_size;
+    }
+
+#if ANKERL_UNORDERED_DENSE_HAS_MADV_HUGEPAGE
+    [[noreturn]] static void out_of_memory() {
+#    if ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()
+        throw std::bad_alloc();
+#    else
+        std::abort();
+#    endif
+    }
+
+    // mmap gives page alignment, not 2 MB alignment, so this maps one huge page too many, unmaps
+    // the misaligned head and the tail it no longer needs, and is left holding exactly
+    // [aligned, aligned + len). deallocate then unmaps that range and nothing else needs to be
+    // remembered. The madvise is advice: if the kernel cannot or will not, the block is ordinary
+    // 4 KB pages and still correct, which is why its result is not checked.
+    [[nodiscard]] static auto map_huge(std::size_t len) -> void* {
+        auto const span = len + huge_page_size;
+        auto* raw = ::mmap(nullptr, span, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (raw == MAP_FAILED) { // NOLINT(cppcoreguidelines-pro-type-cstyle-cast,performance-no-int-to-ptr)
+            out_of_memory();
+        }
+        auto const start = reinterpret_cast<std::uintptr_t>(raw); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto const aligned = (start + huge_page_size - 1) / huge_page_size * huge_page_size;
+        auto const head = aligned - start;
+        auto const tail = span - head - len;
+        if (head != 0) {
+            ::munmap(raw, head);
+        }
+        if (tail != 0) {
+            ::munmap(reinterpret_cast<void*>(aligned + len),
+                     tail); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
+        }
+        auto* block =
+            reinterpret_cast<void*>(aligned); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast,performance-no-int-to-ptr)
+        ::madvise(block, len, MADV_HUGEPAGE);
+        return block;
+    }
+#endif
+};
+
+} // namespace ANKERL_UNORDERED_DENSE_NAMESPACE
+} // namespace ankerl::unordered_dense
+
+#endif

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -33,6 +33,7 @@ place rather than being deleted, because the retraction is usually the more usef
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
 - The #260/#262 sweep run over find and churn, and it comes back empty
+- The opt-in huge page allocator, measured across the size axis
 - The score runs on 4 KB pages and pays 1.6 billion L1 dTLB misses for it
 - Nothing holds a flat slot number any more, and gcc was the one paying for it
 - The two value walks do not want the index prefetch the probe wants
@@ -369,6 +370,117 @@ benchmark binary, where the walk is inlined into `workloads::build`, the same lo
 `and %r13d,%r10d` with the mask and the group pointer both hoisted across the store. gcc
 disambiguates it where it matters. **A scratch TU can invent a redundancy as well as hide one**,
 which is the other half of #254's rule.
+
+**The opt-in huge page allocator, measured across the size axis** (2026-09-12, issue #231,
+Ryzen 9 7950X, clang 22 and gcc 16, `scripts/ab/huge_pages.{cpp,sh}`, `include/ankerl/huge_page_allocator.h`).
+
+`huge_page_allocator<T, Threshold = 2 MB>`: a block of at least `Threshold` bytes is `mmap`ed on
+its own, 2 MB aligned, rounded up to a multiple of 2 MB and `madvise(MADV_HUGEPAGE)`d; smaller
+blocks go to `std::allocator`. Handed to the map as the allocator it covers both regions, since the
+index rebinds the value allocator. The harness instantiates the score's own workloads
+(`test/bench/workloads.h`) on the map with each allocator, one cell per process so the variant is
+a template instantiation, five interleaved rounds, medians. ns per operation, `std::allocator` then
+`huge_page_allocator`, ratio above 1 meaning huge pages are faster:
+
+| clang | 50000 | 200000 | 800000 | 4000000 |
+|---|---|---|---|---|
+| `build` u64 | 18.27 / 18.55 (0.98) | 20.40 / 13.30 (**1.53**) | 22.07 / 12.78 (**1.73**) | 38.35 / 24.58 (**1.56**) |
+| `build` str | 68.49 / 58.45 (**1.17**) | 71.91 / 63.59 (**1.13**) | 85.46 / 68.64 (**1.25**) | 121.82 / 94.45 (**1.29**) |
+| `churn` u64 | 10.61 / 10.65 (1.00) | 12.66 / 12.26 (1.03) | 16.13 / 12.12 (**1.33**) | 53.74 / 49.40 (1.09) |
+| `churn` str | 33.95 / 34.15 (0.99) | 44.59 / 40.74 (1.09) | 100.67 / 93.91 (1.07) | 156.20 / 146.53 (1.07) |
+| `churn` big | -- | 15.08 / 12.40 (**1.22**) | 32.93 / 28.13 (**1.17**) | 58.31 / 53.13 (1.10) |
+| `find` u64 | 4.47 / 4.48 (1.00) | 5.49 / 5.45 (1.01) | 6.50 / 6.21 (1.05) | 16.27 / 14.25 (**1.14**) |
+| `find` str | 16.65 / 16.66 (1.00) | 19.27 / 18.91 (1.02) | 28.13 / 25.63 (1.10) | 65.97 / 60.81 (1.08) |
+
+gcc at the two headline sizes says the same: `build` u64 24.18 / 13.92 (**1.74**) at 800k and
+43.12 / 27.00 (**1.60**) at 4M, `build` str 90.14 / 74.78 (1.21) and 126.88 / 99.81 (1.27),
+`churn` u64 18.35 / 13.84 (**1.33**) and 60.23 / 55.89 (1.08), `find` u64 6.10 / 5.80 (1.05) and
+15.13 / 13.17 (**1.15**), `find` str 28.34 / 25.91 (1.09) and 66.14 / 61.38 (1.08), `churn` str
+106.66 / 99.60 (1.07) and 162.69 / 152.21 (1.07).
+
+**Three things the table says.** First, the size axis is the whole result, and it is the header
+comment's: at 50000 entries nothing but the string build moves, because nothing but the string
+values vector (2 MB at 50000 x 40 bytes) reaches a block of 2 MB. The score's 50000-entry churn
+gained 7% from the glibc route in the entry below and 0% here, and both are right -- a per-block
+allocator has no neighbour to share a huge page with. Second, `build` gains far more than the TLB:
+a doubling vector faults in every new block, and on 2 MB pages that is 512 times fewer faults --
+the cost `tame_allocator()` removed from the score, halved again, and it starts at 200000 for
+integers. Third, the allocator's reach ends at what the map allocates. `perf stat` per operation,
+L1 misses served by the L2 TLB / page walks, 4 KB then huge: `find` u64 4M 1.07 / 0.94 to 0.55 /
+0.016; `churn` u64 800k 1.32 / 0.79 to 0.48 / 0.0006; but `churn` str 4M 0.37 / 2.68 to only 0.29 /
+1.11 and `find` str 4M 0.95 / 1.53 to 0.57 / 0.45, because a string's *body* is `malloc`ed outside
+the allocator and still lives on 4 KB pages. The environment route covers those; this one cannot.
+
+**The segmented container, with its segment sized for the page** (asked as "would it make sense to
+size one chunk exactly as one huge page"). Yes, and it is the cleanest fit in the story for a
+power-of-two element size: a 2 MB segment of 16 byte pairs is 131072 elements, exactly one huge
+page, verified 2 MB aligned at elements 0, 131072 and 262144 of a 300000 entry map, with no
+rounding to amortize and no copy on growth. The catch is `num_bits_closest`, which rounds the
+element count *down* to a power of two so the index stays a shift and a mask: a "2 MB" segment of
+40 byte pairs is 32768 elements, 1.28 MB, below the threshold, and gets nothing; 16 MB segments
+bound the rounding at 2 MB per segment for any element size. The `segmented_map` alias hardcodes
+4096 bytes, so the recipe goes through the map's container slot. ns per operation, clang, `std::vector`
+on `std::allocator` / on the allocator / segmented on `std::allocator` / segmented 2 MB on the
+allocator / segmented 16 MB on the allocator:
+
+| | 200000 | 800000 | 4000000 |
+|---|---|---|---|
+| `churn` u64 | 11.80 / 11.38 / 13.98 / 13.39 / 13.47 | 16.05 / 12.00 / 18.61 / 14.19 / 14.52 | 53.94 / 49.55 / 65.95 / 61.23 / 61.17 |
+| `churn` str | 44.60 / 40.71 / 45.69 / 45.79 / 41.72 | 100.99 / 93.88 / 102.59 / 100.44 / 95.59 | 155.93 / 145.94 / 158.30 / 154.39 / 148.84 |
+| `find` u64 | 5.55 / 5.42 / 5.86 / 5.85 / 5.94 | 6.55 / 6.25 / 7.02 / 6.85 / 6.82 | 16.34 / 14.27 / 17.32 / 15.40 / 15.26 |
+| `find` str | 19.43 / 19.04 / 19.79 / 19.92 / 19.51 | 28.13 / 25.74 / 28.99 / 28.40 / 26.25 | 66.18 / 60.92 / 67.64 / 65.55 / 62.40 |
+| `build` u64 | 20.34 / 13.56 / 19.17 / 15.10 / 15.02 | 22.04 / 13.19 / 21.21 / 15.04 / 14.65 | 39.33 / 24.69 / 39.02 / 26.36 / 26.19 |
+| `build` str | 72.57 / 64.14 / 72.44 / 71.67 / 62.32 | 85.64 / 69.17 / 76.44 / 74.02 / **63.28** | 121.14 / 94.78 / 105.77 / 98.23 / **91.31** |
+| `churn` big | | 32.98 / 28.10 / 37.65 / 35.74 / 31.74 | |
+| `build` big | | 77.09 / 25.50 / 40.51 / 36.26 / **20.49** | |
+
+Three readings. The 2 MB segment gets the vector's whole gain for 16 byte pairs (`churn` u64 800k
+18.61 to 14.19, the same 1.31 the vector reads) and nothing for 40 and 72 byte ones, exactly as the
+rounding says, and 16 MB segments get it for all three. The segmented container itself is 10-20%
+slower than the vector on churn and lookups -- this file had never recorded that number -- and it
+is the second dependent load of every value access, which huge pages do not remove: segmented on
+huge pages lands about where the vector on 4 KB pages was. And on builds the order inverts: a
+segmented map neither copies on growth nor faults a new block in, so 16 MB segments on the allocator
+are the fastest build measured, 63.3 against the vector's 69.2 for strings and 20.5 against 25.5
+for 64 byte values, 3.8x the plain vector. Whether `segmented_map` should expose the segment size
+is an API question, not a measurement one; the recipe needs the container slot today.
+
+**boost::unordered_flat_map on the same allocator**, with the hash `scripts/ab/ab.cpp` gives it,
+because the 2026-09-06 entry found huge pages worth the same 22% to both maps at one size and one
+workload and the question was whether that holds. Point measurements, one per cell, five rounds,
+ns per operation: this map / this map on the allocator / boost / boost on the allocator. **Not
+octave geomeans**, so the boost-against-this-map ratios are the kind CLAUDE.md says must be re-taken
+before being quoted as a ranking; the allocator-against-itself ratios are what this table is for.
+
+| | 200000 | 800000 | 4000000 |
+|---|---|---|---|
+| `churn` u64 | 11.96 / 11.41 / 13.33 / 12.68 | 16.32 / 12.22 / 17.89 / 15.96 | 54.30 / 49.58 / 30.55 / 28.54 |
+| `churn` str | 44.79 / 40.61 / 54.07 / 49.81 | 101.17 / 94.14 / 109.01 / 104.04 | 156.17 / 146.11 / 111.76 / 105.80 |
+| `churn` big | | 33.08 / 28.19 / 49.35 / 30.41 | |
+| `find` u64 | 5.56 / 5.40 / 4.76 / 4.79 | 6.56 / 6.24 / 5.61 / 5.36 | 16.34 / 14.19 / 11.54 / 10.45 |
+| `find` str | 19.41 / 19.10 / 18.66 / 18.20 | 28.53 / 26.23 / 25.93 / 24.77 | 66.17 / 60.85 / 57.10 / 55.27 |
+| `build` u64 | 20.32 / 13.46 / 23.19 / 15.44 | 21.78 / 12.98 / 26.54 / 14.71 | 38.67 / 24.84 / 47.05 / 24.86 |
+| `build` str | 72.56 / 63.86 / 86.76 / 80.54 | 86.06 / 68.78 / 153.40 / 139.82 | 124.73 / 95.31 / 275.52 / 229.78 |
+| `build` big | | 77.61 / 25.36 / 93.54 / 36.20 | |
+
+Huge pages help both, and by amounts that follow each layout. boost gains most where its one
+region holds everything: the 64 byte value churn at 800k goes 49.35 to 30.41 (1.62x) because the
+values are inline in its bucket array and one huge-paged region gets all of it, where this map's
+values are a second region and its churn goes 33.08 to 28.19 (1.17x); its integer builds gain
+1.5-1.9x to this map's 1.5-1.7x. This map gains more on the integer churn at 800k (1.34x against
+1.12x), where its two regions are two translations per access and boost's one is one. The
+counters on the integer find at 4M say the same for both: L1 misses served by the L2 TLB per
+operation 1.07 to 0.55 here and 1.34 to 0.46 for boost, page walks 0.94 to 0.016 and 0.53 to 0.016.
+Nothing changes who is ahead where: boost stays ahead on lookups and on the large integer and
+string churn, this map stays ahead on every build and on churn up to 800k, and at 4M the two
+integer builds land on the same number (24.84 and 24.86) with or without -- which is the "level at
+4M" the insert-path entry above recorded, unmoved by the page size.
+
+**The threshold is 2 MB, not #231's 4 MB.** `huge4` -- the same allocator at a 4 MB threshold --
+tracks the 2 MB one wherever every block is past both and loses wherever blocks fall between:
+`build` u64 at 200000 reads 13.30 against 17.08, because the 3.2 MB values vector qualifies at one
+threshold and not the other. There is no size at which 4 MB wins, since a block below 2 MB is
+never rounded either way.
 
 **The score runs on 4 KB pages and pays 1.6 billion L1 dTLB misses for it** (2026-09-12, found
 while closing #268; Ryzen 9 7950X, gcc 16 and clang 22, glibc 2.43, THP mode `madvise`).

--- a/scripts/ab/huge_pages.cpp
+++ b/scripts/ab/huge_pages.cpp
@@ -1,0 +1,178 @@
+// What the huge page allocator is worth, across the size axis and per workload.
+//
+// The scored benchmark's workloads, instantiated on the map with std::allocator and with
+// huge_page_allocator, one cell per run so that the variant is a template instantiation and never a
+// branch inside anything timed. The workloads are the score's own (test/bench/workloads.h), so a
+// cell here is the same code the score runs, at a size the score does not.
+//
+//   huge_pages <std|huge|huge4|seg|seghuge|seghuge16|boost|boosthuge> <u64|str|big> <build|churn|find|ie> <size>
+//
+// prints ns per operation and the operation count, where an operation is what the workload does
+// per element: one insert for build, erase + insert + two finds per churn round, one hundred finds
+// per step of find, an operator[] and an erase per step of insert-erase. `huge4` is the allocator
+// with a 4 MB threshold, which #231 named as the starting point; `huge` is the 2 MB default. `seg*`
+// is the segmented container in the map's container slot, `boost*` is boost::unordered_flat_map
+// with the same hash, both compiled in only where their headers are.
+//
+// Sizes are template parameters of the workloads, so the set is fixed here: 50000, 200000, 800000,
+// 2000000, 4000000. The first is the score's own churn size and the smallest table whose blocks
+// can reach the 2 MB threshold at all; the last is where the 2026-09-06 lookup measurement found 22%.
+#include <ankerl/huge_page_allocator.h>
+#include <ankerl/unordered_dense.h>
+
+#include <bench/workloads.h>
+
+#if defined(__has_include)
+#    if __has_include(<boost/unordered/unordered_flat_map.hpp>)
+#        include <boost/unordered/unordered_flat_map.hpp>
+#        define HUGE_PAGES_HAS_BOOST 1
+#    endif
+#endif
+#if !defined(HUGE_PAGES_HAS_BOOST)
+#    define HUGE_PAGES_HAS_BOOST 0
+#endif
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <utility>
+
+namespace {
+
+template <class K, class V, template <class> class A>
+using map_with = ankerl::unordered_dense::map<K, V, ankerl::unordered_dense::hash<K>, std::equal_to<K>, A<std::pair<K, V>>>;
+
+template <class T>
+using std_alloc = std::allocator<T>;
+template <class T>
+using huge_alloc = ankerl::unordered_dense::huge_page_allocator<T>;
+template <class T>
+using huge4_alloc = ankerl::unordered_dense::huge_page_allocator<T, (std::size_t{4} << 20U)>;
+
+// The segmented container with a segment sized for huge pages, handed to the map through its
+// container slot. A segment is a power of two of elements that fits the byte size, so a 2 MB
+// segment of 16 byte pairs is exactly one huge page and a 2 MB segment of 40 byte pairs is 1.28 MB
+// and below the allocator's threshold; 16 MB segments bound that rounding at 2 MB per segment.
+template <class T>
+using seg_std = ankerl::unordered_dense::segmented_vector<T, std::allocator<T>, (std::size_t{2} << 20U)>;
+template <class T>
+using seg_huge = ankerl::unordered_dense::segmented_vector<T, huge_alloc<T>, (std::size_t{2} << 20U)>;
+template <class T>
+using seg_huge16 = ankerl::unordered_dense::segmented_vector<T, huge_alloc<T>, (std::size_t{16} << 20U)>;
+
+#if HUGE_PAGES_HAS_BOOST
+// boost::unordered_flat_map with the same hash the paired harness gives it (scripts/ab/ab.cpp), and
+// the allocator in its slot: one region, so the allocator covers all of it.
+template <class K, class V, template <class> class A>
+using boost_with =
+    boost::unordered_flat_map<K, V, ankerl::unordered_dense::hash<K>, std::equal_to<K>, A<std::pair<K const, V>>>;
+#endif
+
+struct result {
+    double ns;
+    std::size_t ops;
+};
+
+template <class Map, std::size_t N>
+auto run(std::string const& work) -> result {
+    auto ops = std::size_t{};
+    auto const t0 = std::chrono::steady_clock::now();
+    if (work == "build") {
+        workloads::build<Map, N>();
+        ops = N;
+    } else if (work == "churn") {
+        workloads::churn<Map, N>();
+        ops = 4 * 4 * N; // four rounds of N, each erase + insert + two finds
+    } else if (work == "find") {
+        workloads::find_50<Map, N>();
+        ops = 100 * N;
+    } else if (work == "ie") {
+        workloads::insert_erase<Map, N>();
+        ops = (N - 1) * 200 * 2;
+    } else {
+        std::fprintf(stderr, "unknown workload %s\n", work.c_str());
+        std::exit(2);
+    }
+    auto const t1 = std::chrono::steady_clock::now();
+    return {static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count()), ops};
+}
+
+template <class Map>
+auto run_size(std::string const& work, std::size_t n) -> result {
+    switch (n) {
+    case 50000:
+        return run<Map, 50000>(work);
+    case 200000:
+        return run<Map, 200000>(work);
+    case 800000:
+        return run<Map, 800000>(work);
+    case 2000000:
+        return run<Map, 2000000>(work);
+    case 4000000:
+        return run<Map, 4000000>(work);
+    default:
+        std::fprintf(stderr, "size must be one of 50000 200000 800000 2000000 4000000\n");
+        std::exit(2);
+    }
+}
+
+template <template <class, class, template <class> class> class M, template <class> class A>
+auto run_keys(std::string const& keys, std::string const& work, std::size_t n) -> result {
+    if (keys == "u64") {
+        return run_size<M<std::uint64_t, std::size_t, A>>(work, n);
+    }
+    if (keys == "str") {
+        return run_size<M<std::string, std::size_t, A>>(work, n);
+    }
+    if (keys == "big") {
+        return run_size<M<std::uint64_t, workloads::big_value, A>>(work, n);
+    }
+    std::fprintf(stderr, "keys must be u64, str or big\n");
+    std::exit(2);
+}
+
+} // namespace
+
+auto main(int argc, char** argv) -> int {
+    if (argc != 5) {
+        std::fprintf(
+            stderr,
+            "usage: %s <std|huge|huge4|seg|seghuge|seghuge16|boost|boosthuge> <u64|str|big> <build|churn|find|ie> <size>\n",
+            argv[0]);
+        return 2;
+    }
+    auto const alloc = std::string(argv[1]);
+    auto const keys = std::string(argv[2]);
+    auto const work = std::string(argv[3]);
+    auto const n = static_cast<std::size_t>(std::strtoull(argv[4], nullptr, 10));
+    auto r = result{};
+    if (alloc == "std") {
+        r = run_keys<map_with, std_alloc>(keys, work, n);
+    } else if (alloc == "huge") {
+        r = run_keys<map_with, huge_alloc>(keys, work, n);
+    } else if (alloc == "huge4") {
+        r = run_keys<map_with, huge4_alloc>(keys, work, n);
+    } else if (alloc == "seg") {
+        r = run_keys<map_with, seg_std>(keys, work, n);
+    } else if (alloc == "seghuge") {
+        r = run_keys<map_with, seg_huge>(keys, work, n);
+    } else if (alloc == "seghuge16") {
+        r = run_keys<map_with, seg_huge16>(keys, work, n);
+#if HUGE_PAGES_HAS_BOOST
+    } else if (alloc == "boost") {
+        r = run_keys<boost_with, std_alloc>(keys, work, n);
+    } else if (alloc == "boosthuge") {
+        r = run_keys<boost_with, huge_alloc>(keys, work, n);
+#endif
+    } else {
+        std::fprintf(stderr, "allocator must be std, huge, huge4, seg, seghuge, seghuge16, boost or boosthuge\n");
+        return 2;
+    }
+    std::printf("%.3f ns/op %zu ops\n", r.ns / static_cast<double>(r.ops), r.ops);
+    return 0;
+}

--- a/scripts/ab/huge_pages.sh
+++ b/scripts/ab/huge_pages.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# The huge page allocator against std::allocator, interleaved round by round, medians reported.
+#
+#   scripts/ab/huge_pages.sh [-c COMPILER] [-k u64|str|big] [-w build|churn|find|ie] [-n SIZE]
+#                            [-p] [rounds] [alloc...]
+#
+# Allocators are the modes huge_pages.cpp lists: std huge huge4 seg seghuge seghuge16 boost boosthuge.
+# Defaults: clang++, u64 keys, churn, 800000 entries, five rounds, `std` against `huge`. -p runs
+# every cell once more under `perf stat` and prints the two TLB counters that are the mechanism,
+# per operation: L1 DTLB misses served by the L2 TLB on 4 KB pages, and page walks. AB_CORE pins.
+#
+# Read the size axis, not one cell: the allocator only puts blocks of 2 MB and up on huge pages,
+# so a 50000-entry table gains nothing here and 5-8% under glibc's heap-wide madvise -- that is a
+# statement about where the blocks are, not noise. See include/ankerl/huge_page_allocator.h.
+set -euo pipefail
+export LC_ALL=C
+cxx=clang++ keys=u64 work=churn size=800000 perf=0
+while getopts "c:k:w:n:p" opt; do
+    case $opt in
+        c) cxx=$OPTARG ;;
+        k) keys=$OPTARG ;;
+        w) work=$OPTARG ;;
+        n) size=$OPTARG ;;
+        p) perf=1 ;;
+        *) exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
+rounds=${1:-5}
+[ $# -gt 0 ] && shift
+allocs=("$@")
+[ ${#allocs[@]} -gt 0 ] || allocs=(std huge)
+
+root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+build=${AB_BUILD:-$(mktemp -d)}
+mkdir -p "$build"
+bin="$build/huge_pages_$(basename "$cxx")"
+[ -x "$bin" ] || "$cxx" -O3 -DNDEBUG -std=c++17 -I"$root/include" -I"$root/test" -o "$bin" \
+    "$root/scripts/ab/huge_pages.cpp" "$root/test/app/nanobench.cpp"
+
+pin=${AB_CORE:+taskset -c $AB_CORE}
+declare -A runs
+for _ in $(seq 1 "$rounds"); do
+    for a in "${allocs[@]}"; do
+        runs[$a]+="$($pin "$bin" "$a" "$keys" "$work" "$size" | awk '{print $1}') "
+    done
+done
+
+echo "$cxx, $keys keys, $work, $size entries, $rounds rounds, ns per operation"
+for a in "${allocs[@]}"; do
+    printf '  %-6s ' "$a"
+    tr ' ' '\n' <<<"${runs[$a]}" | grep -v '^$' | sort -n |
+        awk '{v[NR] = $1} END {printf "median %8.3f   min %8.3f   max %8.3f\n",
+              (NR % 2 ? v[(NR + 1) / 2] : (v[NR / 2] + v[NR / 2 + 1]) / 2), v[1], v[NR]}'
+done
+if [ "$perf" = 1 ]; then
+    for a in "${allocs[@]}"; do
+        out=$($pin perf stat -x, -e ls_l1_d_tlb_miss.tlb_reload_4k_l2_hit,ls_l1_d_tlb_miss.all_l2_miss \
+            -- "$bin" "$a" "$keys" "$work" "$size" 2>&1)
+        ops=$(grep -o '[0-9]* ops' <<<"$out" | awk '{print $1}')
+        printf '  %-6s per op: ' "$a"
+        awk -F, -v ops="$ops" '/tlb_reload_4k_l2_hit/ {printf "L2 TLB hits %.3f   ", $1 / ops}
+                               /all_l2_miss/ {printf "page walks %.4f\n", $1 / ops}' <<<"$out"
+    done
+fi

--- a/scripts/lint/lint-version.py
+++ b/scripts/lint/lint-version.py
@@ -17,6 +17,7 @@ CHECKS = [
     (HEADER, r"Version (\d+)\.(\d+)\.(\d+)", 1),
     (ROOT / "CMakeLists.txt", r"^\s+VERSION (\d+)\.(\d+)\.(\d+)", 1),
     (ROOT / "include" / "ankerl" / "stl.h", r"Version (\d+)\.(\d+)\.(\d+)", 1),
+    (ROOT / "include" / "ankerl" / "huge_page_allocator.h", r"Version (\d+)\.(\d+)\.(\d+)", 1),
     (ROOT / "meson.build", r"version:\s*'?(\d+)\.(\d+)\.(\d+)'?", 1),
     (ROOT / "test" / "unit" / "namespace.cpp", r"unordered_dense::v(\d+)_(\d+)_(\d+)", 1),
 ]

--- a/test/meson.build
+++ b/test/meson.build
@@ -63,6 +63,7 @@ test_sources = [
     'unit/hash_string_view.cpp',
     'unit/hash.cpp',
     'unit/hash_golden.cpp',
+    'unit/huge_page_allocator.cpp',
     'unit/include_only.cpp',
     'unit/initializer_list.cpp',
     'unit/insert_or_assign.cpp',

--- a/test/unit/huge_page_allocator.cpp
+++ b/test/unit/huge_page_allocator.cpp
@@ -1,0 +1,110 @@
+#include <ankerl/huge_page_allocator.h>
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <cstddef> // for size_t
+#include <cstdint> // for uint64_t, uintptr_t
+#include <functional>
+#include <memory> // for allocator_traits
+#include <type_traits>
+#include <utility> // for pair, move
+
+// The allocator itself, then the map on top of it over every container shape. The map part is what
+// #231 asked for -- that it round-trips -- and the shapes are not decoration: segmented_vector asks
+// for 64 KB segments that stay below the threshold while its index goes above it, so that one map
+// exercises both paths at once.
+namespace {
+
+template <class T>
+using huge = ankerl::unordered_dense::huge_page_allocator<T>;
+
+using traits = std::allocator_traits<huge<int>>;
+static_assert(traits::is_always_equal::value);
+static_assert(traits::propagate_on_container_move_assignment::value);
+static_assert(std::is_same_v<traits::rebind_alloc<double>, huge<double>>);
+static_assert(huge<int>::threshold == (std::size_t{2} << 20U));
+static_assert(huge<int>::is_huge(huge<int>::threshold / sizeof(int)) == huge<int>::uses_huge_pages);
+static_assert(!huge<int>::is_huge(huge<int>::threshold / sizeof(int) - 1));
+
+} // namespace
+
+TEST_CASE("huge_page_allocator_large_blocks_are_huge_page_aligned") {
+    auto alloc = huge<std::uint64_t>();
+    constexpr auto n = std::size_t{3} << 18U; // 2 MB of uint64_t: exactly the threshold, rounded to one page
+    auto* p = alloc.allocate(n);
+    REQUIRE(p != nullptr);
+    if constexpr (huge<std::uint64_t>::uses_huge_pages) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        REQUIRE(reinterpret_cast<std::uintptr_t>(p) % huge<std::uint64_t>::huge_page_size == 0);
+    }
+    // every 4 KB page of it is writable and reads back
+    for (std::size_t i = 0; i < n; i += 512) {
+        p[i] = i;
+    }
+    for (std::size_t i = 0; i < n; i += 512) {
+        REQUIRE(p[i] == i);
+    }
+    alloc.deallocate(p, n);
+
+    // below the threshold it is std::allocator's memory, with no alignment promise beyond the type's
+    auto* q = alloc.allocate(16);
+    q[0] = 1;
+    q[15] = 2;
+    REQUIRE(q[0] + q[15] == 3);
+    alloc.deallocate(q, 16);
+}
+
+TEST_CASE("huge_page_allocator_instances_compare_equal_across_rebinds") {
+    REQUIRE(huge<int>() == huge<double>());
+    REQUIRE(!(huge<int>() != huge<char>()));
+    auto a = huge<int>();
+    auto b = huge<double>(a); // converting constructor, the rebind path a container takes
+    REQUIRE(a == b);
+    // a different threshold is a different allocator
+    REQUIRE(huge<int>() != ankerl::unordered_dense::huge_page_allocator<int, (std::size_t{4} << 20U)>());
+}
+
+TEST_CASE_MAP("huge_page_allocator_round_trips_with_the_map",
+              std::uint64_t,
+              std::uint64_t,
+              ankerl::unordered_dense::hash<std::uint64_t>,
+              std::equal_to<std::uint64_t>,
+              huge<std::pair<std::uint64_t, std::uint64_t>>) {
+    // 300000 entries: the values are 4.8 MB and the index 2.9 MB (or 5 MB for group_big), so both
+    // regions are above the threshold and come from mmap. Every erase below then shrinks nothing,
+    // and the rehash at the end reallocates the index through the same path.
+    constexpr auto n = std::uint64_t{300000};
+    auto map = map_t();
+    for (std::uint64_t i = 0; i < n; ++i) {
+        map[i] = i * 2;
+    }
+    REQUIRE(map.size() == n);
+    for (std::uint64_t i = 0; i < n; i += 7) {
+        auto it = map.find(i);
+        REQUIRE(it != map.end());
+        REQUIRE(it->second == i * 2);
+    }
+    for (std::uint64_t i = 0; i < n; i += 2) {
+        REQUIRE(map.erase(i) == 1);
+    }
+    REQUIRE(map.size() == n / 2);
+    REQUIRE(!map.contains(0));
+    REQUIRE(map.contains(1));
+
+    auto copy = map;
+    REQUIRE(copy.get_allocator() == map.get_allocator());
+    REQUIRE(copy == map);
+
+    auto moved = std::move(map);
+    REQUIRE(moved.size() == n / 2);
+    REQUIRE(moved == copy);
+
+    moved.rehash(0);
+    REQUIRE(moved == copy);
+    moved.swap(copy);
+    copy.clear();
+    REQUIRE(copy.empty());
+    REQUIRE(moved.size() == n / 2);
+    REQUIRE(moved.find(12345)->second == 12345 * 2);
+}


### PR DESCRIPTION
Stacked on #269 (it edits the notes and `CLAUDE.md` lines that PR adds); GitHub retargets to `main` once #269 merges. Closes #231.

## What ships

- `include/ankerl/huge_page_allocator.h` — `huge_page_allocator<T, Threshold = 2 MB>`: blocks at or above the threshold are `mmap`ed 2 MB-aligned, rounded up to a multiple of 2 MB, and `madvise(MADV_HUGEPAGE)`d; smaller blocks go to `std::allocator`. Stateless, so instances compare equal and propagation is never a question. Off Linux it forwards everything to `std::allocator` with the same interface (`uses_huge_pages` says which you got).
- `test/unit/huge_page_allocator.cpp` — alignment of large blocks, the `std::allocator` path below the threshold, rebind equality, and a 300000-entry round trip over all four container shapes (both regions above the threshold).
- `scripts/ab/huge_pages.{cpp,sh}` — the score's own workloads on the map with each allocator, one cell per process, interleaved rounds, medians, `-p` for the TLB counters. Modes for the segmented container and for `boost::unordered_flat_map`.
- README 3.8, a notes entry with every table, the version linter covering the new header.

Verified on clang, gcc, ASan+UBSan, unity-16, `-m32` (both), `-fno-exceptions` (both); linters green.

## What it is worth

`std::allocator` → `huge_page_allocator`, ns/op, clang (gcc within a few percent of the same ratios):

| | 50000 | 200000 | 800000 | 4000000 |
|---|---|---|---|---|
| build u64 | flat | 20.4 → 13.3 (**1.53×**) | 22.1 → 12.8 (**1.73×**) | 38.4 → 24.6 (**1.56×**) |
| build str | 68.5 → 58.4 (1.17×) | 71.9 → 63.6 (1.13×) | 85.5 → 68.6 (1.25×) | 121.8 → 94.4 (1.29×) |
| churn u64 | flat | 12.7 → 12.3 | 16.1 → 12.1 (**1.33×**) | 53.7 → 49.4 (1.09×) |
| find u64 | flat | flat | 6.50 → 6.21 (1.05×) | 16.3 → 14.3 (**1.14×**) |

The size axis is the result: at 50000 no block reaches 2 MB, so the score's own 3% needs the heap-wide glibc route (#269), which shares extents — a per-block allocator cannot. Builds gain more than the TLB because a doubling vector faults in every new block, 512× fewer on 2 MB pages. The 4 MB threshold #231 suggested loses wherever a block falls between 2 and 4 MB (build u64 at 200k: 17.1 vs 13.3), so the default is 2 MB. A string's *body* is `malloc`ed outside any allocator the map holds and stays on 4 KB pages: string churn at 4M keeps 1.1 page walks per op of its 2.7.

**Segmented container, segment sized for the page**: exactly one huge page for 16-byte pairs (verified aligned), nothing for 40- and 72-byte ones because the segment rounds its element count down to a power of two; 16 MB segments bound that rounding and make it the fastest build measured (64-byte values at 800k: 77.1 → **20.5**, vs the vector's 25.4 on the allocator). The segmented container itself costs 10–20% on churn and lookups, which huge pages do not take back.

**boost::unordered_flat_map on the same allocator** gains 1.5–1.9× on integer builds and 1.62× churning 64-byte values (its one region holds them inline), 1.12× on integer churn at 800k where this map gains 1.34×. Point measurements at fixed sizes, labelled as such in the notes; nothing changes which map is ahead where.

🤖 Generated with [Claude Code](https://claude.com/claude-code)