### PR TITLE
Rewrite CLAUDE.md for agent sessions, and ship the two methods it cites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,398 +1,200 @@
-# CLAUDE.md
+# CLAUDE.md — ankerl::unordered_dense, operating rules for agent sessions
 
-`ankerl::unordered_dense::{map, set}` — a single-header C++17 dense hash map. The whole
-implementation is `include/ankerl/unordered_dense.h`; tests and benchmarks are in `test/` and build
-into one doctest binary, `udm-test`.
+Reader: an agent session. Everything here is a rule, a command or a pointer; the evidence behind every
+rule is in `notes/index-design.md` under the grep phrase given. Nothing here is narrative.
 
-**Evidence lives in `notes/index-design.md`.** This file is the rules; that file is the ~150
-experiments they came from. Before proposing any optimization, grep it — most ideas that look new
-have been measured and rejected, several of them twice.
+## Files
+
+| what | where |
+|---|---|
+| the map, single implementation file | `include/ankerl/unordered_dense.h` (+ `stl.h` = its std includes, split out for `import std`; both are needed to copy the header) |
+| opt-in huge page allocator | `include/ankerl/huge_page_allocator.h` (separate: needs `<sys/mman.h>`; never referenced by the map) |
+| tests + benchmarks, one doctest binary `udm-test` | `test/unit/*.cpp`, `test/bench/*.cpp`, `test/bench/workloads.h` (the scored workloads), `test/app/` (doctest.h with `TEST_CASE_MAP`, allocator fixtures) |
+| evidence, ~170 entries | `notes/index-design.md` — grep it before proposing anything |
+| measurement harnesses | `scripts/ab/` — `README.md` there documents `run.sh` (paired), `maps.sh`/`maps_one.sh` (other maps, perf), the rest below |
+| mutation testing | `scripts/mutate/mutate.py`, bug files in `scripts/mutate/bugs/` |
+| fuzz corpora | `data/fuzz/<target>/`, replayed by the `fuzz` suite on every run |
+| linters | `scripts/lint/all.py` |
+| CI | `.github/workflows/main.yml` (34 legs), `bench.yml` (nine runners, push to `bench`) |
+
+## Workflow
+
+- **PR only.** `enforce_admins` is on; direct pushes to main are blocked. Branch, `gh pr create`,
+  `gh pr merge N --rebase --delete-branch=false` — rebase merges are the only kind allowed.
+- **Merge only when told** ("merge when green" = wait for 34/34 in `gh pr checks N`; the JSON
+  `conclusion` is `""` while pending, not null — read the tabular view).
+- **Stacked PR** (edits lines an open PR adds): branch from that branch, `--base <that-branch>`; after
+  the first rebase-merges, `git rebase --onto origin/main <first> <second>`, force-push with lease,
+  wait for the re-run. #269→#270.
+- One PR per issue; commit message = one sentence in the repo's voice + the numbers + `Closes #N`.
+- `/simplify` after a PR is up; fix what it finds directly. It has caught a stale mutation block and
+  two claims that outran their evidence.
+- Never bare `git stash` — other sessions share the stash. Prefer a WIP commit.
+- Do not edit a shell script while it runs (bash re-reads at the old offset). Do not run builds or
+  anything heavy while a benchmark runs; pin benchmarks with `AB_CORE=2`.
+- `AB_BUILD` on `/home/martinus/gra/<name>`, never `/tmp` (tmpfs; a full `/tmp` wedges every shell
+  command). Delete the directory once the numbers are in the notes.
+- Every measured result goes into `notes/index-design.md` as an entry (bold opening sentence = what
+  was tried and what happened; one index line per entry, same commit), and retractions are written
+  in place, never deleted. A negative result is an entry too.
+
+## Build, test, lint
+
+```sh
+CXX="ccache clang++" meson setup --buildtype release builddir/clang_release   # once; all benchmarking uses this
+CXX="ccache g++"     meson setup --buildtype release builddir/gcc_release     # the compiler that does not fold
+ninja -C builddir/clang_release && ./builddir/clang_release/test/udm-test   # every header change; ~830 cases
+./builddir/clang_release/test/udm-test -tc='huge_page*'                     # filter by test case glob
+python3 scripts/lint/all.py            # clang-tidy-18 cannot run on this machine: its failure is expected, the other four must pass
+clang-format -i <file>                 # version 21 pinned; the format linter's verdict is its exit code
+```
+
+Warnings are errors (`-Wconversion -Wold-style-cast -pedantic-errors`, MSVC `/W4`). Existing build
+dirs: `builddir/{clang_release,gcc_release,san_address,unity16,fuzz,...}`; `ninja -C` any of them.
+
+CI legs to reproduce locally before pushing header or test changes, each caught a green-elsewhere failure:
+- 32-bit (gcc and clang): `g++ -m32 -std=c++17 -fsyntax-only -Wall -Wextra -Wconversion -Wold-style-cast -pedantic-errors -Iinclude -Itest -I$(dirname $(find subprojects/doctest-2.5.3 -name doctest.h)) <file>` — clang and MSVC each catch narrowings the other misses.
+- `-fno-exceptions` (both compilers) for anything that throws; the header has `ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()`.
+- **Unity leg whenever a test file is added or removed**: `ninja -C builddir/unity16 && ./builddir/unity16/test/udm-test` (`--unity=on --unity-size=16`). A new file shifts every later file's chunk and can collide anonymous-namespace names.
+- ASan+UBSan (`builddir/san_address`) for anything touching memory or the index.
+- Any leg: `meson setup builddir --force-fallback-for=fmt -Dcpp_std=c++17 <matrix setup_args> && meson test -C builddir --print-errorlogs`.
+- Offline: put sources in `subprojects/doctest-2.5.3/` and `subprojects/fmt-12.0.0/` with a minimal `meson.build` calling `meson.override_dependency()`.
 
 ## The index, in one paragraph
 
-Groups of sixteen, not robin hood, since 2026-09-05. One 88 byte block per group of sixteen slots
-(`bucket_type::group`, 5.5 bytes per slot): sixteen one-byte fingerprints compared in one SSE2/NEON
-instruction, eight overflow counters, and sixteen `uint32_t` value indices, all in one array.
-Quadratic probing over groups. An insert increments the counter of its fingerprint class in every
-full group it passes; an erase decrements it again, so **there are no tombstones and no rehash is
-ever needed**. `bucket_type::group_big` is the same with 64 bit indices.
-
-Nothing moves once placed, with one exception: a hit found inside a *writing* operation
-(`operator[]`, `try_emplace`, `insert`) moves itself back to its home group if there is room
-(`move_home`). Without it a churned table drifts — at load 0.76 after 200 turnovers, 1.036 groups
-per hit against a fresh 1.031 and 1.061 per miss against 1.052 — and with one writing lookup per
-round it churns to *better* than fresh.
-
-Against the robin hood index it replaced (4.11.0) it is 1.10x on the score, 1.45x on churn at a
-fixed size, 1.5x on misses, 1.33x on hits, 1.2x on insert-erase, and 5.5 bytes per slot instead of
-8. The eleven layouts measured and rejected on the way are in `martinus/ai#3`.
-
-## Build
-
-Meson and ninja are required (`pip install -r requirements.txt`). doctest and fmt are fetched
-automatically as meson subprojects.
-
-```sh
-CXX="ccache clang++" meson setup --buildtype release builddir/clang_release   # once; benchmarks need this
-CXX="ccache clang++" meson setup builddir/clang_debug                         # development
-ninja -C builddir/clang_release                                               # after every change
-```
-
-Warnings are errors (`werror=true`, `warning_level=3`, `-Wconversion`, `-Wold-style-cast`, …).
-
-## Test
-
-Any change to the header must pass:
-
-```sh
-meson test -C builddir/clang_release unit --verbose
-./builddir/clang_release/test/udm-test              # or directly
-```
-
-The `fuzz` suite inside it replays `data/fuzz/<target>` on every run, on every CI leg.
+Groups of sixteen since 2026-09-05: one 88 byte block per group (`bucket_type::group`, 5.5 B/slot) =
+16 one-byte fingerprints compared in one SSE2/NEON instruction + 8 overflow counters + 16 `uint32_t`
+value indices; `group_big` = 152 bytes with 64-bit indices. Quadratic probing over groups. An insert
+increments the counter of its fingerprint class in every full group it passes, an erase decrements
+it: **no tombstones, no rehash ever needed**. Nothing moves once placed, except a hit found inside a
+*writing* operation moves home if there is room (`move_home`), which takes back a churned table's
+drift. Every key/value search is bounded (`delta == m_group_mask`); the two placement walks are
+unbounded by design (free-slot invariant). Erase swaps the last value into the hole and re-finds
+its slot by hashing it (`repoint_value`) — the "string erase second hash", #266. Against the robin
+hood index it replaced (4.11.0): 1.10x score, 1.45x churn, 1.5x misses, 1.33x hits, 5.5 B/slot vs 8.
 
 ## Benchmark
 
-The metric is `bench_quick_overall_udm`: fifteen nanobench workloads (iterate-while-modifying,
-insert/erase, build-from-empty, churn at a fixed size, random find at 50% hits) over
-`map<uint64_t, size_t>`, `map<std::string, size_t>` and `map<uint64_t, big_value>`, reported as a
-geometric mean. **Lower is better.**
+The metric: `bench_quick_overall_udm`, fifteen workloads (iterate-while-modifying, insert/erase,
+build, churn at a fixed size, find at 50% hits) × (`map<uint64_t,size_t>`, `map<string,size_t>`,
+`map<uint64_t,big_value>`), geometric mean, **lower is better**. Every workload's table is ≤ 200000
+entries; churn is 50000. Anything past L2/L3 is invisible to it and needs the size-axis harnesses.
 
 ```sh
-./builddir/clang_release/test/udm-test -ns -tc=bench_quick_overall_udm   # -ns because benchmarks are skip()ed
-./builddir/clang_release/test/udm-test -ltc                              # list all test cases
-./builddir/clang_release/test/udm-test -ns -ts=bench                     # every benchmark, incl. bench_copy etc.
-scripts/ab/run.sh                                                        # the paired A/B harness — use this
-scripts/ab/run.sh -c g++ -r <rev> -b all 12                              # other compiler / baseline revision
+./builddir/clang_release/test/udm-test -ns -tc=bench_quick_overall_udm   # the score (-ns: benchmarks are skip()ed)
+./builddir/clang_release/test/udm-test -ns -ts=bench                     # every benchmark
 ```
 
-`.github/workflows/bench.yml` runs the same harness on nine machines (linux and arm, gcc and clang,
-with and without the vector compare, one Windows leg), against `origin/main` and against boost where
-boost is installable. Push to `bench` to trigger it; `scripts/ab/summarize.py` turns a run into the
-markdown table in the job summary. Those runners are shared, which the paired harness is built for —
-but it means the **absolute** times from them mean nothing and are not summarised.
+### Which measurement answers which question
 
-### Rules that stop wasted work
+| question | tool | reads |
+|---|---|---|
+| does a header change move the score, ≥ ~10%, inlining untouched | `scripts/ab/run.sh [-c g++] [-r REV] all 12` (paired, one process, octave geomean) | believe the ratio when the CI excludes 100% |
+| anything touching `always_inline`, a function's size, a template boundary, or < 10% | `AB_BUILD=/home/martinus/gra/x scripts/ab/solo.sh [-c g++] [-r main] 5` (one header per binary, alternated) **then** `scripts/ab/perwl.sh /home/martinus/gra/x` | solo.sh prints **baseline/candidate** (>1 = candidate faster; the inverse of run.sh). perwl.sh prints candidate/baseline **ins/op per workload**: deterministic to 4 decimals, the decisive number |
+| the mechanism (cycles, misses, TLB) | `perf stat` / `perf record` on the score binary or `scripts/ab/maps_one.sh` (one map per binary) | `perf record` first: an out-of-line symbol in `nm` is not evidence the hot path calls it (#268) |
+| an environment setting: page size, allocator tunable, governor | `scripts/ab/same_binary.sh 5 GLIBC_TUNABLES=glibc.malloc.hugetlb=1` | same binary, no layout band; the paired harness cannot see this (both sides share a process) |
+| the size axis, other maps, allocators | `scripts/ab/huge_pages.sh`, `scripts/ab/maps.sh`, `scripts/ab/prefetch_lines.sh`, ... (all self-contained, variant = template instantiation, interleaved rounds, medians) | never one size: sweep, and sweep across the cache boundary |
+| is the paired harness biased today | `scripts/ab/run.sh -r HEAD` (same header both sides) | reads `rmissstr` 1.036, `buildbig` 0.983, `hashstr` 0.872 on a clean tree: retires anything under ~5% there |
 
-Each of these was learned by getting an answer wrong first; `notes/index-design.md` has the case.
+Calibration constants, all measured: run-to-run drift 1–2%; **code layout luck ±3%** (two runs of the
+same two binaries are one layout sample; `-falign-functions=32` re-rolls it: #262 read 0.9975 and
+1.0052 on two layouts); `hashstr` control swings 0.92–1.13 in the paired harness (its floor); a
+THP-`always` runner scores 2.6–3.6% above a `madvise` one for no reason in the code — record
+`/sys/kernel/mm/transparent_hugepage/enabled` before comparing machines; nanobench `err%` > 3 = rerun.
 
-- **Release builds only.** Never benchmark a debug build.
-- **Record a baseline on the unmodified code first**, then compare after each change, 2–3 times.
-  Treat anything inside run-to-run noise (~1–2%) as no change.
-- **Never compare runs made at different times.** A desktop drifts several percent over minutes.
-  `scripts/ab/run.sh` interleaves baseline and candidate round by round; believe a result when the
-  confidence interval excludes 100%.
-- **Never quote a ratio taken at one table size.** Load factor sweeps from ½ to max between
-  doublings, and two indexes double at *different* sizes. `run.sh` measures five sizes across an
-  octave and reports the geometric mean; `-p 1` restores the old single size. An eleven-slot group
-  read 1.384 at one size and 1.039 over the octave; `churn64` read 1.199 and 0.974 — sign reversed.
-  Every boost ratio not labelled "octave geomean" is a point measurement and must be re-taken.
-- **A prefetch pipeline can be a loss while the data is in cache, so sweep across that boundary
-  too.** The lookahead costs 13–17 instructions per element in the three loops measured, paid
-  whether or not the prefetch was needed — but only one of the three wants a gate, so measure, do
-  not assume. `replace()` was measured at 200k and 2M, both above its crossover, and shipped a
-  version that was a fifth slower below 65k. Two sizes on the same side of a cache are one size, and
-  the load factor still sweeps underneath: the *same* index size reads 0.75 and 1.05 at two n.
-- **The control for "does this pipeline pay" is the same entry point with the ring removed**, built
-  as a second binary (`solo.sh`, not the paired harness — removing a ring changes a function's
-  size). A caller's own loop of single calls is not it: that carries the call boundary's 15
-  instructions and shows the bulk entry point winning everywhere. Only the *time* needs the size
-  sweep; the instruction premium is flat, so one `perf` run gives it.
-- **The paired harness cannot measure anything that changes inlining, and gets the sign wrong.**
-  It compiles both headers into one translation unit, which is exactly when a compiler exhausts its
-  inlining budget. For anything touching `always_inline`, a function's size or a template boundary,
-  build the score twice as two single-header binaries and alternate them — and settle it on
-  **instruction counts**, which neither layout nor drift can move.
-- **A paired two-header run decides a 10% question, not a 3% one.** Below that, one map per binary
-  with `perf stat`. The `hashstr` control never touches a map and still swings 0.92–1.13 between
-  runs; that is the resolution floor.
-- **Code layout luck is ±3%**, from edits to code that never executes. Judge micro-optimizations by
-  mechanism plus a focused microbenchmark, never by a single sub-benchmark delta.
-- **Rerun if nanobench prints `err%` above ~3.** A CPU-governor warning is normal noise.
-- **Take a null run before believing a sub-benchmark delta.** `scripts/ab/run.sh -r HEAD` on a clean
-  tree puts the *same* header on both sides; it reads `rmissstr` 1.036, `buildbig` 0.983 and
-  `hashstr` 0.872. That bias was reported as a win in two consecutive PRs before it was checked. One
-  run, and it retires anything under about 5% on those workloads.
-- **A benchmark's own input model can make a wrong heuristic look right.** `scripts/ab/range_insert.cpp`
-  draws duplicates from a pool that grows with the range, so the fresh-key rate is stationary — and a
-  range-insert sizing rule that extrapolated that rate reproduced the right bucket count at every
-  duplicate rate from 0% to 99% while being **64x wrong** on a fixed set of keys. The unit tests
-  caught it; the benchmark never would have. A benchmark says how fast, not whether it is right.
-- **A benchmark with a small per-epoch batch must advance its own randomness.** A replayed key
-  sequence is learned by the branch predictor and flatters the branchiest probe by up to 2.7x. This
-  mistake has been made twice, in two different tools.
-- **A benchmark that picks its variant inside the measured loop is measuring the dispatch.** Two
-  modes of `prefetch_lines.cpp` naming the *identical* pair of addresses read 14.11 and 13.43
-  ns/block, because the `how == "pair"` compare was in the loop. Make the variant a template
-  parameter, the same reason a gated loop needs two instantiations rather than a branch, and re-take
-  anything the old harness published (#250's ordering survived, #252).
-- **A benchmark that rebuilds its subject every round is measuring the allocator too, and bimodally.**
-  `replace_bulk.cpp` read 4.40, 2.85, 2.88, 4.76, 5.19, 2.76 ns/element for the *same* binary because
-  each round built a fresh map and the index allocation landed inside the clock. Replacing into the
-  same warmed map and reporting the **median round** rather than the mean took four repeats of one
-  cell from 3.32 / 3.33 / 3.31 / 3.27 (max 6.14) to 3.158 / 3.141 / 3.145 / 3.147 (max 3.92). Any
-  harness used to settle a 5–10% question needs both.
-- **A pipeline's payoff can depend on the caller's data, not only on the size.** `replace()`'s ring is
-  worth 1.5x to a `uint64_t` with no duplicates and costs 16% to one with a quarter of them, at the
-  *same* index size, because a duplicate refills its ring slot from the element read next and has no
-  distance to prefetch over. A single index threshold cannot serve both; pick it on the geomean across
-  key types and rates, and say in the comment what it gives up.
-- **An instruction count can move because you perturbed the inliner. That is real for the binary you
-  shipped and is not a property of the change.** Bounding `slot_of_value`'s `while (true)` reads
-  133.0 → 119.5 instructions and 0.92–0.95 of the time per erase under clang, and that does ship. It
-  is not a property of `[[noreturn]]` or of bounded loops, which is what it was first written up as:
-  force `slot_of_value` out of line and the three variants collapse to 137.0 / 138.1 / 137.1, and
-  under gcc they are 85.5 / 85.1 / 84.5. It landed on a different clang inlining decision — one a
-  compiler upgrade or an unrelated edit to those functions can flip, and one that transfers to
-  nothing else. **Instruction counts are immune to code layout, not to inlining.** Before
-  *generalising* one, pin the inlining with `noinline` and check a second compiler; both take
-  minutes. Keep the win, do not build a rule on it. #254. The contrast is #260, where the same kind of
-  count did transfer: taking a slot pack-and-unpack out of `finish_erase` reads -5.1 instructions per
-  erase under clang and -4.5 under gcc, from a mechanism visible in the disassembly and with nothing
-  else in the binary changed. #262 is the same defect on the lookup half of the erase -- `probe_result`
-  packed a slot that `erase_group_slot` and `move_home` took apart -- and it is also the cleanest
-  demonstration of the layout band: gcc scored it 1.0017, clang 0.9975 and 0.9956 on one pair of
-  binaries and **1.0052** on a pair built with `-falign-functions=32`. Two runs of the same two
-  binaries are one layout sample.
-- **Profile first; an out-of-line symbol is not a hot call site, and a scratch TU can invent a
-  redundancy as well as hide one.** #268 swept find and churn for more of #260's shape and found one:
-  `move_home` re-derived the home group and the counter from `mh` that all three writing callers were
-  already holding. gcc emitted 26 out-of-line copies of it, the fix made all 32 into `.part.0` clones
-  with the early exit inlined, and it was worth **nothing** — `perf record` on the baseline never
-  shows `move_home` above 0.2%, because the hot workloads inline it and the out-of-line copies serve
-  the cold instantiations. The per-workload counts that did move were `churn`, `build` and `find`,
-  none of which can call it: one `churn` instantiation grew 7065 → 10384 bytes, so that was the
-  inliner. The other candidate, a `m_group_mask` reload in `place_group` forced by the `uint8_t`
-  counter store, is real in a one-map TU (`and 0x38(%r10),%r9d`) and absent in the benchmark binary
-  (`and %r13d,%r10d`, hoisted). One `perf record` would have retired both in a minute.
-- **The score runs on 4 KB pages, and the page size is worth more than anything left in the code.**
-  Zen 4's L1 dTLB reaches 288 KB; every scored workload except `iterate` works on more, so each random
-  access to the index or the values is an L2 TLB lookup, and on `churn`'s dependent chain that is
-  latency: 1.6 billion of them per score pass, 107x fewer on 2 MB pages, 2.6-3.6% of the score. Two
-  consequences. A runner whose THP mode is `always` scores higher than one on `madvise` for no reason
-  in the code, so record the mode before comparing machines. And an environment variable cannot be
-  measured by the paired harness, which runs both sides in one process -- it takes two whole runs of
-  the *same* binary, alternating, which also has no layout band to argue with. #268, #231.
-- **Do not edit a shell script while it is running.** bash re-reads the file at its old byte offset.
+### Rules (each one cost a wrong answer first; grep the phrase)
 
-### Rules the workloads themselves must obey
+- Release builds only. Baseline first, then 2–3 comparisons. Never compare runs from different times.
+- **Never quote a ratio from one table size.** Load factor sawtooths ½→max between doublings and two
+  indexes double at different sizes: 11 slots read 1.384 at one size, 1.039 over the octave; churn64
+  reversed sign. Every boost ratio not labelled "octave geomean" is a point measurement. grep "octave".
+- **Sweep across the cache boundary for any prefetch/pipeline.** Lookahead costs 13–17 instr/element
+  whether needed or not; `replace()` shipped a fifth slower below 65k after being measured only above
+  its crossover. Two sizes on one side of a cache are one size. grep "crossover".
+- **The control for a pipeline is the same entry point with the ring removed, as a second binary**
+  (`solo.sh`), not the caller's loop of single calls (that carries the 15-instruction call boundary).
+- **Instruction counts are immune to layout, not to inlining.** A count that moved because the
+  inliner moved is real for the shipped binary and transfers to nothing: #254's 133→119.5 vanished
+  under `noinline` and never existed under gcc. Before generalising a count: pin with `noinline`,
+  check the second compiler, and read `perwl.sh` for workloads that *cannot* run the changed code —
+  if they moved, it was the inliner (#268: one `churn` instantiation grew 7065→10384 bytes). grep
+  "inlining artifact".
+- **A scratch one-map TU can hide a redundancy (#254) or invent one (#268: a `m_group_mask` reload
+  real in the scratch TU, hoisted in the score binary).** Read the disassembly of the score binary's
+  hot function, found via `perf record`, not a scratch TU's.
+- **Profile before disassembling.** #268's only real find had a 0.2% ceiling readable from one
+  `perf record`; the audit spent a day reaching it. grep "sweep run over find and churn".
+- **The paired harness gets the sign wrong on anything that changes inlining** (both headers in one
+  TU exhaust the budget): removing an `always_inline` read 0.979 paired and 1.017 solo. grep "solo".
+- **A benchmark that picks its variant inside the timed loop measures the dispatch** (14.11 vs 13.43
+  ns for identical addresses). Variant = template parameter; a gated loop = two instantiations, never
+  a branch (a predicted branch with a ring, a lambda and an array hanging off it cost 10%).
+- **A benchmark that rebuilds its subject every round measures the allocator, bimodally** (4.40 /
+  2.85 / 4.76 ns for one binary). Warm the subject, report the median round.
+- **A benchmark with a small per-epoch batch must advance its own randomness**; a replayed key
+  sequence is learned by the predictor (2.7x flattery; made twice, two tools). grep "replay".
+- **A benchmark's input model can make a wrong heuristic look right** (a fresh-key rate that is
+  stationary in the harness and 64x wrong on real data). Unit tests judge correctness, benchmarks
+  judge speed. grep "birthday".
+- **A pipeline's payoff depends on the caller's data, not only the size**: `replace()`'s ring is 1.5x
+  with no duplicates and −16% with a quarter, same size. Pick gates on the geomean over key types and
+  rates and state what they give up. grep "duplicate rate".
+- **Walk value containers with iterators in any loop that also places** — a `uint8_t` fingerprint
+  store may alias the container's data pointer, so an indexed read reloads it per element (10.43→2.74
+  ns). Hold one cursor fewer than feels natural (`size()`, not `last`): a fourth live value cost 3.5%
+  cycles with fewer instructions. grep "cursor".
+- **The page size is worth more than anything left in the code**: L1 dTLB = 72 entries = 288 KB;
+  every scored workload but `iterate` exceeds it; 1.6 G L2-TLB lookups per score pass, 107x fewer on
+  2 MB pages. It is not the map's to set (process policy, source break on the allocator type,
+  machine-dependent results): opt-in allocator #231 or the environment. grep "4 KB pages".
 
-`test/bench/workloads.h`. Breaking any of these makes the score measure the input instead of the map.
+### Rules the workloads must obey (`test/bench/workloads.h`; break one and the score measures the input)
 
-- String keys must vary in length (8–135 bytes, skewed short). One fixed length makes the hash's
-  length dispatch perfectly predictable: 0.31 branch misses per hash against 0.01.
-- Integer keys must be scrambled through a bijection, never small sequential values — the top bits
-  of a multiplied small integer walk a lattice and nothing collides.
-- Something must grow the table, something must hold a fixed size and churn, and something must
-  carry a mapped value bigger than eight bytes. Each of those was missing once and hid a whole class
-  of behaviour.
-- `workloads::tame_allocator()` must be called by every workload. Without it a build measures the
-  kernel's page fault handler: 38% of `build64`'s cycles were kernel time, and whether it was paid
-  depended on what ran earlier in the process.
-- A churn loop must draw fresh insert keys, not recycle from a small pool — recycling under-reports
-  the drift by half.
-
-Scores from before any of these changed are not comparable with scores after.
+String keys 8–135 bytes skewed short (fixed length = predictable hash dispatch); integer keys through
+a bijection (small sequential ints never collide); something must grow, something must churn at a
+fixed size, something must carry a >8-byte value; `tame_allocator()` in every workload (else 38% of a
+build is the page-fault handler); churn draws fresh keys (recycling halves the drift). Scores before
+and after any workload change are not comparable, and the change is the fix, not a workaround.
 
 ## Mutation testing
 
-Coverage says a line ran; `scripts/mutate/mutate.py` says something would have noticed it
-misbehaving. It never touches the working tree — every build happens in a throwaway copy.
-
 ```sh
-scripts/mutate/mutate.py --diff                        # whatever is uncommitted — the everyday mode
-scripts/mutate/mutate.py --diff HEAD~1                 # only what that change touched
-scripts/mutate/mutate.py --bugs scripts/mutate/bugs/erase-path.txt   # put a specific bug back
-scripts/mutate/mutate.py --replace OLD NEW             # one bug, must match exactly once
-scripts/mutate/mutate.py --reverse HEAD                # undo a fix, keep today's tests
-scripts/mutate/mutate.py --lines 1278-1290 --dry-run   # size a run first
+scripts/mutate/mutate.py --diff                    # uncommitted changes — the everyday mode
+scripts/mutate/mutate.py --diff HEAD~1
+scripts/mutate/mutate.py --bugs scripts/mutate/bugs/erase-path.txt
+scripts/mutate/mutate.py --lines 1278-1290 --dry-run   # size a run; one mutant ≈ 100 CPU-s
 ```
-
-- Verdicts are `caught` (a test failed — the number to move), `compiler`, `hang`, `oom`, `survived`.
-  **Check the verdict, not just that the block applied**: a `compiler` verdict means the question was
-  never asked, and three of the obvious rewrites here are rejected by the compiler rather than a test.
-- A mutant that reads one slot past a bucket comes back `survived` without a sanitizer. Re-run
-  anything surprising with `--meson-arg=-Db_sanitize=address,undefined`.
-- **A stale block in a `bugs/` file makes the tool refuse the whole file, so none of the others are
-  checked either.** Five of `invariants.txt`'s went stale silently once. Re-run after renames.
-- A block whose replacement contains what it replaces needs `<<< additive` on its fence.
-- One mutant costs a full rebuild (~100 CPU-seconds); budget a minute for a handful and an hour for
-  a function. `--operators` picks what to change; `deletions` and `bitwise` are the sharp ones here.
-
-**`mutate_core.py` is vendored byte-identically into nanobench and oans.** Change it here, run
-`scripts/test_mutate.py`, then copy it to both and update all three `.sha256` files —
-`lint-mutate-core.py` fails if this copy moved without its hash. `scripts/test_mutate.py` covers the
-cmake and make backends this project never runs, because a backend tested only where it is used is
-untested.
+- Verdicts: `caught` is the number to move; `compiler` means the question was never asked.
+- **A stale block in a `bugs/` file makes the tool refuse the whole file** — re-run after every
+  rename; a rename silently disabled 46 blocks once. `<<< additive` when a replacement contains its
+  original. Re-run surprises with `--meson-arg=-Db_sanitize=address,undefined` (a one-past read
+  survives without it).
+- `mutate_core.py` is vendored byte-identically into nanobench and oans: change here, run
+  `scripts/test_mutate.py`, copy to both, update all three `.sha256`.
 
 ## Fuzzing
 
-The `fuzz` suite replays the committed corpora on every test run. The targets go looking:
-
 ```sh
 CXX=clang++ meson setup builddir/fuzz && ninja -C builddir/fuzz test/fuzz_group_index
-./builddir/fuzz/test/fuzz_group_index -max_total_time=60 scratch-dir data/fuzz/fuzz_group_index
-scripts/fuzz_afl.py run|sweep|minimize [target]        # AFL++, every physical core; minimize folds findings back
+./builddir/fuzz/test/fuzz_group_index -max_total_time=60 scratch-dir data/fuzz/fuzz_group_index   # corpus dir SECOND
+scripts/fuzz_afl.py run|sweep|minimize [target]
 ```
+`fuzz_group_index` hashes with the identity and is the only target that reaches the index's own
+structure (it found the unbounded miss). `data/fuzz/fuzz_group_index/cb8d5c38…` is the hang input;
+coverage minimization drops it — put it back. `afl-fuzz` needs `core_pattern` not piped.
 
-- **libFuzzer writes into the *first* corpus directory given.** Keep `data/fuzz/...` second or it
-  fills with hundreds of generated files.
-- `fuzz_group_index` is the only target that can reach the index's own structure: it hashes with the
-  identity, so a key names the group, fingerprint class and identity separately, and "fill this
-  group, send one key past it, take the fillers back out" is a handful of mutations rather than a
-  coincidence. That is how an unbounded miss survived every other target and 767 unit tests.
-- `data/fuzz/fuzz_group_index/cb8d5c38…` is the input that hung the probe before the miss had a
-  bound. **Coverage minimization drops it every time** — put it back by hand.
-- `afl-fuzz` refuses to start while `/proc/sys/kernel/core_pattern` pipes to a crash handler.
+## Already measured — do not propose again without new evidence (grep the phrase in the notes)
 
-## CI
-
-`.github/workflows/main.yml`, 34 legs: gcc and clang, C++17 and C++23, 32 and 64 bit, libc++,
-unity, no-SSE2, sanitizers, valgrind, MinGW, MSVC, macOS arm64, Linux ARM64, modules. Any leg
-reproduces as:
-
-```sh
-meson setup builddir --force-fallback-for=fmt -Dcpp_std=c++17 <matrix setup_args>
-meson test -C builddir --print-errorlogs
-```
-
-- **Reproduce the unity leg with its own size (`--unity=on --unity-size=16`) whenever a test file is
-  added or removed**, not only when one is edited. Adding a file shifts every later file's chunk and
-  can collide two anonymous-namespace names written years apart.
-- Linters run via `scripts/lint/all.py`. `clang-tidy-18` and `clang-format` 21 are pinned because
-  both tools gain checks between releases; the format linter *skips* rather than fails when it
-  cannot find version 21.
-
-## Offline / sandboxed environments
-
-If meson cannot download the wrap subprojects, put the sources in `subprojects/doctest-2.5.3/` and
-`subprojects/fmt-12.0.0/` (matching each `.wrap` file's `directory` field) with a minimal
-`meson.build` declaring `doctest_dep` and `fmt_dep` and calling `meson.override_dependency()`.
-Meson skips the download when the directory exists. Both are gitignored.
-
-## What has already been tried
-
-One line each; the evidence is in `notes/index-design.md`, searchable by these phrases. **This is
-not the whole list — it is the ideas most likely to be proposed again.**
-
-*The counters.* One counter per group, folly-style: 0.959 on the score. Sixteen nibbles: 0.986.
-Thirty-two two-bit: 0.988. An exact in-home counter: worth 2–3% in cache only. Three fresh hash bits
-per probe step: noise. **Eight one-byte counters is the top of that axis** — the point where a
-counter is one aligned load and still per-class.
-
-*The probe.* Double hashing instead of the triangular sequence: mechanism works, time worse. A
-sliding unaligned window (indivi's): 1–5% of a hit, and it forecloses both counters and the merged
-block. Fusing the insert's probe with its placement: more instructions, not fewer. Removing either
-index prefetch *there*: a clang win and a bigger gcc loss, so left alone — but the two walks that
-look a *value* up (`slot_of_value`, `repoint_value`) do not want it at all and no longer have it,
-because the index they read is the answer rather than an address to load from (#263).
-
-*The layout.* Merged 88 byte block: **kept**, 7% of a lookup's instructions and 28% of its dTLB
-misses at 4M. A quarter of those blocks span three cache lines, and `prefetch_block` steps
-by 64 from the start rather than asking for the first and the last — same instruction count, 3.3%,
-because it takes the middle line (counters and fingerprints) over the tail. Naming all three lines
-is *slower* than either (#250, `scripts/ab/prefetch_lines.cpp`). Both helpers ask for **two
-consecutive lines from where they start, clamped into the block** — unchanged code for `group`, 4%
-and 2% for `group_big`'s 152 bytes, where naming the line they each used to miss buys nothing (#252). Splitting fingerprints from counters: a tie. Cache-line-aligning the indices: 0.993.
-A second fingerprint in the index's spare bits: 0.975. 16-bit indices for small maps: 0.986. A
-12-slot 64 byte block: 0.9888.
-
-*The values.* A narrower value index, tiny pointers included: bounded at ~9% of memory and no speed
-by insertion order itself -- the referrer does not choose the position, so the index carries
-log2(n) - 1.44 bits per entry. The one speed idea behind it, a value address the group predicts and
-can prefetch, was measured on a layout built to make the prediction exact: 0.82 of a hit at 12M
-entries, **0.99 for a string**, and misses 13-24% worse at every size. Closed, #229.
-A slot back-pointer per value: pays only for string erase-by-iterator, loses the
-score. Distance nibbles with it: 0.959. `realloc` growth: available today via
-`AllocatorOrContainer`. A growth factor below 2: 7–13% of steady memory for 9–19% of a build —
-a knob, not a default. Not zeroing the index: 1.7% of a large build, and undefined behaviour in the
-copy constructor.
-
-*The hash.* Twelve hashes measured against this one; **nothing clean is faster on latency**, which
-is what a lookup pays. AES-NI is 28% faster hashing and 9–37% slower in the map. Four latency
-tunings of the current hash: worthless, and the microbenchmark that said otherwise had the key's
-length on its dependency chain. The hash is done; what a string lookup pays is the probe and the
-key compare.
-
-*Compilers.* `always_inline` on `probe` and `do_place_element`: **both kept**, worth 1.244 vs 1.149
-under gcc and 17–20% of a build in a caller's translation unit. clang splits the insert path and
-gcc does not, which is most of the build difference between them: measured exactly with callgrind,
-the split costs **15 instructions of prologue and epilogue per insert** and clang pays the same 15
-on boost, so it is the call boundary and not this map's register allocation. **PGO removes all of
-it** (96.4 to 69.3 instructions, 34.0 to 17.5 cycles) on both maps. No source change steers it, and
-six have been tried; what is left against boost once the boundary is gone is eleven instructions,
-and at 4M entries the two are level.
-
-*Range insert sizing.* `insert(first, last)` reserving from the range is **2x** and was **declined**,
-#248 — every version that gets the 2x is a heuristic about data the map cannot see, and an ordered
-range defeats all of them. `reserve(size() + distance())` is 128x the index at a 99% duplicate rate
-*and* 1.21 slower; a sampled fresh rate is 64x (2048 keys drawn from ten thousand come back 90% new
-— the birthday bound, not a duplicate rate); a capture-recapture read of the same sample is accurate
-and still guesses. Note the cost is the **value vector's** reallocation, not the index rehash:
-reserving only the values gets 10.4 ns/element against 9.9 for both and 19.6 for neither, and
-reserving only the buckets is *worse* than not reserving.
-
-*Probe termination.* Every probe that searches for a key or a value is bounded; the two *placement*
-walks are not, and deliberately -- they terminate on the free-slot invariant the load factor
-maintains, which no caller can break. The miss probe got its bound after a fuzz hang; `slot_of_value`
-got one after a five-line hang a mutable key could reach (#254). The bound costs one compare on the
-next-group path and nothing on a home-group hit.
-
-*Audited and empty -- in the code.* The #260/#262 disassembly sweep over find, churn and the two
-placement walks: one real round trip (`move_home` re-deriving what its callers held), worth 0.2% at
-the ceiling and 0.0% measured, plus two candidates this file had already closed. #268. What the same
-session did find is below the code.
-
-*Huge pages.* **2.6% of the score under gcc and 3.6% under clang, 5-8% of churn and the 50% find**,
-measured by running one binary twice with `GLIBC_TUNABLES=glibc.malloc.hugetlb=1` on and off; 22%
-of a lookup past L3. The old line here said the score could not see them; it was measuring hits on a
-warm map, the one shape that overlaps its translations. Nothing in the header can ask for a page
-size. An opt-in allocator can, and so can a user's environment; both are documented in README 3.8.
-`huge_page_allocator` (#231) puts blocks of 2 MB and up on their own huge pages: `build` 1.5-1.7x
-from 200000 entries, `churn` 1.33x at 800000, lookups 1.14x at 4M, **nothing at 50000** because
-no block there is 2 MB -- the score's churn gain needs the heap-wide route, which shares extents.
-A string's body is `malloc`ed outside any allocator the map holds and stays on 4 KB pages.
-
-*Still open.* Nothing measured and unclaimed; #231's size sweep is in the notes.
-A built-in probe-length statistics facility like boost's. The string erase's ~50 ns second hash.
-
-*Bulk lookups.* `visit(first, last, f)` is 1.07-1.14x over the same batch looked up one key at a
-time, past the cache. The larger effect is the caller's: **batching the keys at all is 1.5x**, and a
-`prefetch(key)` API that was credited with that was reverted the same day it shipped.
-
-*The five pipelines.* The rehash, the range insert, `replace()`'s dedup and `merge()` each have their
-own `pipeline_depth` ring, and the bulk visit has chunks instead (a ring there measured 15% worse);
-sharing them costs the rehash 1.9 instructions per element and was rejected. `replace()` and
-`merge()` are gated, on **index** bytes — counting the values too was measured wrong. The two
-thresholds are **not the same**: 256 KB and 1 MB. `replace()`'s was re-measured across both key types
-and both duplicate rates for #257 and kept: it is the best of four candidates on the geomean (0.9081
-against 0.9137 / 0.9143 / 0.9286), and it buys a 1.5x on one cell by accepting a 1.163 on its
-neighbour. A gate's crossover is where the ring's fixed 13–17
-instructions per element stop being worth the misses they hide, so it moves with what the *rest* of
-the loop costs — writing merge's walk with iterators instead of indices made it 5–11% cheaper and
-pushed its crossover two doublings up. Re-fit the constant whenever the gated loop changes; a shared
-one costs 7–12% in an octave. The range insert is slightly
-negative below a few thousand elements and a clear win above; the visit loses 8% only when every key
-hits a map below ~16k, where the same map at a 50% hit rate wins 11%, so its axis is the caller's
-hit rate. The rehash is the one that has never been measured below cache. #247, #242.
-
-**A gate that is a runtime branch inside the loop costs nearly everything it saves.** `merge()`'s
-first version read the gate per element; the ungated case then came back 10% slower than the same
-loop with the ring deleted, because a perfectly predicted branch is not free when a ring, a lambda
-and a live array hang off it. Two instantiations of one body (`walk(std::true_type{})`) get the
-plain loop back.
-
-**Walk a value container with iterators, never with an index, in any loop that also places
-elements.** `fill_buckets_from_values` records why — a `uint8_t` fingerprint store may alias the
-container's data pointer, so an indexed read reloads it after every placement, and that is a store-
-to-load chain per element (10.43 → 2.74 ns/insert there). `merge()`'s walk cost 0.89–0.95 for being
-written with indices first; `replace()`'s two loops cost 0.68–0.98 over 24 cells. All four loops that
-place are cursor-based now, `do_visit` indexes randomly from the probe and cannot be, and for a
-**string** key the win shows up as cycles with the instruction count flat — there the reload is not
-extra work, it is a latency in front of the next hash.
-
-**But hold one cursor fewer than feels natural: ask the container its `size()`.** `replace()`'s first
-cursor version also held `last` and tested `last - read`. It retired two *fewer* instructions per
-element and took **3.5% more cycles**, reproducibly — a fourth live value across a loop holding three
-ring arrays, and it cannot be decremented on a pop because `std::deque::pop_back` invalidates the
-past-the-end iterator, so it needs an `end()` after every one.
+- Counters: 1/group 0.959; 16 nibbles 0.986; 32 two-bit 0.988; exact in-home counter 2–3% in cache only. Eight bytes is the top. "counter"
+- Group size: 11 slots below 1.00; 24 slots 0.85–1.00 everywhere (dilutes the 8 classes); 12-slot 64 B block 0.9888. Sixteen is a 3-axis optimum. "twenty-four slots"
+- Probe: double hashing worse; sliding window 1–5% of a hit and forecloses counters + merged block; fused probe+placement more instructions. "double hashing", "window"
+- Prefetch: `prefetch_index` 2 lines from +64 clamped, `prefetch_block` 2 lines from +0 — naming a third line loses (#250, #252); dropping the second is a clang win and a 12% gcc loss; the two value walks want none (#263). "prefetch_lines"
+- Layout: merged 88 B block kept (7% of lookup instr, 28% of dTLB at 4M); split fp/counters tie; line-aligned indices 0.993; second fingerprint 0.975; 16-bit indices 0.986. "merged block"
+- Values: narrower index / tiny pointers ~9% memory, no speed (#229); slot back-pointer only pays string erase-by-iterator (#266 open: re-test back-pointer alone, sweep the cache boundary); distance nibbles 0.959; growth < 2 is a knob; not zeroing the index 1.7% and UB. "tiny pointers", "back-pointer"
+- Hash: 12 alternatives, none faster on latency; AES-NI 28% faster hashing, 9–37% slower in the map; short/long split loses; latency tunings worthless (the microbench had the length on the chain). "hash"
+- Compilers: `always_inline` on `probe` and `do_place_element` kept (17–20% of a build in a one-map TU; costs the score, which is a 90-TU binary); clang's insert split = 15 instr/insert call boundary, PGO removes it, six source changes did not. `probe_past_home`'s return shape #267 open. "call boundary"
+- Range insert sizing from `distance()`: 2x and declined (#248) — every version guesses at data the map cannot see. No heuristics about caller data, ever. "birthday"
+- Pipelines: 5 rings (rehash, range insert, replace dedup, merge; visit uses chunks), not shared (1.9 instr/element); gates on index bytes, 256 KB and 1 MB, re-fit whenever the gated loop changes (#247, #242, #257). `visit` 1.07–1.14x; batching keys at all is 1.5x. "gate", "visit"
+- Erase path round trips: #260 (−5 instr/erase, transfers), #262 (gcc −5%), #268 (`move_home` re-derivation: real, worth 0.0%). "slot number"
+- Huge pages: score 2.6–3.6% via glibc tunable; allocator (#231) builds 1.5–1.7x from 200k, churn 1.33x at 800k, nothing at 50k (no 2 MB block), threshold 2 MB not 4; segmented 16 MB segments fastest build; boost gains equally. Not a default. #271 (aliases), #272 (segment size on `segmented_map`) open. "4 KB pages", "size axis"
+- Still open: #266, #267, #271, #272; a probe-length statistics facility; the rehash has never been measured below cache.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,40 @@ rule is in `notes/index-design.md` under the grep phrase given. Nothing here is 
   was tried and what happened; one index line per entry, same commit), and retractions are written
   in place, never deleted. A negative result is an entry too.
 
+## Session mechanics (what cost turns last time)
+
+- **Long runs: one background call, no polling.** Start it with `run_in_background`, `tee` its
+  output to `/home/martinus/gra/<name>/*.txt` (the task's own output file is on `/tmp`), and do
+  independent work until the notification. The command cap is 1 hour: split sweeps at ~45 min.
+- **Smoke every harness at the smallest size, one round, before the real run.** Three scripts this
+  week failed only at run time: `env VAR=x fn` cannot call a shell function; `ls_l1_d_tlb_miss.all_l2_dtlb_miss`
+  is not an event; `$!` after `cmd | tee &` is `tee`'s pid.
+- **Verify the mechanism is engaged before A/B-ing it.** A setting that did not take effect measures
+  as a clean null. Huge pages: `AnonHugePages` in `/proc/<pid>/smaps_rollup` mid-run, or `perf stat
+  -e ls_l1_d_tlb_miss.tlb_reload_2m_l2_hit`. Prefetch/inlining: the symbol table (`nm -C | grep -c`)
+  and `perf record` of the hot function.
+- **CI watcher** (pending shows as `pending` in the tabular view; JSON `conclusion` is `""`):
+  `for i in $(seq 1 55); do t=$(gh pr checks N | awk -F'\t' '{print $2}' | sort | uniq -c | awk '{printf "%s=%s ", $2, $1}'); grep -q pending <<<"$t" || { echo "$t"; break; }; sleep 60; done`
+  — then `gh pr merge N --rebase --delete-branch=false` only if the user said "merge when green".
+- **perf events that exist on this machine** (Zen 4, perf 6.x): `cycles`, `instructions`,
+  `branch-misses`, `dTLB-load-misses`, `ls_l1_d_tlb_miss.{all,all_l2_miss,tlb_reload_4k_l2_hit,tlb_reload_2m_l2_hit,tlb_reload_coalesced_page_hit}`.
+  Four or more events multiplex; three per run for clean counts. `cpuid` is not installed.
+- **A new public header**: `Version X.Y.Z` line in its banner, add it to `CHECKS` in
+  `scripts/lint/lint-version.py`, `#include "unordered_dense.h"` for the version namespace, a unit
+  test registered in `test/meson.build` (then the unity leg), CMake installs the directory so nothing
+  else changes.
+- **Templates.** Issue: `## The number` (measured, with the notes entry name) / `## What to build` /
+  `## How to measure it` / `## Done means`. Notes entry: `**What was tried and what happened**
+  (YYYY-MM-DD, issue #N, Ryzen 9 7950X, clang 22 and gcc 16, the scripts used).` then tables, then
+  "what this says and does not say"; index line = the bold sentence. Commit: one sentence, body with
+  numbers, `Closes #N`. Comment on an issue only when asked ("comment that").
+- **The owner's requests, as phrased:** "Ok now 260" = implement issue 260 and open its PR. "Run
+  simplify" = `/simplify` on the open PR, fix findings directly (never file them as issues unless
+  told). "Merge when green" = watch CI, merge on 34/34, otherwise report. "File 1 2 and 3" = one issue
+  per numbered point in the last reply. "Comment that" = post the last reasoning as an issue comment.
+  "Is it still running?" = check the background job and show partial output. Questions ("would it
+  make sense to…") want the measured answer and a recommendation, not a plan.
+
 ## Build, test, lint
 
 ```sh

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -4,13 +4,15 @@ Every experiment run on this map's index, hash and benchmarks, with the numbers 
 `CLAUDE.md` carries the rules that came out of this; this file is the evidence, and it is here so
 that the rules can be checked and so that a rejected idea is not proposed a second time.
 
-**How to use it.** Do not read it front to back -- it is ~2400 lines. Search it for the thing you
+**How to use it.** Do not read it front to back -- it is ~4600 lines. Search it for the thing you
 are about to try, by the phrase in the index below (`grep -n "double hashing" notes/index-design.md`)
 or by a symbol (`grep -n move_home notes/index-design.md`). Each entry opens with a bold sentence
-saying what was tried and what happened, and the paragraph under it is the evidence.
+saying what was tried and what happened, and the paragraph under it is the evidence; bold sentences
+inside an entry are its sub-results and are not indexed. The index is kept by hand: one line per
+entry, the entry's opening sentence, added in the same commit as the entry.
 
-**Read it before proposing an optimization.** 149 ideas are recorded here and most of them lost.
-Several were proposed twice because the first rejection was not looked up.
+**Read it before proposing an optimization.** About 170 entries are recorded here and most of them
+lost. Several were proposed twice because the first rejection was not looked up.
 
 **Dates are load-bearing.** An entry is true of the header on the day it was measured. Anything
 older than the change it is about has to be re-measured, and entries that were retracted say so in

--- a/scripts/ab/perwl.sh
+++ b/scripts/ab/perwl.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Per-workload ratios of one nanobench column from the two binaries of a solo.sh build directory.
+#
+#   scripts/ab/perwl.sh [-m ins|ns|cyc|bra|miss] [-t TESTCASE] <AB_BUILD dir>
+#
+# Prints candidate/baseline per scored workload. The default column is ins/op, which neither code
+# layout nor drift can move: two runs of the same two binaries give the same fifteen numbers to
+# four decimals, so a difference is the change or the inliner and never noise -- and a workload
+# that *cannot* execute the changed code and still moves is the inliner (#254, #268). Below 1.00
+# means the candidate does less. This is the measurement that decides anything under 10%.
+set -euo pipefail
+export LC_ALL=C
+metric=ins tc=bench_quick_overall_udm
+while getopts "m:t:" opt; do
+    case $opt in
+        m) metric=$OPTARG ;;
+        t) tc=$OPTARG ;;
+        *) exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
+d=${1:?AB_BUILD dir with udm-base and udm-cand}
+case $metric in
+    ns) col=2 ;; ins) col=5 ;; cyc) col=6 ;; bra) col=8 ;; miss) col=9 ;;
+    *) echo "metric must be ins, ns, cyc, bra or miss" >&2; exit 1 ;;
+esac
+extract() {
+    ${AB_CORE:+taskset -c $AB_CORE} "$1" -ns -tc="$tc" 2>/dev/null |
+        awk -F'|' -v c="$col" '/ankerl::unordered_dense::map</ {
+            v = $c; gsub(/[ ,%]/, "", v); n = $11; gsub(/^ +| +$|`/, "", n)
+            sub(/ankerl::unordered_dense::map/, "", n); print n "\t" v }'
+}
+paste <(extract "$d/udm-base") <(extract "$d/udm-cand") |
+    awk -F'\t' -v m="$metric" '{printf "  %8.4f  %s\n", $4 / $2, $1} END {print "  (candidate over baseline, " m "/op)"}'

--- a/scripts/ab/same_binary.sh
+++ b/scripts/ab/same_binary.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# One binary, run alternately with and without an environment setting; the score's ratio per round.
+#
+#   scripts/ab/same_binary.sh [-t TESTCASE] [-b BINARY] [rounds] VAR=value [VAR=value...]
+#
+# For anything the paired harness cannot see because both of its sides share one process: the page
+# size (GLIBC_TUNABLES=glibc.malloc.hugetlb=1), an allocator tunable, a CPU governor. There is no
+# second build and no code layout to argue with, so the ratio is the environment and nothing else.
+# Above 1.00 means the setting is faster. Keep the machine otherwise idle; AB_CORE pins.
+set -euo pipefail
+export LC_ALL=C
+tc=bench_quick_overall_udm bin=builddir/clang_release/test/udm-test
+while getopts "t:b:" opt; do
+    case $opt in
+        t) tc=$OPTARG ;;
+        b) bin=$OPTARG ;;
+        *) exit 1 ;;
+    esac
+done
+shift $((OPTIND - 1))
+rounds=5
+[[ ${1:-} =~ ^[0-9]+$ ]] && { rounds=$1; shift; }
+[ $# -ge 1 ] || { sed -n '2,10p' "$0"; exit 1; }
+score() { ${AB_CORE:+taskset -c $AB_CORE} "$bin" -ns -tc="$tc" 2>&1 | grep bench_quick_overall_map_udm | awk '{print $1}'; }
+echo "$bin, $tc, plain against: $*"
+sum=0
+for r in $(seq 1 "$rounds"); do
+    a=$(score)
+    b=$(env "$@" bash -c "$(declare -f score); bin='$bin'; tc='$tc'; score")
+    ratio=$(awk -v a="$a" -v b="$b" 'BEGIN {printf "%.4f", a / b}')
+    sum=$(awk -v s="$sum" -v r="$ratio" 'BEGIN {print s + log(r)}')
+    echo "  round $r   plain $a   with $b   ratio $ratio"
+done
+awk -v s="$sum" -v n="$rounds" 'BEGIN {printf "  geomean %.4f  (above 1.00 means the setting is faster)\n", exp(s / n)}'


### PR DESCRIPTION
`CLAUDE.md` rewritten for its actual reader: a file map, the workflow rules (PR only, rebase merges, stacked PRs, `AB_BUILD` off tmpfs, notes discipline), the build/test/CI-reproduction commands, one paragraph of index design, a table of which measurement answers which question with the measured calibration constants, the rules each with its grep phrase into the notes, and the list of everything already measured with issue numbers. 200 lines instead of 398; every number kept, every narrative dropped; `notes/index-design.md` stays the evidence and its header now states the index rule and current counts.

Two scripts for the methods the file cites that until now lived in `/tmp`:

- `scripts/ab/perwl.sh <AB_BUILD dir>` — per-workload candidate/baseline of one nanobench column (default `ins/op`, deterministic to four decimals) from a `solo.sh` build directory. Smoke: identical binaries read 1.0000 fifteen times.
- `scripts/ab/same_binary.sh [rounds] VAR=value` — one binary with and without an environment setting, alternating, geomean; for what the paired harness cannot see. Smoke: `GLIBC_TUNABLES=glibc.malloc.hugetlb=1` reads 1.054 in one round.

No header changes. Linters green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)