### PR TITLE
Sweep fifty sizes across the octave, and measure the sawtooth instead of assuming it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,8 @@ entries; churn is 50000. Anything past L2/L3 is invisible to it and needs the si
 | the mechanism (cycles, misses, TLB) | `perf stat` / `perf record` on the score binary or `scripts/ab/maps_one.sh` (one map per binary) | `perf record` first: an out-of-line symbol in `nm` is not evidence the hot path calls it (#268) |
 | an environment setting: page size, allocator tunable, governor | `scripts/ab/same_binary.sh 5 GLIBC_TUNABLES=glibc.malloc.hugetlb=1` | same binary, no layout band; the paired harness cannot see this (both sides share a process) |
 | the size axis, other maps, allocators | `scripts/ab/huge_pages.sh`, `scripts/ab/maps.sh`, `scripts/ab/prefetch_lines.sh`, ... (all self-contained, variant = template instantiation, interleaved rounds, medians) | never one size: sweep, and sweep across the cache boundary |
-| is the paired harness biased today | `scripts/ab/run.sh -r HEAD` (same header both sides) | reads `rmissstr` 1.036, `buildbig` 0.983, `hashstr` 0.872 on a clean tree: retires anything under ~5% there |
+| a ratio against a map that is not this header (boost, another slots-per-group) | `scripts/ab/run.sh -b -p 50` (2.4x the default's wall clock) | five points are worth up to 26% there and 0.6% against another revision of this header: the two sawtooths are only in phase in the second case (#274) |
+| is the paired harness biased today | `scripts/ab/run.sh -r HEAD` (same header both sides) | one build is one sample of the layout band: `rmissstr` 1.036 then 0.993-1.008, `rhit64` 0.976-1.000, `hashstr` 0.872-1.05. Re-take it per build and retire anything under ~5% |
 
 Calibration constants, all measured: run-to-run drift 1–2%; **code layout luck ±3%** (two runs of the
 same two binaries are one layout sample; `-falign-functions=32` re-rolls it: #262 read 0.9975 and
@@ -142,6 +143,9 @@ THP-`always` runner scores 2.6–3.6% above a `madvise` one for no reason in the
 - **Never quote a ratio from one table size.** Load factor sawtooths ½→max between doublings and two
   indexes double at different sizes: 11 slots read 1.384 at one size, 1.039 over the octave; churn64
   reversed sign. Every boost ratio not labelled "octave geomean" is a point measurement. grep "octave".
+  **Five points across that octave never land on its peak** (load 0.763 of a maximum of 0.800) and
+  read half the amplitude `-p 50` reads (`rmiss64` 1.29x against 1.46x). Five is right for a
+  header-against-header A/B and wrong for anything out of phase with this map. grep "Fifty points".
 - **Sweep across the cache boundary for any prefetch/pipeline.** Lookahead costs 13–17 instr/element
   whether needed or not; `replace()` shipped a fifth slower below 65k after being measured only above
   its crossover. Two sizes on one side of a cache are one size. grep "crossover".

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -404,6 +404,34 @@ not a cycle. A five-point sweep puts two points below it and three above, a fift
 and forty-five, and the geomean moves by the difference. It is the "sweep across the cache boundary"
 rule arriving in a workload that was never thought of as a size sweep.
 
+**The sizes are template arguments, and that is worth at most 1.4%, which is the layout band.**
+Asked on 2026-09-12: does making every swept size a compile-time constant buy anything? The premise
+`workloads.h` states -- "turning a literal loop bound into a runtime value is a change even when the
+value is the same" -- had never been measured. Two builds of the harness from one source, the second
+with every size passed through `asm volatile("" : "+r"(v))` before use, which is exactly what a
+function argument would do to the compiler's knowledge of it and changes nothing else. Candidate
+time, opaque over constant, five sizes each:
+
+| `build64` | `churn64` | `ie64` | `find64` | `buildstr` | `churnstr` | `rhit64` | `rmissstr` |
+|---|---|---|---|---|---|---|---|
+| 0.959 | 1.014 | 1.006 | 1.006 | 1.010 | 0.995 | **0.998** | **0.986** |
+
+The last two are the control: `rhit*`/`rmiss*` take their trip count from a body constant, not from
+the template parameter, so their code is identical in both binaries -- and they read 0.998 and 0.986,
+which is the two-binary layout band. Every workload that did change is inside it, in both directions.
+`build64`'s 0.959 is the largest number in the table and it says the *opaque* build was faster, which
+is what layout luck looks like.
+
+So the rule holds where it was written -- the scored instantiation must keep compiling the literal it
+always did, because silently editing the benchmark is the thing to avoid -- and buys nothing
+measurable for the swept points. What it costs there is compile time that scales with the point
+count: 17.4 s at fifty sizes against 3.6 s at five, where runtime sizes would compile in the
+five-size time whatever P is. Within one run the per-point control ratios scatter by 0.25-0.92%
+standard deviation, mostly under nanobench's own interval, so fifty separate instantiations are not
+adding noise either; the geomean's standard error from that scatter is 0.04-0.33%. **If a grid finer
+than fifty is ever wanted, passing the swept sizes at runtime is the change to make, and this is the
+measurement that says it is safe.**
+
 **The growth is measured now, not assumed.** An octave is one whole turn of the cycle only because
 the bucket array doubles, which is this map's policy and not a law -- a growth factor under two is a
 knob this file already records. So before anything is timed the harness inserts into each map in the

--- a/notes/index-design.md
+++ b/notes/index-design.md
@@ -34,6 +34,7 @@ place rather than being deleted, because the retraction is usually the more usef
 
 **Dead ends of the group index (paired A/B, 2026-09-05)**
 
+- Fifty points draw the load-factor sawtooth that five average out, and five points are worth 26% of a cross-family ratio
 - The #260/#262 sweep run over find and churn, and it comes back empty
 - The opt-in huge page allocator, measured across the size axis
 - The score runs on 4 KB pages and pays 1.6 billion L1 dTLB misses for it
@@ -310,6 +311,159 @@ probing and rewarded the opposite, and it hid most of the SSE2 probe's gain. The
 decides every lookup with an rng of its own. `find_random.cpp` still replays.
 
 ## Dead ends of the group index (paired A/B, 2026-09-05)
+**Fifty points draw the load-factor sawtooth that five average out, and five points are worth 26% of
+a cross-family ratio** (2026-09-12, issue #274, Ryzen 9 7950X, clang 22, `scripts/ab/run.sh -p`,
+`scripts/ab/ab.cpp`, `test/bench/workloads.h`).
+
+The paired harness has swept five sizes across an octave since 2026-09-07 (the boost entry below)
+because a comparison at one size reports wherever that size lands on each map's sawtooth. #274 asked
+the next question: five points cannot land on the *peak* -- the size just before a doubling, which
+is where a table is fullest and every probe is longest -- so is a much denser sweep affordable, is
+the octave really one whole turn of the cycle, and can the payload be cut so the run does not
+explode?
+
+**The switch did not mean what it said.** The five sizes were a table of five scale factors and
+`-p N` ran its first N, so `-p 3` swept from n to 1.32n -- three fifths of an octave -- and printed
+"octave geomean" over it. Nothing recorded in this file was taken that way (every `run.sh` entry
+says five), but the switch was there and it was wrong. The count is now a compile-time constant --
+`run.sh -p` rebuilds the binary, because the sizes are template arguments -- and the i-th of P
+points is `n * 2^(i/P)` for any P, which spans exactly one doubling however many are asked for.
+
+**What fifty points see that five do not.** The dearest point of an octave over the cheapest, per
+element, same header on both sides, twelve epochs:
+
+| | 5 points | 50 points | dearest at |
+|---|---|---|---|
+| `rmiss64` | 1.286x | **1.458x** | load 0.795 |
+| `churn64` | 1.142x | **1.284x** | load 0.795 |
+| `churnbig` | 1.148x | 1.247x | load 0.795 |
+| `rhit64` | 1.115x | 1.168x | load 0.742 |
+| `churnstr` | 1.055x | 1.120x | load 0.752 |
+| `rmissstr` | 1.061x | 1.099x | load 0.795 |
+
+A fifth of an octave gets no closer to the peak than load 0.763 of a maximum of 0.800; a fiftieth
+reaches 0.795. Half of `rmiss64`'s amplitude is in that last 4% of the load, which is exactly where
+the issue expected it to be: the cost of a miss is superlinear in the load factor, so the top of the
+cycle is a spike and not a plateau, and a sweep that steps past it never sees it.
+
+**The spike belongs to the miss and not to the hit**, which fifty points make plain and five could
+not. `rmiss64` steps 32.2% and `rmissstr` 10.3% across the single size where the array doubles;
+`rhit64`'s largest step anywhere in the octave is 2.0% and `rhitstr`'s 2.9%, and neither is at the
+doubling -- their 1.168x and 1.097x climb with the size of the table and not with its load. A key
+that is there is found in its home group whatever the load; a key that is not there is what walks.
+
+**And what five points are worth, measured rather than argued.** A fifty-point run contains ten
+five-point sweeps -- every tenth point, each spanning the whole octave, each one a sweep this
+harness would have reported without complaint. Each one's geomean against the fifty-point one:
+
+| | `base/cand`, the same header twice | `boost/cand` |
+|---|---|---|
+| `churn64` | 0.999 .. 1.005 | **0.742 .. 1.023** |
+| `churnbig` | 0.995 .. 1.002 | 0.787 .. 1.069 |
+| `churnstr` | 0.998 .. 1.001 | 0.855 .. 1.038 |
+| `rmiss64` | 0.989 .. 0.996 | 0.833 .. 1.010 |
+| `build64` | 0.992 .. 1.003 | 1.459 .. 1.571 |
+| `rhit64` | 0.974 .. 0.980 | 0.753 .. 0.776 |
+| `rhitstr` | 0.993 .. 1.017 | 0.858 .. 0.881 |
+
+**Against another revision of this header, five points are worth 0.6%** -- the two sawtooths are in
+phase, so they cancel out of the ratio whatever is sampled, which is the reason every same-family
+paired number in this file is sound however it was taken. **Against boost they are worth 26%**:
+`churn64` reads 0.742 or 1.023 for one quantity depending only on which five of the fifty sizes the
+sweep starts from. Two fifty-point runs made the same day give that spread to within 0.4%, so it is
+the phase and not the noise. The five-point and fifty-point geomeans themselves differ by under 4%
+on nine of the ten workloads and by **16% on `buildbig`** (1.986 against 1.716), for a reason worth
+seeing on its own.
+
+The fifty-point column is the one to quote from now on. `boost::unordered_flat_map` given this
+library's hash, **boost's time over this map's, so above 1.00 means this map is faster**, the same
+header on the other two sides, same order of columns as the table above:
+
+| | 5 points | 50 points |
+|---|---|---|
+| `build64` | 1.591 | 1.526 |
+| `buildstr` | 2.026 | 2.054 |
+| `buildbig` | 1.986 | **1.716** |
+| `churn64` | 0.805 | 0.810 |
+| `churnstr` | 0.890 | 0.898 |
+| `churnbig` | 0.843 | 0.858 |
+| `rhit64` | 0.761 | 0.762 |
+| `rmiss64` | 0.868 | 0.888 |
+| `rhitstr` | 0.875 | 0.869 |
+| `rmissstr` | 0.832 | 0.837 |
+
+The two columns agree because one five-point sweep out of ten was run, not because five points are
+enough: the table above this one is what the other nine would have said.
+
+**`buildbig`'s octave has a 5.9x step in it that has nothing to do with the load factor.** Building
+a `map<uint64_t, big_value>` costs 3.90 ms at 249666 entries and 23.09 ms at 263902, one 5.7% step
+in size later, and stays there for the rest of the octave: 64 bytes times a quarter million is 17 MB
+of values, and doubling that vector wants the old and the new at once, which is where a 32 MB L3
+stops holding the copy. The sawtooth column reads 6.45x for that workload and it is a cache cliff,
+not a cycle. A five-point sweep puts two points below it and three above, a fifty-point sweep five
+and forty-five, and the geomean moves by the difference. It is the "sweep across the cache boundary"
+rule arriving in a workload that was never thought of as a size sweep.
+
+**The growth is measured now, not assumed.** An octave is one whole turn of the cycle only because
+the bucket array doubles, which is this map's policy and not a law -- a growth factor under two is a
+knob this file already records. So before anything is timed the harness inserts into each map in the
+comparison and records every size at which `bucket_count()` changes:
+
+    # cand  grows at 1639 3277 6554 13108 26215 52429 104858 209716   x2.000 -- one octave is exactly one sawtooth
+    # boost grows at 1680 3360 6720 13440 26880 53760 107520 215040   x2.000 -- one octave is exactly one sawtooth
+
+Both double, so both are one octave per cycle and the geomean over an octave is unbiased for both;
+they double 2.5% apart, which is the whole reason the boost column needs the points. A map whose
+ratios were not 2.000 would print a warning saying the geomean weighs part of the cycle twice. The
+same table gives every point line its load factor, so where on the cycle a number sits is readable
+instead of inferred.
+
+**The run does not get ten times longer, and the reason is where a point's cost was cut.** All
+twenty workloads, twelve epochs, clang: **2m21 at five points and 5m34 at fifty**, against 3m19 for
+the five-point run before this change; with boost as a third alternative, 3m32 and 8m37 against
+4m51. Compiling costs 3.6s at five points and 17.4s at fifty, since every size is a template argument.
+Three things pay for the other forty-five points:
+
+- **The two lookup workloads search a table built outside the timed region**, a million times rather
+  than ten million. Before, every timed iteration filled a fifty thousand entry map and then searched
+  it; the fill is not what `rhit64` is for, and with a tenth of the lookups it would have been a tenth
+  of the measurement. `rhit*`/`rmiss*` cost 8.2 s and 2.9 s at fifty points where they cost 7.7 s and
+  3.0 s at five before -- the payload cut buys exactly the ten times the point count spends.
+- **The two workloads that grow a map from empty keep five points.** Their cost is the integral over
+  every doubling they passed through, so there is no cycle left in it. Measured at fifty points
+  anyway, by building the harness with that cap removed: `ie64`'s per-element cost moves 1.021x from
+  its cheapest size to its dearest against the 1.026x five points read, `find64` 1.137x against
+  1.110x and monotonically with size, and **neither has a single step over 1.3%** anywhere in fifty
+  -- where `rmiss64` steps 32.2%, `churn64` 22.1% and `build64` 18.1% in one 1.4% increment of size,
+  at exactly the 52429 and 209716 the growth probe prints. The two of them at fifty points cost 4m43
+  to reproduce what five points said.
+- **Nothing else needed anything.** `build*` and `churn*` run the full payload at every point, which
+  is what takes the run from 2m21 to 5m34; they are the cheap ones.
+
+**Two traps inside that restructuring, both of them this file's own rules.** Passing the table to
+the lookup loop by pointer made it 6.28 ns per hit against the 6.05 the old loop cost, because the
+rng's state update is a store the compiler must assume can alias the map's members -- reached through
+the same pointer -- so it reloaded them on every lookup. Drawing the rng and the key pointer into
+locals and writing the rng back at the end restores 6.05: the same aliasing the notes record for the
+value walks, in a new place. And the control for those four workloads reads 0.976 in one build of the
+harness and 1.000 in another, with `-falign-functions=32` moving 0.976 to 0.997 -- the +-3% code
+layout band, now plainly visible because the timed region is one tight loop and nothing else.
+
+**What this says and does not say.** It says a cross-family ratio -- this map against boost, or an
+index against one with a different number of slots per group -- wants fifty points, and that the ten
+boost ratios in this file taken at five carry up to 26% of sampling error on churn and 16% on
+`buildbig`. It says a header-against-header A/B does not want them: 0.6% is below everything else
+this harness is subject to, and `-p 5` stays the default for that reason. It does not say the
+absolute times of `rhit*`/`rmiss*` are comparable with any run before 2026-09-12 -- the payload is a
+tenth and the table is no longer rebuilt inside the measurement -- **and their boost ratios are not
+either**: taking the fill out moved `rhit64` from 0.798 to 0.760, `rmiss64` 0.917 to 0.868,
+`rmissstr` 0.931 to 0.832 and `rhitstr` 0.886 to 0.874. This map's own per-lookup cost is where it
+was (6.05 ns per hit before, 6.00-6.10 after), so the move is on boost's side of the ratio, and how
+much of it is the fill leaving the measurement and how much is the +-2% the control shows across
+builds was not separated. Against another revision of this header the ratios did not move, because
+there the fill is the same code on both sides and cancels. And it does not touch `bench_quick_overall_udm`: every scored workload compiles the
+same code it did, because the knobs added are template parameters whose defaults are what they were.
+
 **The #260/#262 sweep run over find and churn, and it comes back empty** (2026-09-12, issue #268,
 Ryzen 9 7950X, gcc 16 and clang 22, `scripts/ab/solo.sh`, `perf record` and `perf stat`).
 
@@ -1231,6 +1385,12 @@ mechanism could not reach a lookup at all. Running `scripts/ab/run.sh -r HEAD` o
 and `hashstr` 0.872. So the candidate side of a paired run is systematically faster on those, and a
 single-digit-percent reading on them means nothing. The null run is the check, it costs one run, and
 it should be taken before believing any sub-benchmark delta under about 5%.
+
+Re-taken 2026-09-12 after the lookup workloads stopped rebuilding their table (see "Fifty points
+draw the load-factor sawtooth"): `rmissstr` now reads 0.993 to 1.008 and `rhit64` 0.976 to 1.000
+across builds of the harness, with `-falign-functions=32` moving that 0.976 to 0.997. **The null run
+has to be re-taken per build, not per harness** -- each build is one sample of the code layout band,
+and the workload that carries the bias is not always the same one.
 
 **A block's prefetches should step from its start, not jump to its end** (2026-09-11, issue #250,
 `scripts/ab/prefetch_lines.cpp`, Ryzen 9 7950X, clang 22). Raised by a cleanup review as "a quarter

--- a/scripts/ab/README.md
+++ b/scripts/ab/README.md
@@ -33,6 +33,76 @@ which spans 0.79 to 1.33 point to point. The same thing happens to the boost col
 header untouched: a single same-code run reads `boost/cand` at 1.205, 0.641, 0.649, 0.685 and 0.831
 across one octave of `churn64`, a 1.9x swing, geomean 0.779.
 
+### Fifty points draw it, five average it out
+
+`-p 50` measures fifty sizes across the octave instead of five, and what it draws is not what five
+points suggest. The top of the cycle is a *point*: a sweep spaced a fifth of an octave apart gets
+no nearer the peak than load 0.763, one spaced a fiftieth reaches 0.795 of a maximum of 0.800, and
+the amplitude it then reports is far bigger.
+
+| dearest over cheapest, per element across the octave | 5 points | 50 points |
+|---|---|---|
+| `rmiss64` | 1.286x | **1.458x** |
+| `churn64` | 1.142x | **1.284x** |
+| `churnbig` | 1.148x | 1.247x |
+| `rhit64` | 1.115x | 1.168x |
+| `churnstr` | 1.055x | 1.120x |
+| `rmissstr` | 1.061x | 1.099x |
+
+Each point line carries the load factor of a table of that size, so where on the cycle a number
+sits is readable rather than inferred, and each workload prints its cheapest and dearest point;
+where the workload's live size is about half of n (`ie*`, `find*`) the load is left off rather than
+guessed.
+
+**What that is worth depends on whether the two maps double at the same sizes.** Taking the fifty
+points of a run apart into the ten five-point sweeps inside it -- every tenth point, each one
+spanning the whole octave, each one a sweep this harness would have been happy to report -- and
+comparing each to the fifty-point geomean:
+
+| | `base/cand`, the same header both sides | `boost/cand` |
+|---|---|---|
+| `churn64` | 0.999 .. 1.005 | **0.742 .. 1.023** |
+| `churnbig` | 0.995 .. 1.002 | 0.787 .. 1.069 |
+| `churnstr` | 0.998 .. 1.001 | 0.855 .. 1.038 |
+| `rmiss64` | 0.989 .. 0.996 | 0.833 .. 1.010 |
+| `build64` | 0.992 .. 1.003 | 1.459 .. 1.571 |
+| `rhit64` | 0.974 .. 0.980 | 0.753 .. 0.776 |
+
+Against another revision of this header the five-point sweep is worth 0.6% -- the two sawtooths are
+in phase, so they cancel out of the ratio whatever is sampled, which is why every same-family
+paired number in this project is sound however it was taken. Against boost, whose bucket counts are
+a different sequence, the same five points land anywhere within **26%** of the answer: `churn64`
+reads 0.742 or 1.023 for one quantity depending only on where the five sizes start. Both fifty-point
+runs made on the day agree to 0.4% on that spread, so it is phase and not noise. **A cross-family
+ratio wants fifty points; a header-against-header one does not.**
+
+The cycle is one octave long only because the array doubles, which is the map's policy and not a
+law. So the harness measures it: before anything is timed it inserts into each map under comparison,
+records every size at which `bucket_count()` changes, prints those sizes and the ratio between them,
+and says whether an octave is one whole turn. A growth factor under two -- which this project's
+notes list as a knob -- would make the geomean over an octave weigh part of the cycle twice, and the
+run now says so where it cannot be missed instead of being quietly wrong.
+
+Fifty points do not make the run ten times longer, because what a point costs was cut where the
+sawtooth needs the points and left alone where it does not. All twenty workloads, twelve epochs,
+clang on a 7950X: **2m21 at five points and 5m34 at fifty**, where the five-point run cost 3m19
+before this change. With `-b`, three alternatives instead of two: 4m51 before, 3m32 and 8m37 now.
+
+| workload | sizes at `-p 50` | why |
+|---|---|---|
+| `it*`, `hashstr` | 1 | no bucket array whose load factor cycles, and iteration is quadratic in the element count |
+| `ie*`, `find*` | 5 | the map grows from empty through every doubling while the workload runs, so the cost is already an integral over the cycle: measured over one octave, `ie64`'s per-element cost moves 1.03x and `find64`'s a monotone 1.10x, neither with a cycle in it |
+| `build*`, `churn*` | 50 | n is the live size and the payload is n operations; both carry the whole sawtooth |
+| `rhit*`, `rmiss*` | 50 | the sharpest sawtooth there is here (1.32x on a miss), and a point costs the same at every size |
+
+The two lookup workloads pay for the other fifty: they search a table built **outside** the timed
+region, a million times rather than ten, which is what makes a point of the sweep cheap without the
+fill being part of the ratio. Their absolute times before and after 2026-09-12 are not comparable,
+**and neither are their ratios against a map that is not this header**: `rhit64` against boost read
+0.798 with the fill inside the timed region and 0.760 without it, `rmissstr` 0.931 and 0.832. Their
+ratios against another revision of this header are unchanged to within 1%, because there both sides
+pay the same fill and it cancels. Nothing scored changed.
+
 `it64`, `itstr`, `itbig` and `hashstr` are measured at one size on purpose. Iteration walks the
 dense value vector, which has no buckets and so no sawtooth to average out, and its cost is
 quadratic in the element count, so sweeping it would triple the run for an answer that does not
@@ -40,7 +110,9 @@ move; `hashstr` never touches a table. The sizes are template parameters rather 
 arguments, so the default instantiation is the same code `bench_quick_overall_udm` has always
 compiled -- turning a literal loop bound into a runtime value would be a change to the scored
 benchmark even at the same value, and its absolute numbers are only comparable across time if its
-workloads do not move.
+workloads do not move. That is also why the point count is a compile-time constant: `-p` rebuilds
+the binary rather than re-running it, which costs 17 seconds of clang at fifty points against four
+at five.
 
 ## Every other map, on the same workloads
 
@@ -558,9 +630,11 @@ because that is the only one of the three with branches to mispredict -- 0.575 p
 0.02 for main and 0.024 for this map, counted with `perf` on one-map binaries.
 
 It is the mistake this project's own notes record having fixed once already in the scored find
-workload, reintroduced in this tool. What makes the scored workloads safe and the sweep not is the
-batch size: `find_all` does 10M lookups per epoch, far past what a predictor can hold, while the
-sweep does 20000. The rngs now live in a `state` beside each map and carry on across epochs and
+workload, reintroduced in this tool. What made the scored workloads safe and the sweep not was the
+batch size: `find_all` did 10M lookups per epoch from one seed, far past what a predictor can hold,
+while the sweep does 20000. `find_all` is a million lookups per epoch since 2026-09-12, so it is no
+longer out of reach by size alone, and its rng moved into the table beside its map -- carrying on
+across epochs, exactly as the sweep's does. The rngs now live in a `state` beside each map and carry on across epochs and
 across sample points. Cross-checked afterwards against one-map-per-binary runs of the same
 workload, the fixed sweep agrees to 3-8% and orders the four maps identically at every point; the
 replayed one did not.

--- a/scripts/ab/ab.cpp
+++ b/scripts/ab/ab.cpp
@@ -21,6 +21,17 @@
 //
 // The charts have summarised per octave since 2026-09-06 for exactly this reason. The score did
 // not, and this is that fix.
+//
+// How many sizes is a compile-time constant (run.sh -p passes -DUDM_AB_POINTS), because the sizes
+// are template arguments. Five averages the sawtooth out; fifty draws it, which is what shows
+// where its peak is and how far from the mean the score's own single size sits. What each point
+// costs is held flat as the count rises: the lookup workloads search a table that was built once,
+// outside the timed region, and the workloads that would otherwise multiply the run by ten -- the
+// two that grow a map from empty while operating on it -- keep the five they need, because a cost
+// that integrates over every doubling has no sawtooth left to sample. Measured at fifty points,
+// per element over one octave: churn64 1.28x cheapest to dearest and rmiss64 1.46x, against 1.02x
+// for insert_erase and a monotone 1.14x for find_50 that climbs with the size and has no step over
+// 1.3% anywhere -- where rmiss64 steps 32% across the single size at which the array doubles.
 #include "base.h"
 
 #include <ankerl/unordered_dense.h>
@@ -30,11 +41,13 @@
 #    include <boost/unordered/unordered_flat_map.hpp>
 #endif
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -70,15 +83,152 @@ auto scalar(workloads::insert_erase_result r) -> size_t {
     return r.erased + r.size;
 }
 
-// Five points from n to just under 2n, evenly spaced in log2 so the octave is sampled uniformly:
-// 2^(k/5), as ten-thousandths. Five is enough to average out the sawtooth and few enough that a
-// run stays minutes rather than an hour; the shape within an octave is the size sweep's job
-// (scripts/ab/sweep.cpp), not the score's.
-constexpr size_t max_points = 5;
-constexpr size_t octave_scale[max_points] = {10000, 11487, 13195, 15157, 17411};
+// How many sizes across one octave, and which of them.
+//
+// A compile-time constant because every size is a template argument, so run.sh -p rebuilds rather
+// than re-runs. The i-th of P points is n * 2^(i/P), which spans exactly one doubling however many
+// are asked for -- whereas a table of five scales with only the first three of them used, which is
+// what this harness did until 2026-09-12, samples three fifths of an octave and calls it one.
+#ifndef UDM_AB_POINTS
+#    define UDM_AB_POINTS 5
+#endif
+constexpr size_t sweep_points = UDM_AB_POINTS;
 
-constexpr auto octave_size(size_t n, size_t i) -> size_t {
-    return n * octave_scale[i] / 10000;
+// 2^(i/P) without <cmath>: std::pow is not constexpr in C++17 and these sizes are template
+// arguments. Newton on x^P = 2 from 1 + 1/P, which converges from above for every P; twenty
+// iterations are far more than sizes rounded to whole elements can tell apart. Truncating rather
+// than rounding is what scripts/ab/maps.cpp's octave_size does, so both harnesses mean the same
+// set of sizes by "the octave from n".
+constexpr auto ipow(double x, size_t n) -> double {
+    auto r = 1.0;
+    for (size_t i = 0; i < n; ++i) {
+        r *= x;
+    }
+    return r;
+}
+
+constexpr auto root_of_two(size_t p) -> double {
+    auto x = 1.0 + 1.0 / static_cast<double>(p);
+    for (size_t i = 0; i < 20; ++i) {
+        auto const xp = ipow(x, p);
+        x -= (xp - 2.0) * x / (static_cast<double>(p) * xp);
+    }
+    return x;
+}
+
+constexpr auto octave_size(size_t n, size_t i, size_t points) -> size_t {
+    return static_cast<size_t>(static_cast<double>(n) * ipow(root_of_two(points), i));
+}
+
+// What a workload's size means, which is what decides how many sizes it is worth measuring at and
+// what the per-point line can say about them.
+enum class kind {
+    // No bucket array whose load factor cycles: iteration walks the dense value vector and the
+    // hash workload has no table at all. One point, and sweeping would only cost time.
+    one_size,
+    // The map grows from empty to about n while the workload operates on it, so the cost is an
+    // integral over every doubling it went through and the load factor it ends at is a small part
+    // of it. The five points these get sample the *size* axis, which still moves the ratio between
+    // two maps: they are not one point. What they do not need is a finer grid, because there is no
+    // cycle under the trend to resolve -- measured at fifty points with this cap lifted,
+    // insert_erase's per-element cost moves 1.02x from the cheapest size of an octave to the
+    // dearest and find_50's 1.14x monotonically, and neither has a single step over 1.3%, where
+    // rmiss64 steps 32% across the one size at which the array doubles. The live size is about
+    // half of n for both, so the point's load factor is not the table's and is not printed.
+    grows,
+    // n is the number of live entries and the payload is n operations: build and churn. Both
+    // carry the whole sawtooth -- churn sits at one load for the entire run, and half of a build
+    // is spent in its last doubling.
+    sized,
+    // n is the number of live entries and the payload is a fixed number of lookups against a
+    // table built outside the timed region. The sawtooth is at its sharpest here -- 1.46x on a
+    // miss, of which 32% is the one step across the doubling -- and a point costs the same at
+    // every size. A hit does not ride it: rhit64's largest step is 2.0% and not at the doubling.
+    searches
+};
+
+constexpr auto points_for(kind k) -> size_t {
+    return k == kind::one_size ? 1 : (k == kind::grows ? (std::min)(sweep_points, size_t{5}) : sweep_points);
+}
+
+// Where a map's bucket array actually grows, asked of the map rather than assumed.
+//
+// One octave is one whole turn of the load-factor sawtooth only because the array doubles. That is
+// the map's policy and not a law: a growth factor under two -- which this file's notes list as a
+// knob -- gives a shorter cycle, and then the geomean over an octave weighs part of that cycle
+// twice and part of it once. So insert distinct keys past the top of the sweep and record every
+// size at which bucket_count() changes. The ratios between those sizes are the period, printed
+// with the run, and anything but two is called out where it cannot be missed.
+//
+// It also gives the load factor of every point for free, which is what says where on the sawtooth
+// a measurement sits -- the thing a single-size number never told anyone.
+struct growth {
+    struct step {
+        size_t at;      // the size at which the array grew
+        size_t buckets; // the bucket count it grew to
+    };
+    std::vector<step> steps;
+};
+
+// Below this the steps are the first few allocations, which no workload here measures.
+constexpr size_t growth_floor = 1000;
+
+template <typename Map>
+auto measure_growth(size_t upto) -> growth {
+    auto g = growth();
+    auto map = Map();
+    auto buckets = map.bucket_count();
+    for (size_t i = 0; map.size() < upto; ++i) {
+        map[workloads::key_for<Map>(i)] = i;
+        if (map.bucket_count() != buckets) {
+            buckets = map.bucket_count();
+            g.steps.push_back({map.size(), buckets});
+        }
+    }
+    return g;
+}
+
+// The load factor of a table holding n entries: n over the bucket count in effect there.
+auto load_factor(growth const& g, size_t n) -> double {
+    auto buckets = size_t{0};
+    for (auto const& s : g.steps) {
+        if (s.at <= n) {
+            buckets = s.buckets;
+        }
+    }
+    return buckets == 0 ? 0.0 : static_cast<double>(n) / static_cast<double>(buckets);
+}
+
+void report_growth(char const* who, growth const& g) {
+    auto lo = 1e9;
+    auto hi = 0.0;
+    auto previous = size_t{0};
+    std::printf("# %-5s grows at", who);
+    for (auto const& s : g.steps) {
+        if (s.at < growth_floor) {
+            continue;
+        }
+        std::printf(" %zu", s.at);
+        // The growth factor is the ratio of the bucket counts, which is what it is by definition;
+        // the ratio of the sizes at which growth happened only equals it while the maximum load
+        // factor is the same on both sides of the step.
+        if (previous != 0) {
+            auto const r = static_cast<double>(s.buckets) / static_cast<double>(previous);
+            lo = (std::min)(lo, r);
+            hi = (std::max)(hi, r);
+        }
+        previous = s.buckets;
+    }
+    if (lo > hi) {
+        std::printf(" (nothing above %zu)\n", growth_floor);
+    } else if (lo > 1.99 && hi < 2.01) {
+        std::printf("   x%.3f -- one octave is exactly one sawtooth\n", (lo + hi) / 2);
+    } else {
+        std::printf("   x%.3f..%.3f -- WARNING: the octave is not one whole sawtooth, so the geomean\n"
+                    "#       over it weighs part of the cycle twice. Sweep a period, not an octave.\n",
+                    lo,
+                    hi);
+    }
 }
 
 // One size point: the ratios are the baseline's time over the other map's, so above 1.00 always
@@ -103,17 +253,25 @@ auto geomean(std::vector<double> const& xs) -> double {
 
 template <template <typename, size_t> class Workload, typename Base, typename Cand, typename Boost, size_t N>
 auto measure_at(char const* name, size_t epochs, bool with_boost) -> point {
-    // Output suppressed: five points times twenty workloads is a hundred nanobench tables, and the
-    // per-point line printed below carries what each of them would have said.
+    // Output suppressed: fifty points times twenty workloads is a thousand nanobench tables, and
+    // the per-point line printed below carries what each of them would have said.
     auto bench = ankerl::nanobench::Bench().title(name).epochs(epochs).performanceCounters(false).output(nullptr);
-    auto base = [] {
-        ankerl::nanobench::doNotOptimizeAway(scalar(Workload<Base, N>::run()));
+    // A workload is an object so that one which holds a table builds it here, once, instead of
+    // inside what nanobench repeats. The others are empty and cost nothing.
+    auto base_w = Workload<Base, N>();
+    auto cand_w = Workload<Cand, N>();
+    auto boost_w = std::optional<Workload<Boost, N>>();
+    if (with_boost) {
+        boost_w.emplace();
+    }
+    auto base = [&] {
+        ankerl::nanobench::doNotOptimizeAway(scalar(base_w.run()));
     };
-    auto cand = [] {
-        ankerl::nanobench::doNotOptimizeAway(scalar(Workload<Cand, N>::run()));
+    auto cand = [&] {
+        ankerl::nanobench::doNotOptimizeAway(scalar(cand_w.run()));
     };
-    auto boost = [] {
-        ankerl::nanobench::doNotOptimizeAway(scalar(Workload<Boost, N>::run()));
+    auto boost = [&] {
+        ankerl::nanobench::doNotOptimizeAway(scalar(boost_w->run()));
     };
     auto const res =
         with_boost ? bench.compare("base", base, "cand", cand, "boost", boost) : bench.compare("base", base, "cand", cand);
@@ -142,7 +300,19 @@ void print_time(double ns) {
     }
 }
 
-void report(char const* name, std::vector<point> const& pts, bool with_boost) {
+// Where n is the number of live entries, what the table's load factor is there. Every other
+// workload holds about half of n and its load is not this one, so it is left off the line.
+auto load_of(kind k, growth const& g, point const& p) -> double {
+    return k == kind::sized || k == kind::searches ? load_factor(g, p.n) : 0.0;
+}
+
+void print_load(double load) {
+    if (load != 0.0) {
+        std::printf(" load %.3f", load);
+    }
+}
+
+void report(char const* name, std::vector<point> const& pts, bool with_boost, kind k, growth const& g) {
     std::printf("%s\n", name);
     auto cand_ratios = std::vector<double>();
     auto boost_ratios = std::vector<double>();
@@ -151,10 +321,13 @@ void report(char const* name, std::vector<point> const& pts, bool with_boost) {
         boost_ratios.push_back(p.boost_ratio);
         // hashstr has no table, so it has no size to report -- it is given a base size of zero.
         if (p.n == 0) {
-            std::printf("  %-11s base ", "no table");
+            std::printf("  %-11s ", "no table");
         } else {
-            std::printf("  n=%-9zu base ", p.n);
+            std::printf("  n=%-9zu", p.n);
+            print_load(load_of(k, g, p));
+            std::printf(" ");
         }
+        std::printf("base ");
         print_time(p.base_ns);
         std::printf("  cand ");
         print_time(p.cand_ns);
@@ -164,42 +337,67 @@ void report(char const* name, std::vector<point> const& pts, bool with_boost) {
         }
         std::printf("\n");
     }
-    auto const g = geomean(cand_ratios);
+    auto const gm = geomean(cand_ratios);
     auto const gb = geomean(boost_ratios);
     if (pts.size() > 1) {
-        std::printf("  octave geomean %.4f", g);
+        std::printf("  octave geomean %.4f", gm);
         if (with_boost) {
             std::printf("   boost/cand %.4f", gb);
         }
         std::printf("   (%zu points, %zu .. %zu)\n", pts.size(), pts.front().n, pts.back().n);
+        // The sawtooth itself, which is what more than a handful of points is for: the dearest
+        // point of the octave over the cheapest, per element where the payload is n operations and
+        // per run where it is a fixed number of lookups. It is a lower bound on the real amplitude
+        // and it rises with the point count, because the peak is a size and not an interval --
+        // fifty points reach load 0.795 of a maximum of 0.800 and five get no closer than 0.763.
+        // The geomean above does not depend on the count that way: an octave is a whole period
+        // whatever its phase.
+        auto const unit = [k](point const& p) {
+            return k == kind::searches ? p.cand_ns : p.cand_ns / static_cast<double>(p.n);
+        };
+        auto const ends = std::minmax_element(pts.begin(), pts.end(), [&](point const& a, point const& b) {
+            return unit(a) < unit(b);
+        });
+        auto const& cheapest = *ends.first;
+        auto const& dearest = *ends.second;
+        std::printf("  sawtooth %.3fx  cheapest n=%zu", unit(dearest) / unit(cheapest), cheapest.n);
+        print_load(load_of(k, g, cheapest));
+        std::printf(", dearest n=%zu", dearest.n);
+        print_load(load_of(k, g, dearest));
+        std::printf("\n");
     }
     // The machine-readable line summarize.py reads. One per workload, whatever the point count, so
     // a swept run and a single-size run are summarised by the same code.
-    std::printf("#ratio %s %.6f %.6f %zu\n\n", name, g, gb, pts.size());
+    std::printf("#ratio %s %.6f %.6f %zu\n\n", name, gm, gb, pts.size());
     std::fflush(stdout);
 }
 
-template <template <typename, size_t> class Workload, size_t BaseN, typename Base, typename Cand, typename Boost, size_t... I>
-void compare_seq(char const* name, size_t epochs, size_t points, bool with_boost, std::index_sequence<I...> /*unused*/) {
+template <template <typename, size_t> class Workload,
+          size_t BaseN,
+          kind K,
+          typename Base,
+          typename Cand,
+          typename Boost,
+          size_t... I>
+void compare_seq(char const* name, size_t epochs, bool with_boost, growth const& g, std::index_sequence<I...> /*unused*/) {
     auto pts = std::vector<point>();
-    // Every point is instantiated, only the wanted ones run: the sizes are template arguments, so
-    // that a workload's default instantiation stays the exact code the scored benchmark compiles.
-    (void)std::initializer_list<int>{
-        (I < points
-             ? (pts.push_back(measure_at<Workload, Base, Cand, Boost, octave_size(BaseN, I)>(name, epochs, with_boost)), 0)
-             : 0)...};
-    report(name, pts, with_boost);
+    // The sizes are template arguments, so that a workload's default instantiation stays the exact
+    // code the scored benchmark compiles.
+    (void)std::initializer_list<int>{(
+        pts.push_back(measure_at<Workload, Base, Cand, Boost, octave_size(BaseN, I, points_for(K))>(name, epochs, with_boost)),
+        0)...};
+    report(name, pts, with_boost, K, g);
 }
 
-template <template <typename, size_t> class Workload, size_t BaseN, typename Base, typename Cand, typename Boost>
-void compare(char const* name, size_t epochs, size_t points, bool with_boost) {
-    compare_seq<Workload, BaseN, Base, Cand, Boost>(
-        name, epochs, points > max_points ? max_points : points, with_boost, std::make_index_sequence<max_points>{});
+template <template <typename, size_t> class Workload, size_t BaseN, kind K, typename Base, typename Cand, typename Boost>
+void compare(char const* name, size_t epochs, bool with_boost, growth const& g) {
+    compare_seq<Workload, BaseN, K, Base, Cand, Boost>(name, epochs, with_boost, g, std::make_index_sequence<points_for(K)>{});
 }
 
 // The workloads as templates with a map and a size, so that compare() can name them and sweep them.
 // Each is instantiated once per octave point; the default size never appears here, it belongs to
-// the scored benchmark.
+// the scored benchmark. run() is not static because the lookup workloads carry the table they
+// search, which is built when the object is.
 template <typename Map, size_t N>
 struct iterate {
     static auto run() {
@@ -237,16 +435,20 @@ struct hash_strings {
         return workloads::hash_strings<Map>();
     }
 };
+// The table is a runtime size rather than a template argument: nothing in the timed loop depends
+// on it, so making it one would generate fifty copies of identical code per map type.
 template <typename Map, size_t N>
 struct find_hits {
-    static auto run() {
-        return workloads::find_all<Map, true, N>();
+    workloads::lookup_table<Map> table{N};
+    auto run() {
+        return workloads::find_all<true>(&table);
     }
 };
 template <typename Map, size_t N>
 struct find_misses {
-    static auto run() {
-        return workloads::find_all<Map, false, N>();
+    workloads::lookup_table<Map> table{N};
+    auto run() {
+        return workloads::find_all<false>(&table);
     }
 };
 
@@ -254,24 +456,29 @@ struct find_misses {
 
 auto main(int argc, char** argv) -> int {
     if (argc < 2) {
-        std::printf("usage: %s <workload|all> [epochs=12] [boost=0] [points=5]\n"
+        std::printf("usage: %s <workload|all> [epochs=12] [boost=0]\n"
                     "workloads: it64 ie64 build64 churn64 find64 itstr iestr buildstr churnstr findstr\n"
                     "           itbig iebig buildbig churnbig findbig (64 byte mapped value)\n"
                     "           (bench_quick_overall_udm)\n"
                     "           rhit64 rmiss64 rhitstr rmissstr (all hits / no hits)\n"
                     "           hashstr (the string hash on its own)\n"
-                    "\npoints is how many sizes across one octave each workload is measured at, and\n"
-                    "what is reported is the geometric mean of those ratios. 1 restores the single\n"
+                    "\nThis binary sweeps %zu sizes across one octave and reports the geometric mean\n"
+                    "of those ratios. The count is a compile-time constant because the sizes are\n"
+                    "template arguments: rebuild with run.sh -p to change it. 1 restores the single\n"
                     "size the score used before 2026-09-07, which is only comparable with itself.\n",
-                    argv[0]);
+                    argv[0],
+                    sweep_points);
         return 1;
     }
     std::string w = argv[1];
     auto epochs = static_cast<size_t>(argc > 2 ? std::atoi(argv[2]) : 12);
     bool boost = argc > 3 && std::atoi(argv[3]) != 0;
-    auto points = static_cast<size_t>(argc > 4 ? std::atoi(argv[4]) : static_cast<int>(max_points));
-    if (points < 1) {
-        points = 1;
+    if (argc > 4) {
+        std::printf("this binary was built for %zu points -- the count is a compile-time constant now,\n"
+                    "rebuild with run.sh -p %s\n",
+                    sweep_points,
+                    argv[4]);
+        return 1;
     }
 #ifndef UDM_AB_HAVE_BOOST
     if (boost) {
@@ -282,41 +489,60 @@ auto main(int argc, char** argv) -> int {
     auto want = [&](char const* n) {
         return w == "all" || w == n;
     };
-    // The base size of each workload is the one the scored benchmark uses, and the octave runs from
-    // there to just under twice it.
+    // The probe below allocates and frees a map of the largest size in the run, so it goes through
+    // the same allocator settings every workload uses -- otherwise it is the one thing that runs
+    // before the first tame_allocator() and it would hand the first workload a heap no other run
+    // of this harness had.
+    workloads::tame_allocator();
+    // Where every map in the run grows, measured before anything is timed. It is what the load
+    // factor on each point line is computed from, and it is the check that an octave is one whole
+    // turn of the sawtooth rather than an assumption about the growth factor. The integer map
+    // answers for all three value types: the bucket array grows on a count, not on a size.
     //
-    // Iteration and the hash workload are measured at one point on purpose. Iteration walks the
-    // dense value vector, which has no buckets and so no sawtooth to average out, and its cost is
-    // quadratic in the element count -- sweeping an octave would make it three times the run for an
-    // answer that does not change. hashstr never touches a table at all.
-#define U64(name, workload, base_n, pts) \
-    if (want(name))                      \
-    compare<workload, base_n, base_u64, cand_u64, boost_u64>(name, epochs, (pts), boost)
-#define STR(name, workload, base_n, pts) \
-    if (want(name))                      \
-    compare<workload, base_n, base_str, cand_str, boost_str>(name, epochs, (pts), boost)
-#define BIG(name, workload, base_n, pts) \
-    if (want(name))                      \
-    compare<workload, base_n, base_big, cand_big, boost_big>(name, epochs, (pts), boost)
-    U64("it64", iterate, 5000, 1);
-    U64("ie64", insert_erase, 20000, points);
-    U64("build64", build, 200000, points);
-    U64("churn64", churn, 50000, points);
-    U64("find64", find_50, 100000, points);
-    STR("itstr", iterate, 5000, 1);
-    STR("iestr", insert_erase, 20000, points);
-    STR("buildstr", build, 200000, points);
-    STR("churnstr", churn, 50000, points);
-    STR("findstr", find_50, 100000, points);
-    BIG("itbig", iterate, 5000, 1);
-    BIG("iebig", insert_erase, 20000, points);
-    BIG("buildbig", build, 200000, points);
-    BIG("churnbig", churn, 50000, points);
-    BIG("findbig", find_50, 100000, points);
-    U64("rhit64", find_hits, 50000, points);
-    U64("rmiss64", find_misses, 50000, points);
-    STR("rhitstr", find_hits, 50000, points);
-    STR("rmissstr", find_misses, 50000, points);
-    STR("hashstr", hash_strings, 0, 1);
+    // The largest size any workload reaches: the builds start at 200000, which is the highest base
+    // here, and the top of an octave is just under twice its bottom.
+    constexpr auto largest = octave_size(200000, points_for(kind::sized) - 1, points_for(kind::sized));
+    auto const g = measure_growth<cand_u64>(largest);
+    report_growth("cand", g);
+    report_growth("base", measure_growth<base_u64>(largest));
+#ifdef UDM_AB_HAVE_BOOST
+    if (boost) {
+        report_growth("boost", measure_growth<boost_u64>(largest));
+    }
+#endif
+    std::printf("\n");
+    std::fflush(stdout);
+    // The base size of each workload is the one the scored benchmark uses, and the octave runs from
+    // there to just under twice it. What each workload's size means -- and so how many points it is
+    // worth measuring at -- is the `kind` argument; see the enum.
+#define U64(name, workload, base_n, k) \
+    if (want(name))                    \
+    compare<workload, base_n, k, base_u64, cand_u64, boost_u64>(name, epochs, boost, g)
+#define STR(name, workload, base_n, k) \
+    if (want(name))                    \
+    compare<workload, base_n, k, base_str, cand_str, boost_str>(name, epochs, boost, g)
+#define BIG(name, workload, base_n, k) \
+    if (want(name))                    \
+    compare<workload, base_n, k, base_big, cand_big, boost_big>(name, epochs, boost, g)
+    U64("it64", iterate, 5000, kind::one_size);
+    U64("ie64", insert_erase, 20000, kind::grows);
+    U64("build64", build, 200000, kind::sized);
+    U64("churn64", churn, 50000, kind::sized);
+    U64("find64", find_50, 100000, kind::grows);
+    STR("itstr", iterate, 5000, kind::one_size);
+    STR("iestr", insert_erase, 20000, kind::grows);
+    STR("buildstr", build, 200000, kind::sized);
+    STR("churnstr", churn, 50000, kind::sized);
+    STR("findstr", find_50, 100000, kind::grows);
+    BIG("itbig", iterate, 5000, kind::one_size);
+    BIG("iebig", insert_erase, 20000, kind::grows);
+    BIG("buildbig", build, 200000, kind::sized);
+    BIG("churnbig", churn, 50000, kind::sized);
+    BIG("findbig", find_50, 100000, kind::grows);
+    U64("rhit64", find_hits, 50000, kind::searches);
+    U64("rmiss64", find_misses, 50000, kind::searches);
+    STR("rhitstr", find_hits, 50000, kind::searches);
+    STR("rmissstr", find_misses, 50000, kind::searches);
+    STR("hashstr", hash_strings, 0, kind::one_size);
     return 0;
 }

--- a/scripts/ab/run.sh
+++ b/scripts/ab/run.sh
@@ -11,7 +11,13 @@
 #                reported, because a table's load factor sweeps a sawtooth between doublings and
 #                two indexes double at different sizes -- so one fixed size measures wherever that
 #                size happens to land on each. `-p 1` is the single size the score used before
-#                2026-09-07; it runs five times faster and is only comparable with itself.
+#                2026-09-07; it runs five times faster and is only comparable with itself. `-p 50`
+#                draws the sawtooth instead of averaging it out: 5m34 against the default's 2m21
+#                here, where a tenfold count would have been 20 minutes. The two workloads that
+#                grow a map from empty keep five points, having no sawtooth left to sample, and
+#                the two lookup workloads search a table built once outside the timed region. The
+#                sizes are template arguments, so -p rebuilds the binary: 17s of clang at fifty
+#                points against 4s at five.
 #
 # Uses the vendored nanobench (test/third-party, >= 4.6 for Bench::compare()); NANOBENCH_INCLUDE
 # overrides it. The workloads come from test/bench/workloads.h, the benchmark's own. Everything is built in $AB_BUILD (default: a temporary directory), the tree is not
@@ -50,11 +56,11 @@ esac
 git -C "$root" show "$rev:include/ankerl/unordered_dense.h" \
     | sed 's/ankerl::unordered_dense/udmbase::unordered_dense/g; s/ANKERL_UNORDERED_DENSE/UDMBASE_UNORDERED_DENSE/g; s/namespace ankerl/namespace udmbase/g; s|#        include "stl.h"|#        include <ankerl/stl.h>|' \
     > "$build/base.h"
-flags=(-O3 -DNDEBUG -std=c++17 -I"$build" -I"$root/include" -I"$root/test")
+flags=(-O3 -DNDEBUG -std=c++17 "-DUDM_AB_POINTS=$points" -I"$build" -I"$root/include" -I"$root/test")
 # shellcheck disable=SC2206 -- word splitting is what makes AB_EXTRA_FLAGS able to carry several
 flags+=(${AB_EXTRA_FLAGS:-})
 [ $boost = 1 ] && flags+=(-DUDM_AB_HAVE_BOOST)
 [ -f "$build/nanobench_$cxx.o" ] || (cd "$build" && printf '#define ANKERL_NANOBENCH_IMPLEMENT\n#include <third-party/nanobench.h>\n' > nb.cpp && "$cxx" "${flags[@]}" -c nb.cpp -o "nanobench_$cxx.o")
 "$cxx" "${flags[@]}" "$root/scripts/ab/ab.cpp" "$build/nanobench_$cxx.o" -o "$build/$exe"
 echo "baseline $rev vs working tree, $cxx, in $build" >&2
-"$build/$exe" "$1" "${2:-12}" "$boost" "$points"
+"$build/$exe" "$1" "${2:-12}" "$boost"

--- a/scripts/ab/summarize.py
+++ b/scripts/ab/summarize.py
@@ -113,7 +113,9 @@ def main():
         lo, hi = min(swept), max(swept)
         span = str(lo) if lo == hi else f"{lo}-{hi}"
         print(f"_Each ratio is the geometric mean over {span} sizes spanning one octave. Iteration and "
-              "hashstr are measured at one size: neither has a bucket array whose load factor sweeps._")
+              "hashstr are measured at one size: neither has a bucket array whose load factor sweeps. "
+              "`ie*` and `find*` grow a map from empty through every doubling, which averages the "
+              "sawtooth out already, so they keep five sizes however many the rest are given._")
     else:
         print("_One size per workload, so each ratio is a single point on each map's load-factor "
               "sawtooth and is comparable only with other single-size runs._")

--- a/test/bench/quick_overall_map.cpp
+++ b/test/bench/quick_overall_map.cpp
@@ -144,17 +144,21 @@ TEST_CASE("bench_find_all_hits_or_misses_udm" * doctest::test_suite("bench") * d
     bench.title("find").minEpochTime(100ms);
     using map_t = ankerl::unordered_dense::map<uint64_t, size_t>;
     using map_str_t = ankerl::unordered_dense::map<std::string, size_t, hash_str_t>;
-    bench.run("map<uint64_t, size_t> all hits", [] {
-        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_t, true>());
+    // The tables are built here and searched below, so what is timed is the lookups and not a
+    // fill; see workloads::lookup_table.
+    auto ints = workloads::lookup_table<map_t>();
+    auto strings = workloads::lookup_table<map_str_t>();
+    bench.run("map<uint64_t, size_t> all hits", [&] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<true>(&ints));
     });
-    bench.run("map<uint64_t, size_t> no hits", [] {
-        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_t, false>());
+    bench.run("map<uint64_t, size_t> no hits", [&] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<false>(&ints));
     });
-    bench.run("map<std::string, size_t> all hits", [] {
-        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_str_t, true>());
+    bench.run("map<std::string, size_t> all hits", [&] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<true>(&strings));
     });
-    bench.run("map<std::string, size_t> no hits", [] {
-        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<map_str_t, false>());
+    bench.run("map<std::string, size_t> no hits", [&] {
+        ankerl::nanobench::doNotOptimizeAway(workloads::find_all<false>(&strings));
     });
 }
 

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -183,10 +183,14 @@ struct insert_erase_result {
 // Random insert & erase, ~10k entries live.
 //
 // Range is the size knob: a template parameter, not a function argument, so that the default
-// instantiation is the same code it has always been. That matters -- the scored benchmark's
-// absolute numbers are only comparable across time if its workloads do not change, and turning a
-// literal loop bound into a runtime value is a change even when the value is the same. The A/B
-// harness instantiates other sizes to average a ratio over a whole doubling; see scripts/ab.
+// instantiation is the same code it has always been. That matters for the scored benchmark, whose
+// absolute numbers are only comparable across time if its workloads do not change -- editing a
+// literal the score compiles is editing the score. It is *not* measurable in what the code costs:
+// putting every size behind an `asm volatile("" : "+r"(v))`, which is what a function argument
+// would do to the compiler's knowledge of it, moves the five workloads that have one by 0.959x to
+// 1.014x, against 0.998x and 0.986x for two workloads whose code the change cannot reach. See
+// "The sizes are template arguments" in notes/index-design.md. The A/B harness instantiates other
+// sizes to average a ratio over a whole doubling; see scripts/ab.
 template <typename Map, size_t Range = 20000>
 auto insert_erase() -> insert_erase_result {
     tame_allocator();

--- a/test/bench/workloads.h
+++ b/test/bench/workloads.h
@@ -16,6 +16,7 @@
 #include <cstring>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace workloads {
@@ -123,6 +124,10 @@ struct key_source<std::string> {
         return key;
     }
 };
+
+// The top bit, kept out of every key a workload inserts so that setting it names a key that cannot
+// be there. Three workloads look for one.
+inline constexpr auto never_inserted = uint64_t{1} << 63U;
 
 template <typename Map>
 [[nodiscard]] auto key_for(uint64_t v) -> decltype(auto) {
@@ -234,7 +239,6 @@ auto find_50() -> size_t {
     tame_allocator();
     ankerl::nanobench::Rng insert_rng(123123);
     ankerl::nanobench::Rng search_rng(987654321);
-    constexpr auto never_inserted = uint64_t{1} << 63U;
 
     std::vector<uint64_t> inserted;
     inserted.reserve(Steps);
@@ -263,32 +267,64 @@ auto find_50() -> size_t {
     return checksum;
 }
 
-// 50k entries, then 10M lookups that all hit (a random key that is there) or all miss (one that
-// cannot be): the two ends of what a workload's hit rate can do to the probe.
-template <typename Map, bool Hits, size_t NumElements = 50000>
-auto find_all() -> size_t {
-    tame_allocator();
-    ankerl::nanobench::Rng rng(999);
-    constexpr auto never_inserted = uint64_t{1} << 63U;
-    Map map;
-    std::vector<uint64_t> keys;
-    keys.reserve(NumElements);
-    while (map.size() < NumElements) {
-        auto v = rng() & ~never_inserted;
-        if (map.emplace(key_for<Map>(v), keys.size()).second) {
-            keys.push_back(v);
+// A table of a fixed size and the keys that are in it, for the lookup-only workloads.
+//
+// Built apart from the loop that searches it because these two are the A/B harness's workloads
+// and not the score's, and a point of its size sweep must not pay for a fill: the lookups are a
+// million now rather than ten, so a fill of fifty thousand entries left inside the timed region
+// would be a tenth of what is measured and a tenth of every ratio would be the insert path. It is
+// also what the file's own rule asks for -- warm the subject, then measure it -- where rebuilding
+// it every round measures the allocator.
+//
+// The rng is part of the table, so successive timed runs carry on drawing fresh keys instead of
+// replaying one sequence from a seed, which a branch predictor learns.
+template <typename Map>
+struct lookup_table {
+    Map map{};
+    std::vector<uint64_t> keys{};
+    ankerl::nanobench::Rng rng{999};
+
+    explicit lookup_table(size_t num_elements = 50000) {
+        tame_allocator();
+        keys.reserve(num_elements);
+        while (map.size() < num_elements) {
+            auto const v = rng() & ~never_inserted;
+            if (map.emplace(key_for<Map>(v), keys.size()).second) {
+                keys.push_back(v);
+            }
         }
     }
+};
+
+// 50k entries, then a million lookups that all hit (a random key that is there) or all miss (one
+// that cannot be): the two ends of what a workload's hit rate can do to the probe.
+//
+// The rng is drawn into a local and written back at the end, the keys are read through their own
+// pointer, and the end iterator is taken once. Left in the table, the rng's state update is a store
+// the compiler must assume can alias the map's members -- reached through the same pointer -- and it
+// reloads them on every lookup: 6.28 ns against 6.05 for the same million hits, which is the whole
+// of the difference between this loop and the one that built its own table inside the timed region.
+// It is the aliasing the notes record for the value walks, in a new place. The string workloads
+// still pay some of it inside find() itself, because making a string key memcpy's into a shared
+// buffer and a char store may alias anything.
+template <bool Hits, typename Map>
+auto find_all(lookup_table<Map>* t) -> size_t {
+    constexpr size_t lookups = 1000000;
+    auto rng = t->rng.copy();
+    auto const* keys = t->keys.data();
+    auto const num_keys = t->keys.size();
+    auto const& map = t->map;
+    auto const end = map.end();
     size_t checksum = 0;
-    auto const num_keys = keys.size();
-    for (size_t i = 0; i < 10000000; ++i) {
-        auto r = rng();
+    for (size_t i = 0; i < lookups; ++i) {
+        auto const r = rng();
         auto const& key = key_for<Map>(Hits ? keys[((r >> 32U) * num_keys) >> 32U] : (r | never_inserted));
         auto it = map.find(key);
-        if (it != map.end()) {
+        if (it != end) {
             checksum += it->second;
         }
     }
+    t->rng = std::move(rng);
     return checksum;
 }
 
@@ -351,7 +387,6 @@ auto churn() -> size_t {
     tame_allocator();
     constexpr size_t num_elements = NumElements;
     constexpr size_t num_rounds = 4;
-    constexpr auto never_inserted = uint64_t{1} << 63U;
 
     ankerl::nanobench::Rng rng(31337);
     Map map;


### PR DESCRIPTION
Closes #274. **The harness changes, the map does not** — `include/` is untouched, so no number here says the map got faster. They say what the harness could and could not see.

## The number

Five points across an octave never land on the peak of the load-factor sawtooth — they get no nearer than load 0.763 of a maximum of 0.800 — and they read half the amplitude fifty points read. Amplitude = the dearest sampled size over the cheapest within one octave, same header on both sides:

| | 5 points | 50 points |
|---|---|---|
| `rmiss64` | 1.286x | **1.458x** |
| `churn64` | 1.142x | **1.284x** |
| `churnbig` | 1.148x | 1.247x |
| `rhit64` | 1.115x | 1.168x |
| `churnstr` | 1.055x | 1.120x |

What that costs a **ratio**, measured by taking one fifty-point run apart into the ten five-point sweeps inside it (every tenth point, each spanning the whole octave) and comparing each sweep's geomean with the fifty-point one:

| | `base/cand`, same header twice | `boost/cand` |
|---|---|---|
| `churn64` | 0.999 .. 1.005 | **0.742 .. 1.023** |
| `churnbig` | 0.995 .. 1.002 | 0.787 .. 1.069 |
| `rmiss64` | 0.989 .. 0.996 | 0.833 .. 1.010 |
| `rhit64` | 0.974 .. 0.980 | 0.753 .. 0.776 |

**Five points are worth 0.6% against another revision of this header** — the two sawtooths are in phase and cancel out of the ratio — **and 26% against a map that doubles at different sizes.** Two fifty-point runs made the same day agree on that spread to 0.4%, so it is the phase and not the noise.

Against boost at fifty sizes (boost's time over this map's, above 1.00 meaning this map is faster): `build64` 1.526, `buildstr` 2.054, `buildbig` 1.716, `churn64` 0.810, `churnstr` 0.898, `rhit64` 0.762, `rmiss64` 0.888. The one that moves with the point count is `buildbig`, 1.986 at five sizes, because its octave contains a 5.9x step where 17 MB of values stop fitting in L3 and five sizes put two points below it.

## What changed

- **`-p N` now means N sizes across an octave.** It used the first N of a five-entry scale table, so `-p 3` swept from n to 1.32n and called it an octave. The count is a compile-time constant (`-p` rebuilds; the sizes are template arguments, 17s of clang at fifty against 4s at five) and the i-th of P points is `n * 2^(i/P)` for any P.
- **The growth is measured, not assumed.** Before anything is timed the harness inserts into each map and records every size at which `bucket_count()` changes, prints those and the factor between them, and warns if it is not two — only a doubling makes an octave one whole turn of the cycle. Every point line carries its load factor, and each workload prints its cheapest and dearest point.
- **The run does not get ten times longer**: 2m21 at five points and 5m34 at fifty, where the five-point run cost 3m19 before. The lookup workloads search a table built *outside* the timed region, a million times rather than ten million. The two workloads that grow a map from empty keep five points: measured at fifty, `ie64` moves 1.02x and `find64` 1.14x across an octave with no step over 1.3%, where `rmiss64` steps 32% in one.
- Taking that fill out moves what `rhit*`/`rmiss*` report **against boost**: `rhit64` 0.798 before and 0.760 now, `rmissstr` 0.931 and 0.832. This map's own per-lookup cost is unchanged (6.05 ns per hit before, 6.00–6.10 after), so the move is on boost's side of the ratio; against another revision of this header the ratios did not move, because there the fill is the same code on both sides.
- Two traps found on the way, both of them rules this repo already records: passing the table to the lookup loop by pointer cost 6.28 ns per hit against 6.05, because the rng's state update may alias the map's members; and the control for those four workloads reads 0.976 in one build and 1.000 in another, with `-falign-functions=32` moving 0.976 to 0.997 — the ±3% layout band, visible now that the timed region is one tight loop.

`bench_quick_overall_udm` is untouched: every knob added is a template parameter whose default is what it was.

Evidence in `notes/index-design.md` under "Fifty points draw the load-factor sawtooth that five average out".

## Checks

835 tests pass under clang and gcc and under ASan+UBSan; 32-bit and `-fno-exceptions` syntax legs pass for both compilers on the changed test files; four of five linters pass (clang-tidy cannot run on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)