### PR TITLE
Give the README charts presentation attributes, not only a stylesheet

### DIFF
--- a/doc/bench-readme-str.svg
+++ b/doc/bench-readme-str.svg
@@ -16,248 +16,248 @@
       .f-flat{fill:#5b9bf0}.f-dense{fill:#3cc492}.f-node{fill:#e070cd}
     }
   </style>
-  <rect class="surface" width="1030" height="382"/>
-  <text x="8" y="20" class="hd">relative to unordered_dense 5.0, std::string keys, every map in its default configuration</text>
-  <text x="8" y="38" class="sub">geometric mean over one octave from 1,000,000 entries; lower is better, and 1.00 is level with unordered_dense 5.0. Rows are sorted by the geomean of all five panels; a bar torn off at the right ran past the axis.</text>
-  <text x="192" y="56" class="t" font-weight="600">build + destroy</text>
-  <line x1="192.0" y1="74" x2="192.0" y2="324" class="ax"/>
-  <text x="192.0" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="221.2" y1="74" x2="221.2" y2="324" class="ax"/>
-  <text x="221.2" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="250.5" y1="74" x2="250.5" y2="324" class="ax"/>
-  <text x="250.5" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="279.8" y1="74" x2="279.8" y2="324" class="ax"/>
-  <text x="279.8" y="72" class="m" text-anchor="middle">3</text>
-  <line x1="309.0" y1="74" x2="309.0" y2="324" class="ax"/>
-  <text x="309.0" y="72" class="m" text-anchor="middle">4</text>
-  <line x1="221.2" y1="74" x2="221.2" y2="324" class="ref"/>
-  <line x1="192.0" y1="74" x2="192.0" y2="324" class="base"/>
+  <rect class="surface" fill="#ffffff" width="1030" height="382"/>
+  <text x="8" y="20" class="hd" fill="#111827">relative to unordered_dense 5.0, std::string keys, every map in its default configuration</text>
+  <text x="8" y="38" class="sub" fill="#4b5563">geometric mean over one octave from 1,000,000 entries; lower is better, and 1.00 is level with unordered_dense 5.0. Rows are sorted by the geomean of all five panels; a bar torn off at the right ran past the axis.</text>
+  <text x="192" y="56" class="t" fill="#1f2937" font-weight="600">build + destroy</text>
+  <line x1="192.0" y1="74" x2="192.0" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="192.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="221.2" y1="74" x2="221.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="221.2" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="250.5" y1="74" x2="250.5" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="250.5" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="279.8" y1="74" x2="279.8" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="279.8" y="72" class="m" fill="#4b5563" text-anchor="middle">3</text>
+  <line x1="309.0" y1="74" x2="309.0" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="309.0" y="72" class="m" fill="#4b5563" text-anchor="middle">4</text>
+  <line x1="221.2" y1="74" x2="221.2" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="192.0" y1="74" x2="192.0" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M192.0,88.0 L218.8,88.0 Q221.2,88.0 221.2,90.5 L221.2,97.5 Q221.2,100.0 218.8,100.0 L192.0,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="227.2" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="227.2" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M192.0,105.0 L226.2,105.0 Q228.7,105.0 228.7,107.5 L228.7,114.5 Q228.7,117.0 226.2,117.0 L192.0,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="234.7" y="113" class="m" text-anchor="start">1.26</text>
+  <text x="234.7" y="113" class="m" fill="#4b5563" text-anchor="start">1.26</text>
   <path d="M192.0,122.0 L238.3,122.0 Q240.8,122.0 240.8,124.5 L240.8,131.5 Q240.8,134.0 238.3,134.0 L192.0,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="246.8" y="130" class="m" text-anchor="start">1.67</text>
+  <text x="246.8" y="130" class="m" fill="#4b5563" text-anchor="start">1.67</text>
   <path d="M192.0,139.0 L257.9,139.0 Q260.4,139.0 260.4,141.5 L260.4,148.5 Q260.4,151.0 257.9,151.0 L192.0,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="266.4" y="147" class="m" text-anchor="start">2.34</text>
+  <text x="266.4" y="147" class="m" fill="#4b5563" text-anchor="start">2.34</text>
   <path d="M192.0,156.0 L251.6,156.0 Q254.1,156.0 254.1,158.5 L254.1,165.5 Q254.1,168.0 251.6,168.0 L192.0,168.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="260.1" y="164" class="m" text-anchor="start">2.12</text>
+  <text x="260.1" y="164" class="m" fill="#4b5563" text-anchor="start">2.12</text>
   <path d="M192.0,173.0 L261.0,173.0 Q263.5,173.0 263.5,175.5 L263.5,182.5 Q263.5,185.0 261.0,185.0 L192.0,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="269.5" y="181" class="m" text-anchor="start">2.45</text>
+  <text x="269.5" y="181" class="m" fill="#4b5563" text-anchor="start">2.45</text>
   <path d="M192.0,190.0 L250.0,190.0 Q252.5,190.0 252.5,192.5 L252.5,199.5 Q252.5,202.0 250.0,202.0 L192.0,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="258.5" y="198" class="m" text-anchor="start">2.07</text>
+  <text x="258.5" y="198" class="m" fill="#4b5563" text-anchor="start">2.07</text>
   <path d="M192.0,207.0 L258.2,207.0 Q260.7,207.0 260.7,209.5 L260.7,216.5 Q260.7,219.0 258.2,219.0 L192.0,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="266.7" y="215" class="m" text-anchor="start">2.35</text>
+  <text x="266.7" y="215" class="m" fill="#4b5563" text-anchor="start">2.35</text>
   <path d="M192.0,224.0 L261.5,224.0 Q264.0,224.0 264.0,226.5 L264.0,233.5 Q264.0,236.0 261.5,236.0 L192.0,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="270.0" y="232" class="m" text-anchor="start">2.46</text>
+  <text x="270.0" y="232" class="m" fill="#4b5563" text-anchor="start">2.46</text>
   <path d="M192.0,241.0 L264.2,241.0 Q266.7,241.0 266.7,243.5 L266.7,250.5 Q266.7,253.0 264.2,253.0 L192.0,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="272.7" y="249" class="m" text-anchor="start">2.56</text>
+  <text x="272.7" y="249" class="m" fill="#4b5563" text-anchor="start">2.56</text>
   <path d="M192.0,258.0 L262.8,258.0 Q265.3,258.0 265.3,260.5 L265.3,267.5 Q265.3,270.0 262.8,270.0 L192.0,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="271.3" y="266" class="m" text-anchor="start">2.51</text>
+  <text x="271.3" y="266" class="m" fill="#4b5563" text-anchor="start">2.51</text>
   <path d="M192.0,275.0 L255.7,275.0 Q258.2,275.0 258.2,277.5 L258.2,284.5 Q258.2,287.0 255.7,287.0 L192.0,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="264.2" y="283" class="m" text-anchor="start">2.26</text>
+  <text x="264.2" y="283" class="m" fill="#4b5563" text-anchor="start">2.26</text>
   <path d="M192.0,292.0 L279.6,292.0 Q282.1,292.0 282.1,294.5 L282.1,301.5 Q282.1,304.0 279.6,304.0 L192.0,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="288.1" y="300" class="m" text-anchor="start">3.08</text>
+  <text x="288.1" y="300" class="m" fill="#4b5563" text-anchor="start">3.08</text>
   <path d="M192.0,309.0 L295.8,309.0 Q298.3,309.0 298.3,311.5 L298.3,318.5 Q298.3,321.0 295.8,321.0 L192.0,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="304.3" y="317" class="m" text-anchor="start">3.64</text>
-  <text x="360" y="56" class="t" font-weight="600">find, 50% hits</text>
-  <line x1="359.6" y1="74" x2="359.6" y2="324" class="ax"/>
-  <text x="359.6" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="388.9" y1="74" x2="388.9" y2="324" class="ax"/>
-  <text x="388.9" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="418.1" y1="74" x2="418.1" y2="324" class="ax"/>
-  <text x="418.1" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="447.4" y1="74" x2="447.4" y2="324" class="ax"/>
-  <text x="447.4" y="72" class="m" text-anchor="middle">1.5</text>
-  <line x1="476.6" y1="74" x2="476.6" y2="324" class="ax"/>
-  <text x="476.6" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="418.1" y1="74" x2="418.1" y2="324" class="ref"/>
-  <line x1="359.6" y1="74" x2="359.6" y2="324" class="base"/>
+  <text x="304.3" y="317" class="m" fill="#4b5563" text-anchor="start">3.64</text>
+  <text x="360" y="56" class="t" fill="#1f2937" font-weight="600">find, 50% hits</text>
+  <line x1="359.6" y1="74" x2="359.6" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="359.6" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="388.9" y1="74" x2="388.9" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="388.9" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="418.1" y1="74" x2="418.1" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="418.1" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="447.4" y1="74" x2="447.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="447.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1.5</text>
+  <line x1="476.6" y1="74" x2="476.6" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="476.6" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="418.1" y1="74" x2="418.1" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="359.6" y1="74" x2="359.6" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M359.6,88.0 L415.6,88.0 Q418.1,88.0 418.1,90.5 L418.1,97.5 Q418.1,100.0 415.6,100.0 L359.6,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="424.1" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="424.1" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M359.6,105.0 L423.3,105.0 Q425.8,105.0 425.8,107.5 L425.8,114.5 Q425.8,117.0 423.3,117.0 L359.6,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="431.8" y="113" class="m" text-anchor="start">1.13</text>
+  <text x="431.8" y="113" class="m" fill="#4b5563" text-anchor="start">1.13</text>
   <path d="M359.6,122.0 L416.7,122.0 Q419.2,122.0 419.2,124.5 L419.2,131.5 Q419.2,134.0 416.7,134.0 L359.6,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="425.2" y="130" class="m" text-anchor="start">1.02</text>
+  <text x="425.2" y="130" class="m" fill="#4b5563" text-anchor="start">1.02</text>
   <path d="M359.6,139.0 L438.1,139.0 Q440.6,139.0 440.6,141.5 L440.6,148.5 Q440.6,151.0 438.1,151.0 L359.6,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="446.6" y="147" class="m" text-anchor="start">1.38</text>
+  <text x="446.6" y="147" class="m" fill="#4b5563" text-anchor="start">1.38</text>
   <path d="M359.6,156.0 L413.9,156.0 Q416.4,156.0 416.4,158.5 L416.4,165.5 Q416.4,168.0 413.9,168.0 L359.6,168.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="422.4" y="164" class="m" text-anchor="start">0.97</text>
+  <text x="422.4" y="164" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M359.6,173.0 L410.5,173.0 Q413.0,173.0 413.0,175.5 L413.0,182.5 Q413.0,185.0 410.5,185.0 L359.6,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="419.0" y="181" class="m" text-anchor="start">0.91</text>
+  <text x="419.0" y="181" class="m" fill="#4b5563" text-anchor="start">0.91</text>
   <path d="M359.6,190.0 L413.5,190.0 Q416.0,190.0 416.0,192.5 L416.0,199.5 Q416.0,202.0 413.5,202.0 L359.6,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="422.0" y="198" class="m" text-anchor="start">0.96</text>
+  <text x="422.0" y="198" class="m" fill="#4b5563" text-anchor="start">0.96</text>
   <path d="M359.6,207.0 L424.5,207.0 Q427.0,207.0 427.0,209.5 L427.0,216.5 Q427.0,219.0 424.5,219.0 L359.6,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="433.0" y="215" class="m" text-anchor="start">1.15</text>
+  <text x="433.0" y="215" class="m" fill="#4b5563" text-anchor="start">1.15</text>
   <path d="M359.6,224.0 L417.4,224.0 Q419.9,224.0 419.9,226.5 L419.9,233.5 Q419.9,236.0 417.4,236.0 L359.6,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="425.9" y="232" class="m" text-anchor="start">1.03</text>
+  <text x="425.9" y="232" class="m" fill="#4b5563" text-anchor="start">1.03</text>
   <path d="M359.6,241.0 L435.4,241.0 Q437.9,241.0 437.9,243.5 L437.9,250.5 Q437.9,253.0 435.4,253.0 L359.6,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="443.9" y="249" class="m" text-anchor="start">1.34</text>
+  <text x="443.9" y="249" class="m" fill="#4b5563" text-anchor="start">1.34</text>
   <path d="M359.6,258.0 L413.2,258.0 Q415.7,258.0 415.7,260.5 L415.7,267.5 Q415.7,270.0 413.2,270.0 L359.6,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="421.7" y="266" class="m" text-anchor="start">0.96</text>
+  <text x="421.7" y="266" class="m" fill="#4b5563" text-anchor="start">0.96</text>
   <path d="M359.6,275.0 L413.8,275.0 Q416.3,275.0 416.3,277.5 L416.3,284.5 Q416.3,287.0 413.8,287.0 L359.6,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="422.3" y="283" class="m" text-anchor="start">0.97</text>
+  <text x="422.3" y="283" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M359.6,292.0 L426.1,292.0 Q428.6,292.0 428.6,294.5 L428.6,301.5 Q428.6,304.0 426.1,304.0 L359.6,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="434.6" y="300" class="m" text-anchor="start">1.18</text>
+  <text x="434.6" y="300" class="m" fill="#4b5563" text-anchor="start">1.18</text>
   <path d="M359.6,309.0 L461.7,309.0 Q464.2,309.0 464.2,311.5 L464.2,318.5 Q464.2,321.0 461.7,321.0 L359.6,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="470.2" y="317" class="m" text-anchor="start">1.79</text>
-  <text x="527" y="56" class="t" font-weight="600">churn</text>
-  <line x1="527.2" y1="74" x2="527.2" y2="324" class="ax"/>
-  <text x="527.2" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="556.5" y1="74" x2="556.5" y2="324" class="ax"/>
-  <text x="556.5" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="585.7" y1="74" x2="585.7" y2="324" class="ax"/>
-  <text x="585.7" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="615.0" y1="74" x2="615.0" y2="324" class="ax"/>
-  <text x="615.0" y="72" class="m" text-anchor="middle">1.5</text>
-  <line x1="644.2" y1="74" x2="644.2" y2="324" class="ax"/>
-  <text x="644.2" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="585.7" y1="74" x2="585.7" y2="324" class="ref"/>
-  <line x1="527.2" y1="74" x2="527.2" y2="324" class="base"/>
+  <text x="470.2" y="317" class="m" fill="#4b5563" text-anchor="start">1.79</text>
+  <text x="527" y="56" class="t" fill="#1f2937" font-weight="600">churn</text>
+  <line x1="527.2" y1="74" x2="527.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="527.2" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="556.5" y1="74" x2="556.5" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="556.5" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="585.7" y1="74" x2="585.7" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="585.7" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="615.0" y1="74" x2="615.0" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="615.0" y="72" class="m" fill="#4b5563" text-anchor="middle">1.5</text>
+  <line x1="644.2" y1="74" x2="644.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="644.2" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="585.7" y1="74" x2="585.7" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="527.2" y1="74" x2="527.2" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M527.2,88.0 L583.2,88.0 Q585.7,88.0 585.7,90.5 L585.7,97.5 Q585.7,100.0 583.2,100.0 L527.2,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="591.7" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="591.7" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M527.2,105.0 L588.5,105.0 Q591.0,105.0 591.0,107.5 L591.0,114.5 Q591.0,117.0 588.5,117.0 L527.2,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="597.0" y="113" class="m" text-anchor="start">1.09</text>
+  <text x="597.0" y="113" class="m" fill="#4b5563" text-anchor="start">1.09</text>
   <path d="M527.2,122.0 L583.5,122.0 Q586.0,122.0 586.0,124.5 L586.0,131.5 Q586.0,134.0 583.5,134.0 L527.2,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="592.0" y="130" class="m" text-anchor="start">1.00</text>
+  <text x="592.0" y="130" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M527.2,139.0 L608.5,139.0 Q611.0,139.0 611.0,141.5 L611.0,148.5 Q611.0,151.0 608.5,151.0 L527.2,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="617.0" y="147" class="m" text-anchor="start">1.43</text>
+  <text x="617.0" y="147" class="m" fill="#4b5563" text-anchor="start">1.43</text>
   <path d="M527.2,156.0 L577.7,156.0 Q580.2,156.0 580.2,158.5 L580.2,165.5 Q580.2,168.0 577.7,168.0 L527.2,168.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="586.2" y="164" class="m" text-anchor="start">0.91</text>
+  <text x="586.2" y="164" class="m" fill="#4b5563" text-anchor="start">0.91</text>
   <path d="M527.2,173.0 L576.9,173.0 Q579.4,173.0 579.4,175.5 L579.4,182.5 Q579.4,185.0 576.9,185.0 L527.2,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="585.4" y="181" class="m" text-anchor="start">0.89</text>
+  <text x="585.4" y="181" class="m" fill="#4b5563" text-anchor="start">0.89</text>
   <path d="M527.2,190.0 L578.4,190.0 Q580.9,190.0 580.9,192.5 L580.9,199.5 Q580.9,202.0 578.4,202.0 L527.2,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="586.9" y="198" class="m" text-anchor="start">0.92</text>
+  <text x="586.9" y="198" class="m" fill="#4b5563" text-anchor="start">0.92</text>
   <path d="M527.2,207.0 L578.1,207.0 Q580.6,207.0 580.6,209.5 L580.6,216.5 Q580.6,219.0 578.1,219.0 L527.2,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="586.6" y="215" class="m" text-anchor="start">0.91</text>
+  <text x="586.6" y="215" class="m" fill="#4b5563" text-anchor="start">0.91</text>
   <path d="M527.2,224.0 L581.2,224.0 Q583.7,224.0 583.7,226.5 L583.7,233.5 Q583.7,236.0 581.2,236.0 L527.2,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="589.7" y="232" class="m" text-anchor="start">0.97</text>
+  <text x="589.7" y="232" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M527.2,241.0 L580.0,241.0 Q582.5,241.0 582.5,243.5 L582.5,250.5 Q582.5,253.0 580.0,253.0 L527.2,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="588.5" y="249" class="m" text-anchor="start">0.95</text>
+  <text x="588.5" y="249" class="m" fill="#4b5563" text-anchor="start">0.95</text>
   <path d="M527.2,258.0 L587.8,258.0 Q590.3,258.0 590.3,260.5 L590.3,267.5 Q590.3,270.0 587.8,270.0 L527.2,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="596.3" y="266" class="m" text-anchor="start">1.08</text>
+  <text x="596.3" y="266" class="m" fill="#4b5563" text-anchor="start">1.08</text>
   <path d="M527.2,275.0 L586.2,275.0 Q588.7,275.0 588.7,277.5 L588.7,284.5 Q588.7,287.0 586.2,287.0 L527.2,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="594.7" y="283" class="m" text-anchor="start">1.05</text>
+  <text x="594.7" y="283" class="m" fill="#4b5563" text-anchor="start">1.05</text>
   <path d="M527.2,292.0 L589.4,292.0 Q591.9,292.0 591.9,294.5 L591.9,301.5 Q591.9,304.0 589.4,304.0 L527.2,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="597.9" y="300" class="m" text-anchor="start">1.11</text>
+  <text x="597.9" y="300" class="m" fill="#4b5563" text-anchor="start">1.11</text>
   <path d="M527.2,309.0 L616.3,309.0 Q618.8,309.0 618.8,311.5 L618.8,318.5 Q618.8,321.0 616.3,321.0 L527.2,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="624.8" y="317" class="m" text-anchor="start">1.57</text>
-  <text x="695" y="56" class="t" font-weight="600">iterate</text>
-  <line x1="694.8" y1="74" x2="694.8" y2="324" class="ax"/>
-  <text x="694.8" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="716.9" y1="74" x2="716.9" y2="324" class="ax"/>
-  <text x="716.9" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="739.0" y1="74" x2="739.0" y2="324" class="ax"/>
-  <text x="739.0" y="72" class="m" text-anchor="middle">4</text>
-  <line x1="761.2" y1="74" x2="761.2" y2="324" class="ax"/>
-  <text x="761.2" y="72" class="m" text-anchor="middle">6</text>
-  <line x1="783.3" y1="74" x2="783.3" y2="324" class="ax"/>
-  <text x="783.3" y="72" class="m" text-anchor="middle">8</text>
-  <line x1="805.4" y1="74" x2="805.4" y2="324" class="ax"/>
-  <text x="805.4" y="72" class="m" text-anchor="middle">10</text>
-  <line x1="705.9" y1="74" x2="705.9" y2="324" class="ref"/>
-  <line x1="694.8" y1="74" x2="694.8" y2="324" class="base"/>
+  <text x="624.8" y="317" class="m" fill="#4b5563" text-anchor="start">1.57</text>
+  <text x="695" y="56" class="t" fill="#1f2937" font-weight="600">iterate</text>
+  <line x1="694.8" y1="74" x2="694.8" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="694.8" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="716.9" y1="74" x2="716.9" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="716.9" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="739.0" y1="74" x2="739.0" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="739.0" y="72" class="m" fill="#4b5563" text-anchor="middle">4</text>
+  <line x1="761.2" y1="74" x2="761.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="761.2" y="72" class="m" fill="#4b5563" text-anchor="middle">6</text>
+  <line x1="783.3" y1="74" x2="783.3" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="783.3" y="72" class="m" fill="#4b5563" text-anchor="middle">8</text>
+  <line x1="805.4" y1="74" x2="805.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="805.4" y="72" class="m" fill="#4b5563" text-anchor="middle">10</text>
+  <line x1="705.9" y1="74" x2="705.9" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="694.8" y1="74" x2="694.8" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M694.8,88.0 L703.4,88.0 Q705.9,88.0 705.9,90.5 L705.9,97.5 Q705.9,100.0 703.4,100.0 L694.8,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="711.9" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="711.9" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M694.8,105.0 L703.5,105.0 Q706.0,105.0 706.0,107.5 L706.0,114.5 Q706.0,117.0 703.5,117.0 L694.8,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="712.0" y="113" class="m" text-anchor="start">1.01</text>
+  <text x="712.0" y="113" class="m" fill="#4b5563" text-anchor="start">1.01</text>
   <path d="M694.8,122.0 L703.0,122.0 Q705.5,122.0 705.5,124.5 L705.5,131.5 Q705.5,134.0 703.0,134.0 L694.8,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="711.5" y="130" class="m" text-anchor="start">0.97</text>
+  <text x="711.5" y="130" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M694.8,139.0 L702.8,139.0 Q705.3,139.0 705.3,141.5 L705.3,148.5 Q705.3,151.0 702.8,151.0 L694.8,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="711.3" y="147" class="m" text-anchor="start">0.95</text>
+  <text x="711.3" y="147" class="m" fill="#4b5563" text-anchor="start">0.95</text>
   <path d="M694.8,156.0 L725.0,156.0 Q727.5,156.0 727.5,158.5 L727.5,165.5 Q727.5,168.0 725.0,168.0 L694.8,168.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="733.5" y="164" class="m" text-anchor="start">2.96</text>
+  <text x="733.5" y="164" class="m" fill="#4b5563" text-anchor="start">2.96</text>
   <path d="M694.8,173.0 L727.6,173.0 Q730.1,173.0 730.1,175.5 L730.1,182.5 Q730.1,185.0 727.6,185.0 L694.8,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="736.1" y="181" class="m" text-anchor="start">3.19</text>
+  <text x="736.1" y="181" class="m" fill="#4b5563" text-anchor="start">3.19</text>
   <path d="M694.8,190.0 L736.8,190.0 Q739.3,190.0 739.3,192.5 L739.3,199.5 Q739.3,202.0 736.8,202.0 L694.8,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="745.3" y="198" class="m" text-anchor="start">4.03</text>
+  <text x="745.3" y="198" class="m" fill="#4b5563" text-anchor="start">4.03</text>
   <path d="M694.8,207.0 L725.9,207.0 Q728.4,207.0 728.4,209.5 L728.4,216.5 Q728.4,219.0 725.9,219.0 L694.8,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="734.4" y="215" class="m" text-anchor="start">3.04</text>
+  <text x="734.4" y="215" class="m" fill="#4b5563" text-anchor="start">3.04</text>
   <path d="M694.8,224.0 L729.5,224.0 Q732.0,224.0 732.0,226.5 L732.0,233.5 Q732.0,236.0 729.5,236.0 L694.8,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="738.0" y="232" class="m" text-anchor="start">3.36</text>
+  <text x="738.0" y="232" class="m" fill="#4b5563" text-anchor="start">3.36</text>
   <path d="M694.8,241.0 L722.7,241.0 Q725.2,241.0 725.2,243.5 L725.2,250.5 Q725.2,253.0 722.7,253.0 L694.8,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="731.2" y="249" class="m" text-anchor="start">2.75</text>
+  <text x="731.2" y="249" class="m" fill="#4b5563" text-anchor="start">2.75</text>
   <path d="M694.8,258.0 L785.0,258.0 Q787.5,258.0 787.5,260.5 L787.5,267.5 Q787.5,270.0 785.0,270.0 L694.8,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="793.5" y="266" class="m" text-anchor="start">8.38</text>
+  <text x="793.5" y="266" class="m" fill="#4b5563" text-anchor="start">8.38</text>
   <path d="M694.8,275.0 L805.4,275.0 L798.4,277.0 L805.4,279.0 L798.4,281.0 L805.4,283.0 L798.4,285.0 L805.4,287.0 L694.8,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="811.4" y="283" class="m" text-anchor="start">11.57</text>
+  <text x="811.4" y="283" class="m" fill="#4b5563" text-anchor="start">11.57</text>
   <path d="M694.8,292.0 L805.4,292.0 L798.4,294.0 L805.4,296.0 L798.4,298.0 L805.4,300.0 L798.4,302.0 L805.4,304.0 L694.8,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="811.4" y="300" class="m" text-anchor="start">15.32</text>
+  <text x="811.4" y="300" class="m" fill="#4b5563" text-anchor="start">15.32</text>
   <path d="M694.8,309.0 L805.4,309.0 L798.4,311.0 L805.4,313.0 L798.4,315.0 L805.4,317.0 L798.4,319.0 L805.4,321.0 L694.8,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="811.4" y="317" class="m" text-anchor="start">99.88</text>
-  <text x="862" y="56" class="t" font-weight="600">peak memory</text>
-  <line x1="862.4" y1="74" x2="862.4" y2="324" class="ax"/>
-  <text x="862.4" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="901.4" y1="74" x2="901.4" y2="324" class="ax"/>
-  <text x="901.4" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="940.4" y1="74" x2="940.4" y2="324" class="ax"/>
-  <text x="940.4" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="979.4" y1="74" x2="979.4" y2="324" class="ax"/>
-  <text x="979.4" y="72" class="m" text-anchor="middle">1.5</text>
-  <line x1="940.4" y1="74" x2="940.4" y2="324" class="ref"/>
-  <line x1="862.4" y1="74" x2="862.4" y2="324" class="base"/>
+  <text x="811.4" y="317" class="m" fill="#4b5563" text-anchor="start">99.88</text>
+  <text x="862" y="56" class="t" fill="#1f2937" font-weight="600">peak memory</text>
+  <line x1="862.4" y1="74" x2="862.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="862.4" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="901.4" y1="74" x2="901.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="901.4" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="940.4" y1="74" x2="940.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="940.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="979.4" y1="74" x2="979.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="979.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1.5</text>
+  <line x1="940.4" y1="74" x2="940.4" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="862.4" y1="74" x2="862.4" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M862.4,88.0 L937.9,88.0 Q940.4,88.0 940.4,90.5 L940.4,97.5 Q940.4,100.0 937.9,100.0 L862.4,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="946.4" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="946.4" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M862.4,105.0 L941.4,105.0 Q943.9,105.0 943.9,107.5 L943.9,114.5 Q943.9,117.0 941.4,117.0 L862.4,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="949.9" y="113" class="m" text-anchor="start">1.05</text>
+  <text x="949.9" y="113" class="m" fill="#4b5563" text-anchor="start">1.05</text>
   <path d="M862.4,122.0 L942.6,122.0 Q945.1,122.0 945.1,124.5 L945.1,131.5 Q945.1,134.0 942.6,134.0 L862.4,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="951.1" y="130" class="m" text-anchor="start">1.06</text>
+  <text x="951.1" y="130" class="m" fill="#4b5563" text-anchor="start">1.06</text>
   <path d="M862.4,139.0 L938.1,139.0 Q940.6,139.0 940.6,141.5 L940.6,148.5 Q940.6,151.0 938.1,151.0 L862.4,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="946.6" y="147" class="m" text-anchor="start">1.00</text>
+  <text x="946.6" y="147" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M862.4,156.0 L950.4,156.0 Q952.9,156.0 952.9,158.5 L952.9,165.5 Q952.9,168.0 950.4,168.0 L862.4,168.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="958.9" y="164" class="m" text-anchor="start">1.16</text>
+  <text x="958.9" y="164" class="m" fill="#4b5563" text-anchor="start">1.16</text>
   <path d="M862.4,173.0 L958.8,173.0 Q961.3,173.0 961.3,175.5 L961.3,182.5 Q961.3,185.0 958.8,185.0 L862.4,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="967.3" y="181" class="m" text-anchor="start">1.27</text>
+  <text x="967.3" y="181" class="m" fill="#4b5563" text-anchor="start">1.27</text>
   <path d="M862.4,190.0 L948.8,190.0 Q951.3,190.0 951.3,192.5 L951.3,199.5 Q951.3,202.0 948.8,202.0 L862.4,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="957.3" y="198" class="m" text-anchor="start">1.14</text>
+  <text x="957.3" y="198" class="m" fill="#4b5563" text-anchor="start">1.14</text>
   <path d="M862.4,207.0 L955.2,207.0 Q957.7,207.0 957.7,209.5 L957.7,216.5 Q957.7,219.0 955.2,219.0 L862.4,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="963.7" y="215" class="m" text-anchor="start">1.22</text>
+  <text x="963.7" y="215" class="m" fill="#4b5563" text-anchor="start">1.22</text>
   <path d="M862.4,224.0 L949.0,224.0 Q951.5,224.0 951.5,226.5 L951.5,233.5 Q951.5,236.0 949.0,236.0 L862.4,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="957.5" y="232" class="m" text-anchor="start">1.14</text>
+  <text x="957.5" y="232" class="m" fill="#4b5563" text-anchor="start">1.14</text>
   <path d="M862.4,241.0 L947.9,241.0 Q950.4,241.0 950.4,243.5 L950.4,250.5 Q950.4,253.0 947.9,253.0 L862.4,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="956.4" y="249" class="m" text-anchor="start">1.13</text>
+  <text x="956.4" y="249" class="m" fill="#4b5563" text-anchor="start">1.13</text>
   <path d="M862.4,258.0 L937.5,258.0 Q940.0,258.0 940.0,260.5 L940.0,267.5 Q940.0,270.0 937.5,270.0 L862.4,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="946.0" y="266" class="m" text-anchor="start">1.00</text>
+  <text x="946.0" y="266" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M862.4,275.0 L937.7,275.0 Q940.2,275.0 940.2,277.5 L940.2,284.5 Q940.2,287.0 937.7,287.0 L862.4,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="946.2" y="283" class="m" text-anchor="start">1.00</text>
+  <text x="946.2" y="283" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M862.4,292.0 L939.4,292.0 Q941.9,292.0 941.9,294.5 L941.9,301.5 Q941.9,304.0 939.4,304.0 L862.4,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="947.9" y="300" class="m" text-anchor="start">1.02</text>
+  <text x="947.9" y="300" class="m" fill="#4b5563" text-anchor="start">1.02</text>
   <path d="M862.4,309.0 L946.3,309.0 Q948.8,309.0 948.8,311.5 L948.8,318.5 Q948.8,321.0 946.3,321.0 L862.4,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="954.8" y="317" class="m" text-anchor="start">1.11</text>
-  <text x="184.0" y="56" class="m" text-anchor="end">geomean</text>
-  <text x="146.0" y="96" class="t" text-anchor="end" font-weight='600'>unordered_dense 5.0</text>
-  <text x="184.0" y="96" class="m" text-anchor="end">1.00</text>
-  <text x="146.0" y="113" class="t" text-anchor="end">unordered_dense 4.11</text>
-  <text x="184.0" y="113" class="m" text-anchor="end">1.10</text>
-  <text x="146.0" y="130" class="t" text-anchor="end">F14Vector</text>
-  <text x="184.0" y="130" class="m" text-anchor="end">1.12</text>
-  <text x="146.0" y="147" class="t" text-anchor="end">emhash8</text>
-  <text x="184.0" y="147" class="m" text-anchor="end">1.35</text>
-  <text x="146.0" y="164" class="t" text-anchor="end">indivi flat_umap</text>
-  <text x="184.0" y="164" class="m" text-anchor="end">1.45</text>
-  <text x="146.0" y="181" class="t" text-anchor="end">indivi flat_wmap</text>
-  <text x="184.0" y="181" class="m" text-anchor="end">1.52</text>
-  <text x="146.0" y="198" class="t" text-anchor="end">absl flat</text>
-  <text x="184.0" y="198" class="m" text-anchor="end">1.53</text>
-  <text x="146.0" y="215" class="t" text-anchor="end">boost flat</text>
-  <text x="184.0" y="215" class="m" text-anchor="end">1.56</text>
-  <text x="146.0" y="232" class="t" text-anchor="end">F14Value</text>
-  <text x="184.0" y="232" class="m" text-anchor="end">1.57</text>
-  <text x="146.0" y="249" class="t" text-anchor="end">emilib</text>
-  <text x="184.0" y="249" class="m" text-anchor="end">1.59</text>
-  <text x="146.0" y="266" class="t" text-anchor="end">absl node</text>
-  <text x="184.0" y="266" class="m" text-anchor="end">1.85</text>
-  <text x="146.0" y="283" class="t" text-anchor="end">F14Node</text>
-  <text x="184.0" y="283" class="m" text-anchor="end">1.93</text>
-  <text x="146.0" y="300" class="t" text-anchor="end">boost node</text>
-  <text x="184.0" y="300" class="m" text-anchor="end">2.29</text>
-  <text x="146.0" y="317" class="t" text-anchor="end">std::unordered_map</text>
-  <text x="184.0" y="317" class="m" text-anchor="end">4.08</text>
+  <text x="954.8" y="317" class="m" fill="#4b5563" text-anchor="start">1.11</text>
+  <text x="184.0" y="56" class="m" fill="#4b5563" text-anchor="end">geomean</text>
+  <text x="146.0" y="96" class="t" fill="#1f2937" text-anchor="end" font-weight='600'>unordered_dense 5.0</text>
+  <text x="184.0" y="96" class="m" fill="#4b5563" text-anchor="end">1.00</text>
+  <text x="146.0" y="113" class="t" fill="#1f2937" text-anchor="end">unordered_dense 4.11</text>
+  <text x="184.0" y="113" class="m" fill="#4b5563" text-anchor="end">1.10</text>
+  <text x="146.0" y="130" class="t" fill="#1f2937" text-anchor="end">F14Vector</text>
+  <text x="184.0" y="130" class="m" fill="#4b5563" text-anchor="end">1.12</text>
+  <text x="146.0" y="147" class="t" fill="#1f2937" text-anchor="end">emhash8</text>
+  <text x="184.0" y="147" class="m" fill="#4b5563" text-anchor="end">1.35</text>
+  <text x="146.0" y="164" class="t" fill="#1f2937" text-anchor="end">indivi flat_umap</text>
+  <text x="184.0" y="164" class="m" fill="#4b5563" text-anchor="end">1.45</text>
+  <text x="146.0" y="181" class="t" fill="#1f2937" text-anchor="end">indivi flat_wmap</text>
+  <text x="184.0" y="181" class="m" fill="#4b5563" text-anchor="end">1.52</text>
+  <text x="146.0" y="198" class="t" fill="#1f2937" text-anchor="end">absl flat</text>
+  <text x="184.0" y="198" class="m" fill="#4b5563" text-anchor="end">1.53</text>
+  <text x="146.0" y="215" class="t" fill="#1f2937" text-anchor="end">boost flat</text>
+  <text x="184.0" y="215" class="m" fill="#4b5563" text-anchor="end">1.56</text>
+  <text x="146.0" y="232" class="t" fill="#1f2937" text-anchor="end">F14Value</text>
+  <text x="184.0" y="232" class="m" fill="#4b5563" text-anchor="end">1.57</text>
+  <text x="146.0" y="249" class="t" fill="#1f2937" text-anchor="end">emilib</text>
+  <text x="184.0" y="249" class="m" fill="#4b5563" text-anchor="end">1.59</text>
+  <text x="146.0" y="266" class="t" fill="#1f2937" text-anchor="end">absl node</text>
+  <text x="184.0" y="266" class="m" fill="#4b5563" text-anchor="end">1.85</text>
+  <text x="146.0" y="283" class="t" fill="#1f2937" text-anchor="end">F14Node</text>
+  <text x="184.0" y="283" class="m" fill="#4b5563" text-anchor="end">1.93</text>
+  <text x="146.0" y="300" class="t" fill="#1f2937" text-anchor="end">boost node</text>
+  <text x="184.0" y="300" class="m" fill="#4b5563" text-anchor="end">2.29</text>
+  <text x="146.0" y="317" class="t" fill="#1f2937" text-anchor="end">std::unordered_map</text>
+  <text x="184.0" y="317" class="m" fill="#4b5563" text-anchor="end">4.08</text>
   <rect x="192.0" y="341" width="11" height="11" class="f-flat" fill="#2563c9" opacity="0.85"/>
-  <text x="208.0" y="350" class="m">flat</text>
+  <text x="208.0" y="350" class="m" fill="#4b5563">flat</text>
   <rect x="266.0" y="341" width="11" height="11" class="f-dense" fill="#0e8f60" opacity="0.85"/>
-  <text x="282.0" y="350" class="m">dense</text>
+  <text x="282.0" y="350" class="m" fill="#4b5563">dense</text>
   <rect x="340.0" y="341" width="11" height="11" class="f-node" fill="#a53393" opacity="0.85"/>
-  <text x="356.0" y="350" class="m">node</text>
-  <text x="424.0" y="350" class="m">relative to unordered_dense 5.0: time for the first four panels, peak bytes per entry for the last</text>
+  <text x="356.0" y="350" class="m" fill="#4b5563">node</text>
+  <text x="424.0" y="350" class="m" fill="#4b5563">relative to unordered_dense 5.0: time for the first four panels, peak bytes per entry for the last</text>
 </svg>

--- a/doc/bench-readme-u64.svg
+++ b/doc/bench-readme-u64.svg
@@ -16,248 +16,248 @@
       .f-flat{fill:#5b9bf0}.f-dense{fill:#3cc492}.f-node{fill:#e070cd}
     }
   </style>
-  <rect class="surface" width="1030" height="382"/>
-  <text x="8" y="20" class="hd">relative to unordered_dense 5.0, uint64_t keys, every map in its default configuration</text>
-  <text x="8" y="38" class="sub">geometric mean over one octave from 1,000,000 entries; lower is better, and 1.00 is level with unordered_dense 5.0. Rows are sorted by the geomean of all five panels; a bar torn off at the right ran past the axis.</text>
-  <text x="192" y="56" class="t" font-weight="600">build + destroy</text>
-  <line x1="192.0" y1="74" x2="192.0" y2="324" class="ax"/>
-  <text x="192.0" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="221.2" y1="74" x2="221.2" y2="324" class="ax"/>
-  <text x="221.2" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="250.5" y1="74" x2="250.5" y2="324" class="ax"/>
-  <text x="250.5" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="279.8" y1="74" x2="279.8" y2="324" class="ax"/>
-  <text x="279.8" y="72" class="m" text-anchor="middle">3</text>
-  <line x1="309.0" y1="74" x2="309.0" y2="324" class="ax"/>
-  <text x="309.0" y="72" class="m" text-anchor="middle">4</text>
-  <line x1="221.2" y1="74" x2="221.2" y2="324" class="ref"/>
-  <line x1="192.0" y1="74" x2="192.0" y2="324" class="base"/>
+  <rect class="surface" fill="#ffffff" width="1030" height="382"/>
+  <text x="8" y="20" class="hd" fill="#111827">relative to unordered_dense 5.0, uint64_t keys, every map in its default configuration</text>
+  <text x="8" y="38" class="sub" fill="#4b5563">geometric mean over one octave from 1,000,000 entries; lower is better, and 1.00 is level with unordered_dense 5.0. Rows are sorted by the geomean of all five panels; a bar torn off at the right ran past the axis.</text>
+  <text x="192" y="56" class="t" fill="#1f2937" font-weight="600">build + destroy</text>
+  <line x1="192.0" y1="74" x2="192.0" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="192.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="221.2" y1="74" x2="221.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="221.2" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="250.5" y1="74" x2="250.5" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="250.5" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="279.8" y1="74" x2="279.8" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="279.8" y="72" class="m" fill="#4b5563" text-anchor="middle">3</text>
+  <line x1="309.0" y1="74" x2="309.0" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="309.0" y="72" class="m" fill="#4b5563" text-anchor="middle">4</text>
+  <line x1="221.2" y1="74" x2="221.2" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="192.0" y1="74" x2="192.0" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M192.0,88.0 L218.8,88.0 Q221.2,88.0 221.2,90.5 L221.2,97.5 Q221.2,100.0 218.8,100.0 L192.0,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="227.2" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="227.2" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M192.0,105.0 L229.8,105.0 Q232.3,105.0 232.3,107.5 L232.3,114.5 Q232.3,117.0 229.8,117.0 L192.0,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="238.3" y="113" class="m" text-anchor="start">1.38</text>
+  <text x="238.3" y="113" class="m" fill="#4b5563" text-anchor="start">1.38</text>
   <path d="M192.0,122.0 L234.4,122.0 Q236.9,122.0 236.9,124.5 L236.9,131.5 Q236.9,134.0 234.4,134.0 L192.0,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="242.9" y="130" class="m" text-anchor="start">1.53</text>
+  <text x="242.9" y="130" class="m" fill="#4b5563" text-anchor="start">1.53</text>
   <path d="M192.0,139.0 L215.8,139.0 Q218.3,139.0 218.3,141.5 L218.3,148.5 Q218.3,151.0 215.8,151.0 L192.0,151.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="224.3" y="147" class="m" text-anchor="start">0.90</text>
+  <text x="224.3" y="147" class="m" fill="#4b5563" text-anchor="start">0.90</text>
   <path d="M192.0,156.0 L236.1,156.0 Q238.6,156.0 238.6,158.5 L238.6,165.5 Q238.6,168.0 236.1,168.0 L192.0,168.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="244.6" y="164" class="m" text-anchor="start">1.59</text>
+  <text x="244.6" y="164" class="m" fill="#4b5563" text-anchor="start">1.59</text>
   <path d="M192.0,173.0 L224.9,173.0 Q227.4,173.0 227.4,175.5 L227.4,182.5 Q227.4,185.0 224.9,185.0 L192.0,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="233.4" y="181" class="m" text-anchor="start">1.21</text>
+  <text x="233.4" y="181" class="m" fill="#4b5563" text-anchor="start">1.21</text>
   <path d="M192.0,190.0 L217.8,190.0 Q220.3,190.0 220.3,192.5 L220.3,199.5 Q220.3,202.0 217.8,202.0 L192.0,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="226.3" y="198" class="m" text-anchor="start">0.97</text>
+  <text x="226.3" y="198" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M192.0,207.0 L233.3,207.0 Q235.8,207.0 235.8,209.5 L235.8,216.5 Q235.8,219.0 233.3,219.0 L192.0,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="241.8" y="215" class="m" text-anchor="start">1.50</text>
+  <text x="241.8" y="215" class="m" fill="#4b5563" text-anchor="start">1.50</text>
   <path d="M192.0,224.0 L213.2,224.0 Q215.7,224.0 215.7,226.5 L215.7,233.5 Q215.7,236.0 213.2,236.0 L192.0,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="221.7" y="232" class="m" text-anchor="start">0.81</text>
+  <text x="221.7" y="232" class="m" fill="#4b5563" text-anchor="start">0.81</text>
   <path d="M192.0,241.0 L225.2,241.0 Q227.7,241.0 227.7,243.5 L227.7,250.5 Q227.7,253.0 225.2,253.0 L192.0,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="233.7" y="249" class="m" text-anchor="start">1.22</text>
+  <text x="233.7" y="249" class="m" fill="#4b5563" text-anchor="start">1.22</text>
   <path d="M192.0,258.0 L296.1,258.0 Q298.6,258.0 298.6,260.5 L298.6,267.5 Q298.6,270.0 296.1,270.0 L192.0,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="304.6" y="266" class="m" text-anchor="start">3.64</text>
+  <text x="304.6" y="266" class="m" fill="#4b5563" text-anchor="start">3.64</text>
   <path d="M192.0,275.0 L301.3,275.0 Q303.8,275.0 303.8,277.5 L303.8,284.5 Q303.8,287.0 301.3,287.0 L192.0,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="309.8" y="283" class="m" text-anchor="start">3.82</text>
+  <text x="309.8" y="283" class="m" fill="#4b5563" text-anchor="start">3.82</text>
   <path d="M192.0,292.0 L299.9,292.0 Q302.4,292.0 302.4,294.5 L302.4,301.5 Q302.4,304.0 299.9,304.0 L192.0,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="308.4" y="300" class="m" text-anchor="start">3.77</text>
+  <text x="308.4" y="300" class="m" fill="#4b5563" text-anchor="start">3.77</text>
   <path d="M192.0,309.0 L309.0,309.0 L302.0,311.0 L309.0,313.0 L302.0,315.0 L309.0,317.0 L302.0,319.0 L309.0,321.0 L192.0,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="315.0" y="317" class="m" text-anchor="start">4.84</text>
-  <text x="360" y="56" class="t" font-weight="600">find, 50% hits</text>
-  <line x1="359.6" y1="74" x2="359.6" y2="324" class="ax"/>
-  <text x="359.6" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="383.0" y1="74" x2="383.0" y2="324" class="ax"/>
-  <text x="383.0" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="406.4" y1="74" x2="406.4" y2="324" class="ax"/>
-  <text x="406.4" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="429.8" y1="74" x2="429.8" y2="324" class="ax"/>
-  <text x="429.8" y="72" class="m" text-anchor="middle">1.5</text>
-  <line x1="453.2" y1="74" x2="453.2" y2="324" class="ax"/>
-  <text x="453.2" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="476.6" y1="74" x2="476.6" y2="324" class="ax"/>
-  <text x="476.6" y="72" class="m" text-anchor="middle">2.5</text>
-  <line x1="406.4" y1="74" x2="406.4" y2="324" class="ref"/>
-  <line x1="359.6" y1="74" x2="359.6" y2="324" class="base"/>
+  <text x="315.0" y="317" class="m" fill="#4b5563" text-anchor="start">4.84</text>
+  <text x="360" y="56" class="t" fill="#1f2937" font-weight="600">find, 50% hits</text>
+  <line x1="359.6" y1="74" x2="359.6" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="359.6" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="383.0" y1="74" x2="383.0" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="383.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="406.4" y1="74" x2="406.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="406.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="429.8" y1="74" x2="429.8" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="429.8" y="72" class="m" fill="#4b5563" text-anchor="middle">1.5</text>
+  <line x1="453.2" y1="74" x2="453.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="453.2" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="476.6" y1="74" x2="476.6" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="476.6" y="72" class="m" fill="#4b5563" text-anchor="middle">2.5</text>
+  <line x1="406.4" y1="74" x2="406.4" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="359.6" y1="74" x2="359.6" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M359.6,88.0 L403.9,88.0 Q406.4,88.0 406.4,90.5 L406.4,97.5 Q406.4,100.0 403.9,100.0 L359.6,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="412.4" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="412.4" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M359.6,105.0 L402.6,105.0 Q405.1,105.0 405.1,107.5 L405.1,114.5 Q405.1,117.0 402.6,117.0 L359.6,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="411.1" y="113" class="m" text-anchor="start">0.97</text>
+  <text x="411.1" y="113" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M359.6,122.0 L408.2,122.0 Q410.7,122.0 410.7,124.5 L410.7,131.5 Q410.7,134.0 408.2,134.0 L359.6,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="416.7" y="130" class="m" text-anchor="start">1.09</text>
+  <text x="416.7" y="130" class="m" fill="#4b5563" text-anchor="start">1.09</text>
   <path d="M359.6,139.0 L395.4,139.0 Q397.9,139.0 397.9,141.5 L397.9,148.5 Q397.9,151.0 395.4,151.0 L359.6,151.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="403.9" y="147" class="m" text-anchor="start">0.82</text>
+  <text x="403.9" y="147" class="m" fill="#4b5563" text-anchor="start">0.82</text>
   <path d="M359.6,156.0 L417.2,156.0 Q419.7,156.0 419.7,158.5 L419.7,165.5 Q419.7,168.0 417.2,168.0 L359.6,168.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="425.7" y="164" class="m" text-anchor="start">1.29</text>
+  <text x="425.7" y="164" class="m" fill="#4b5563" text-anchor="start">1.29</text>
   <path d="M359.6,173.0 L395.1,173.0 Q397.6,173.0 397.6,175.5 L397.6,182.5 Q397.6,185.0 395.1,185.0 L359.6,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="403.6" y="181" class="m" text-anchor="start">0.81</text>
+  <text x="403.6" y="181" class="m" fill="#4b5563" text-anchor="start">0.81</text>
   <path d="M359.6,190.0 L391.3,190.0 Q393.8,190.0 393.8,192.5 L393.8,199.5 Q393.8,202.0 391.3,202.0 L359.6,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="399.8" y="198" class="m" text-anchor="start">0.73</text>
+  <text x="399.8" y="198" class="m" fill="#4b5563" text-anchor="start">0.73</text>
   <path d="M359.6,207.0 L390.2,207.0 Q392.7,207.0 392.7,209.5 L392.7,216.5 Q392.7,219.0 390.2,219.0 L359.6,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="398.7" y="215" class="m" text-anchor="start">0.71</text>
+  <text x="398.7" y="215" class="m" fill="#4b5563" text-anchor="start">0.71</text>
   <path d="M359.6,224.0 L395.2,224.0 Q397.7,224.0 397.7,226.5 L397.7,233.5 Q397.7,236.0 395.2,236.0 L359.6,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="403.7" y="232" class="m" text-anchor="start">0.81</text>
+  <text x="403.7" y="232" class="m" fill="#4b5563" text-anchor="start">0.81</text>
   <path d="M359.6,241.0 L410.8,241.0 Q413.3,241.0 413.3,243.5 L413.3,250.5 Q413.3,253.0 410.8,253.0 L359.6,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="419.3" y="249" class="m" text-anchor="start">1.15</text>
+  <text x="419.3" y="249" class="m" fill="#4b5563" text-anchor="start">1.15</text>
   <path d="M359.6,258.0 L410.7,258.0 Q413.2,258.0 413.2,260.5 L413.2,267.5 Q413.2,270.0 410.7,270.0 L359.6,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="419.2" y="266" class="m" text-anchor="start">1.15</text>
+  <text x="419.2" y="266" class="m" fill="#4b5563" text-anchor="start">1.15</text>
   <path d="M359.6,275.0 L407.5,275.0 Q410.0,275.0 410.0,277.5 L410.0,284.5 Q410.0,287.0 407.5,287.0 L359.6,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="416.0" y="283" class="m" text-anchor="start">1.08</text>
+  <text x="416.0" y="283" class="m" fill="#4b5563" text-anchor="start">1.08</text>
   <path d="M359.6,292.0 L412.0,292.0 Q414.5,292.0 414.5,294.5 L414.5,301.5 Q414.5,304.0 412.0,304.0 L359.6,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="420.5" y="300" class="m" text-anchor="start">1.17</text>
+  <text x="420.5" y="300" class="m" fill="#4b5563" text-anchor="start">1.17</text>
   <path d="M359.6,309.0 L449.6,309.0 Q452.1,309.0 452.1,311.5 L452.1,318.5 Q452.1,321.0 449.6,321.0 L359.6,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="458.1" y="317" class="m" text-anchor="start">1.98</text>
-  <text x="527" y="56" class="t" font-weight="600">churn</text>
-  <line x1="527.2" y1="74" x2="527.2" y2="324" class="ax"/>
-  <text x="527.2" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="566.2" y1="74" x2="566.2" y2="324" class="ax"/>
-  <text x="566.2" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="605.2" y1="74" x2="605.2" y2="324" class="ax"/>
-  <text x="605.2" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="644.2" y1="74" x2="644.2" y2="324" class="ax"/>
-  <text x="644.2" y="72" class="m" text-anchor="middle">3</text>
-  <line x1="566.2" y1="74" x2="566.2" y2="324" class="ref"/>
-  <line x1="527.2" y1="74" x2="527.2" y2="324" class="base"/>
+  <text x="458.1" y="317" class="m" fill="#4b5563" text-anchor="start">1.98</text>
+  <text x="527" y="56" class="t" fill="#1f2937" font-weight="600">churn</text>
+  <line x1="527.2" y1="74" x2="527.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="527.2" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="566.2" y1="74" x2="566.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="566.2" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="605.2" y1="74" x2="605.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="605.2" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="644.2" y1="74" x2="644.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="644.2" y="72" class="m" fill="#4b5563" text-anchor="middle">3</text>
+  <line x1="566.2" y1="74" x2="566.2" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="527.2" y1="74" x2="527.2" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M527.2,88.0 L563.7,88.0 Q566.2,88.0 566.2,90.5 L566.2,97.5 Q566.2,100.0 563.7,100.0 L527.2,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="572.2" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="572.2" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M527.2,105.0 L567.0,105.0 Q569.5,105.0 569.5,107.5 L569.5,114.5 Q569.5,117.0 567.0,117.0 L527.2,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="575.5" y="113" class="m" text-anchor="start">1.08</text>
+  <text x="575.5" y="113" class="m" fill="#4b5563" text-anchor="start">1.08</text>
   <path d="M527.2,122.0 L569.0,122.0 Q571.5,122.0 571.5,124.5 L571.5,131.5 Q571.5,134.0 569.0,134.0 L527.2,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="577.5" y="130" class="m" text-anchor="start">1.13</text>
+  <text x="577.5" y="130" class="m" fill="#4b5563" text-anchor="start">1.13</text>
   <path d="M527.2,139.0 L553.2,139.0 Q555.7,139.0 555.7,141.5 L555.7,148.5 Q555.7,151.0 553.2,151.0 L527.2,151.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="561.7" y="147" class="m" text-anchor="start">0.73</text>
+  <text x="561.7" y="147" class="m" fill="#4b5563" text-anchor="start">0.73</text>
   <path d="M527.2,156.0 L583.0,156.0 Q585.5,156.0 585.5,158.5 L585.5,165.5 Q585.5,168.0 583.0,168.0 L527.2,168.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="591.5" y="164" class="m" text-anchor="start">1.49</text>
+  <text x="591.5" y="164" class="m" fill="#4b5563" text-anchor="start">1.49</text>
   <path d="M527.2,173.0 L550.4,173.0 Q552.9,173.0 552.9,175.5 L552.9,182.5 Q552.9,185.0 550.4,185.0 L527.2,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="558.9" y="181" class="m" text-anchor="start">0.66</text>
+  <text x="558.9" y="181" class="m" fill="#4b5563" text-anchor="start">0.66</text>
   <path d="M527.2,190.0 L548.5,190.0 Q551.0,190.0 551.0,192.5 L551.0,199.5 Q551.0,202.0 548.5,202.0 L527.2,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="557.0" y="198" class="m" text-anchor="start">0.61</text>
+  <text x="557.0" y="198" class="m" fill="#4b5563" text-anchor="start">0.61</text>
   <path d="M527.2,207.0 L552.1,207.0 Q554.6,207.0 554.6,209.5 L554.6,216.5 Q554.6,219.0 552.1,219.0 L527.2,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="560.6" y="215" class="m" text-anchor="start">0.70</text>
+  <text x="560.6" y="215" class="m" fill="#4b5563" text-anchor="start">0.70</text>
   <path d="M527.2,224.0 L556.1,224.0 Q558.6,224.0 558.6,226.5 L558.6,233.5 Q558.6,236.0 556.1,236.0 L527.2,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="564.6" y="232" class="m" text-anchor="start">0.81</text>
+  <text x="564.6" y="232" class="m" fill="#4b5563" text-anchor="start">0.81</text>
   <path d="M527.2,241.0 L566.8,241.0 Q569.3,241.0 569.3,243.5 L569.3,250.5 Q569.3,253.0 566.8,253.0 L527.2,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="575.3" y="249" class="m" text-anchor="start">1.08</text>
+  <text x="575.3" y="249" class="m" fill="#4b5563" text-anchor="start">1.08</text>
   <path d="M527.2,258.0 L591.0,258.0 Q593.5,258.0 593.5,260.5 L593.5,267.5 Q593.5,270.0 591.0,270.0 L527.2,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="599.5" y="266" class="m" text-anchor="start">1.70</text>
+  <text x="599.5" y="266" class="m" fill="#4b5563" text-anchor="start">1.70</text>
   <path d="M527.2,275.0 L577.4,275.0 Q579.9,275.0 579.9,277.5 L579.9,284.5 Q579.9,287.0 577.4,287.0 L527.2,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="585.9" y="283" class="m" text-anchor="start">1.35</text>
+  <text x="585.9" y="283" class="m" fill="#4b5563" text-anchor="start">1.35</text>
   <path d="M527.2,292.0 L604.5,292.0 Q607.0,292.0 607.0,294.5 L607.0,301.5 Q607.0,304.0 604.5,304.0 L527.2,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="613.0" y="300" class="m" text-anchor="start">2.05</text>
+  <text x="613.0" y="300" class="m" fill="#4b5563" text-anchor="start">2.05</text>
   <path d="M527.2,309.0 L635.5,309.0 Q638.0,309.0 638.0,311.5 L638.0,318.5 Q638.0,321.0 635.5,321.0 L527.2,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="644.0" y="317" class="m" text-anchor="start">2.84</text>
-  <text x="695" y="56" class="t" font-weight="600">iterate</text>
-  <line x1="694.8" y1="74" x2="694.8" y2="324" class="ax"/>
-  <text x="694.8" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="715.6" y1="74" x2="715.6" y2="324" class="ax"/>
-  <text x="715.6" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="736.5" y1="74" x2="736.5" y2="324" class="ax"/>
-  <text x="736.5" y="72" class="m" text-anchor="middle">4</text>
-  <line x1="757.3" y1="74" x2="757.3" y2="324" class="ax"/>
-  <text x="757.3" y="72" class="m" text-anchor="middle">6</text>
-  <line x1="778.2" y1="74" x2="778.2" y2="324" class="ax"/>
-  <text x="778.2" y="72" class="m" text-anchor="middle">8</text>
-  <line x1="799.0" y1="74" x2="799.0" y2="324" class="ax"/>
-  <text x="799.0" y="72" class="m" text-anchor="middle">10</text>
-  <line x1="705.2" y1="74" x2="705.2" y2="324" class="ref"/>
-  <line x1="694.8" y1="74" x2="694.8" y2="324" class="base"/>
+  <text x="644.0" y="317" class="m" fill="#4b5563" text-anchor="start">2.84</text>
+  <text x="695" y="56" class="t" fill="#1f2937" font-weight="600">iterate</text>
+  <line x1="694.8" y1="74" x2="694.8" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="694.8" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="715.6" y1="74" x2="715.6" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="715.6" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="736.5" y1="74" x2="736.5" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="736.5" y="72" class="m" fill="#4b5563" text-anchor="middle">4</text>
+  <line x1="757.3" y1="74" x2="757.3" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="757.3" y="72" class="m" fill="#4b5563" text-anchor="middle">6</text>
+  <line x1="778.2" y1="74" x2="778.2" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="778.2" y="72" class="m" fill="#4b5563" text-anchor="middle">8</text>
+  <line x1="799.0" y1="74" x2="799.0" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="799.0" y="72" class="m" fill="#4b5563" text-anchor="middle">10</text>
+  <line x1="705.2" y1="74" x2="705.2" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="694.8" y1="74" x2="694.8" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M694.8,88.0 L702.7,88.0 Q705.2,88.0 705.2,90.5 L705.2,97.5 Q705.2,100.0 702.7,100.0 L694.8,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="711.2" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="711.2" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M694.8,105.0 L701.5,105.0 Q704.0,105.0 704.0,107.5 L704.0,114.5 Q704.0,117.0 701.5,117.0 L694.8,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="710.0" y="113" class="m" text-anchor="start">0.89</text>
+  <text x="710.0" y="113" class="m" fill="#4b5563" text-anchor="start">0.89</text>
   <path d="M694.8,122.0 L703.9,122.0 Q706.4,122.0 706.4,124.5 L706.4,131.5 Q706.4,134.0 703.9,134.0 L694.8,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="712.4" y="130" class="m" text-anchor="start">1.11</text>
+  <text x="712.4" y="130" class="m" fill="#4b5563" text-anchor="start">1.11</text>
   <path d="M694.8,139.0 L749.3,139.0 Q751.8,139.0 751.8,141.5 L751.8,148.5 Q751.8,151.0 749.3,151.0 L694.8,151.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="757.8" y="147" class="m" text-anchor="start">5.47</text>
+  <text x="757.8" y="147" class="m" fill="#4b5563" text-anchor="start">5.47</text>
   <path d="M694.8,156.0 L702.9,156.0 Q705.4,156.0 705.4,158.5 L705.4,165.5 Q705.4,168.0 702.9,168.0 L694.8,168.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="711.4" y="164" class="m" text-anchor="start">1.02</text>
+  <text x="711.4" y="164" class="m" fill="#4b5563" text-anchor="start">1.02</text>
   <path d="M694.8,173.0 L751.6,173.0 Q754.1,173.0 754.1,175.5 L754.1,182.5 Q754.1,185.0 751.6,185.0 L694.8,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="760.1" y="181" class="m" text-anchor="start">5.69</text>
+  <text x="760.1" y="181" class="m" fill="#4b5563" text-anchor="start">5.69</text>
   <path d="M694.8,190.0 L791.4,190.0 Q793.9,190.0 793.9,192.5 L793.9,199.5 Q793.9,202.0 791.4,202.0 L694.8,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="799.9" y="198" class="m" text-anchor="start">9.51</text>
+  <text x="799.9" y="198" class="m" fill="#4b5563" text-anchor="start">9.51</text>
   <path d="M694.8,207.0 L770.6,207.0 Q773.1,207.0 773.1,209.5 L773.1,216.5 Q773.1,219.0 770.6,219.0 L694.8,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="779.1" y="215" class="m" text-anchor="start">7.52</text>
+  <text x="779.1" y="215" class="m" fill="#4b5563" text-anchor="start">7.52</text>
   <path d="M694.8,224.0 L799.0,224.0 L792.0,226.0 L799.0,228.0 L792.0,230.0 L799.0,232.0 L792.0,234.0 L799.0,236.0 L694.8,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="805.0" y="232" class="m" text-anchor="start">13.33</text>
+  <text x="805.0" y="232" class="m" fill="#4b5563" text-anchor="start">13.33</text>
   <path d="M694.8,241.0 L762.6,241.0 Q765.1,241.0 765.1,243.5 L765.1,250.5 Q765.1,253.0 762.6,253.0 L694.8,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="771.1" y="249" class="m" text-anchor="start">6.75</text>
+  <text x="771.1" y="249" class="m" fill="#4b5563" text-anchor="start">6.75</text>
   <path d="M694.8,258.0 L799.0,258.0 L792.0,260.0 L799.0,262.0 L792.0,264.0 L799.0,266.0 L792.0,268.0 L799.0,270.0 L694.8,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="805.0" y="266" class="m" text-anchor="start">24.49</text>
+  <text x="805.0" y="266" class="m" fill="#4b5563" text-anchor="start">24.49</text>
   <path d="M694.8,275.0 L799.0,275.0 L792.0,277.0 L799.0,279.0 L792.0,281.0 L799.0,283.0 L792.0,285.0 L799.0,287.0 L694.8,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="805.0" y="283" class="m" text-anchor="start">45.12</text>
+  <text x="805.0" y="283" class="m" fill="#4b5563" text-anchor="start">45.12</text>
   <path d="M694.8,292.0 L799.0,292.0 L792.0,294.0 L799.0,296.0 L792.0,298.0 L799.0,300.0 L792.0,302.0 L799.0,304.0 L694.8,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="805.0" y="300" class="m" text-anchor="start">35.07</text>
+  <text x="805.0" y="300" class="m" fill="#4b5563" text-anchor="start">35.07</text>
   <path d="M694.8,309.0 L799.0,309.0 L792.0,311.0 L799.0,313.0 L792.0,315.0 L799.0,317.0 L792.0,319.0 L799.0,321.0 L694.8,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="805.0" y="317" class="m" text-anchor="start">110.30</text>
-  <text x="862" y="56" class="t" font-weight="600">peak memory</text>
-  <line x1="862.4" y1="74" x2="862.4" y2="324" class="ax"/>
-  <text x="862.4" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="901.4" y1="74" x2="901.4" y2="324" class="ax"/>
-  <text x="901.4" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="940.4" y1="74" x2="940.4" y2="324" class="ax"/>
-  <text x="940.4" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="979.4" y1="74" x2="979.4" y2="324" class="ax"/>
-  <text x="979.4" y="72" class="m" text-anchor="middle">1.5</text>
-  <line x1="940.4" y1="74" x2="940.4" y2="324" class="ref"/>
-  <line x1="862.4" y1="74" x2="862.4" y2="324" class="base"/>
+  <text x="805.0" y="317" class="m" fill="#4b5563" text-anchor="start">110.30</text>
+  <text x="862" y="56" class="t" fill="#1f2937" font-weight="600">peak memory</text>
+  <line x1="862.4" y1="74" x2="862.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="862.4" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="901.4" y1="74" x2="901.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="901.4" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="940.4" y1="74" x2="940.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="940.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="979.4" y1="74" x2="979.4" y2="324" class="ax" stroke="#e5e7eb"/>
+  <text x="979.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1.5</text>
+  <line x1="940.4" y1="74" x2="940.4" y2="324" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="862.4" y1="74" x2="862.4" y2="324" class="base" stroke="#9ca3af"/>
   <path d="M862.4,88.0 L937.9,88.0 Q940.4,88.0 940.4,90.5 L940.4,97.5 Q940.4,100.0 937.9,100.0 L862.4,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="946.4" y="96" class="m" text-anchor="start">1.00</text>
+  <text x="946.4" y="96" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M862.4,105.0 L935.2,105.0 Q937.7,105.0 937.7,107.5 L937.7,114.5 Q937.7,117.0 935.2,117.0 L862.4,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="943.7" y="113" class="m" text-anchor="start">0.97</text>
+  <text x="943.7" y="113" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M862.4,122.0 L955.6,122.0 Q958.1,122.0 958.1,124.5 L958.1,131.5 Q958.1,134.0 955.6,134.0 L862.4,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="964.1" y="130" class="m" text-anchor="start">1.23</text>
+  <text x="964.1" y="130" class="m" fill="#4b5563" text-anchor="start">1.23</text>
   <path d="M862.4,139.0 L941.3,139.0 Q943.8,139.0 943.8,141.5 L943.8,148.5 Q943.8,151.0 941.3,151.0 L862.4,151.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="949.8" y="147" class="m" text-anchor="start">1.04</text>
+  <text x="949.8" y="147" class="m" fill="#4b5563" text-anchor="start">1.04</text>
   <path d="M862.4,156.0 L949.2,156.0 Q951.7,156.0 951.7,158.5 L951.7,165.5 Q951.7,168.0 949.2,168.0 L862.4,168.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="957.7" y="164" class="m" text-anchor="start">1.14</text>
+  <text x="957.7" y="164" class="m" fill="#4b5563" text-anchor="start">1.14</text>
   <path d="M862.4,173.0 L952.2,173.0 Q954.7,173.0 954.7,175.5 L954.7,182.5 Q954.7,185.0 952.2,185.0 L862.4,185.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="960.7" y="181" class="m" text-anchor="start">1.18</text>
+  <text x="960.7" y="181" class="m" fill="#4b5563" text-anchor="start">1.18</text>
   <path d="M862.4,190.0 L953.9,190.0 Q956.4,190.0 956.4,192.5 L956.4,199.5 Q956.4,202.0 953.9,202.0 L862.4,202.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="962.4" y="198" class="m" text-anchor="start">1.21</text>
+  <text x="962.4" y="198" class="m" fill="#4b5563" text-anchor="start">1.21</text>
   <path d="M862.4,207.0 L959.9,207.0 Q962.4,207.0 962.4,209.5 L962.4,216.5 Q962.4,219.0 959.9,219.0 L862.4,219.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="968.4" y="215" class="m" text-anchor="start">1.28</text>
+  <text x="968.4" y="215" class="m" fill="#4b5563" text-anchor="start">1.28</text>
   <path d="M862.4,224.0 L946.7,224.0 Q949.2,224.0 949.2,226.5 L949.2,233.5 Q949.2,236.0 946.7,236.0 L862.4,236.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="955.2" y="232" class="m" text-anchor="start">1.11</text>
+  <text x="955.2" y="232" class="m" fill="#4b5563" text-anchor="start">1.11</text>
   <path d="M862.4,241.0 L953.6,241.0 Q956.1,241.0 956.1,243.5 L956.1,250.5 Q956.1,253.0 953.6,253.0 L862.4,253.0 Z" class="f-flat" fill="#2563c9" opacity="0.8"/>
-  <text x="962.1" y="249" class="m" text-anchor="start">1.20</text>
+  <text x="962.1" y="249" class="m" fill="#4b5563" text-anchor="start">1.20</text>
   <path d="M862.4,258.0 L937.1,258.0 Q939.6,258.0 939.6,260.5 L939.6,267.5 Q939.6,270.0 937.1,270.0 L862.4,270.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="945.6" y="266" class="m" text-anchor="start">0.99</text>
+  <text x="945.6" y="266" class="m" fill="#4b5563" text-anchor="start">0.99</text>
   <path d="M862.4,275.0 L940.9,275.0 Q943.4,275.0 943.4,277.5 L943.4,284.5 Q943.4,287.0 940.9,287.0 L862.4,287.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="949.4" y="283" class="m" text-anchor="start">1.04</text>
+  <text x="949.4" y="283" class="m" fill="#4b5563" text-anchor="start">1.04</text>
   <path d="M862.4,292.0 L937.4,292.0 Q939.9,292.0 939.9,294.5 L939.9,301.5 Q939.9,304.0 937.4,304.0 L862.4,304.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="945.9" y="300" class="m" text-anchor="start">0.99</text>
+  <text x="945.9" y="300" class="m" fill="#4b5563" text-anchor="start">0.99</text>
   <path d="M862.4,309.0 L932.9,309.0 Q935.4,309.0 935.4,311.5 L935.4,318.5 Q935.4,321.0 932.9,321.0 L862.4,321.0 Z" class="f-node" fill="#a53393" opacity="0.8"/>
-  <text x="941.4" y="317" class="m" text-anchor="start">0.94</text>
-  <text x="184.0" y="56" class="m" text-anchor="end">geomean</text>
-  <text x="146.0" y="96" class="t" text-anchor="end" font-weight='600'>unordered_dense 5.0</text>
-  <text x="184.0" y="96" class="m" text-anchor="end">1.00</text>
-  <text x="146.0" y="113" class="t" text-anchor="end">emhash8</text>
-  <text x="184.0" y="113" class="m" text-anchor="end">1.04</text>
-  <text x="146.0" y="130" class="t" text-anchor="end">F14Vector</text>
-  <text x="184.0" y="130" class="m" text-anchor="end">1.21</text>
-  <text x="146.0" y="147" class="t" text-anchor="end">emilib</text>
-  <text x="184.0" y="147" class="m" text-anchor="end">1.25</text>
-  <text x="146.0" y="164" class="t" text-anchor="end">unordered_dense 4.11</text>
-  <text x="184.0" y="164" class="m" text-anchor="end">1.29</text>
-  <text x="146.0" y="181" class="t" text-anchor="end">indivi flat_umap</text>
-  <text x="184.0" y="181" class="m" text-anchor="end">1.34</text>
-  <text x="146.0" y="198" class="t" text-anchor="end">boost flat</text>
-  <text x="184.0" y="198" class="m" text-anchor="end">1.38</text>
-  <text x="146.0" y="215" class="t" text-anchor="end">indivi flat_wmap</text>
-  <text x="184.0" y="215" class="m" text-anchor="end">1.48</text>
-  <text x="146.0" y="232" class="t" text-anchor="end">absl flat</text>
-  <text x="184.0" y="232" class="m" text-anchor="end">1.51</text>
-  <text x="146.0" y="249" class="t" text-anchor="end">F14Value</text>
-  <text x="184.0" y="249" class="m" text-anchor="end">1.65</text>
-  <text x="146.0" y="266" class="t" text-anchor="end">absl node</text>
-  <text x="184.0" y="266" class="m" text-anchor="end">2.80</text>
-  <text x="146.0" y="283" class="t" text-anchor="end">boost node</text>
-  <text x="184.0" y="283" class="m" text-anchor="end">3.04</text>
-  <text x="146.0" y="300" class="t" text-anchor="end">F14Node</text>
-  <text x="184.0" y="300" class="m" text-anchor="end">3.16</text>
-  <text x="146.0" y="317" class="t" text-anchor="end">std::unordered_map</text>
-  <text x="184.0" y="317" class="m" text-anchor="end">4.89</text>
+  <text x="941.4" y="317" class="m" fill="#4b5563" text-anchor="start">0.94</text>
+  <text x="184.0" y="56" class="m" fill="#4b5563" text-anchor="end">geomean</text>
+  <text x="146.0" y="96" class="t" fill="#1f2937" text-anchor="end" font-weight='600'>unordered_dense 5.0</text>
+  <text x="184.0" y="96" class="m" fill="#4b5563" text-anchor="end">1.00</text>
+  <text x="146.0" y="113" class="t" fill="#1f2937" text-anchor="end">emhash8</text>
+  <text x="184.0" y="113" class="m" fill="#4b5563" text-anchor="end">1.04</text>
+  <text x="146.0" y="130" class="t" fill="#1f2937" text-anchor="end">F14Vector</text>
+  <text x="184.0" y="130" class="m" fill="#4b5563" text-anchor="end">1.21</text>
+  <text x="146.0" y="147" class="t" fill="#1f2937" text-anchor="end">emilib</text>
+  <text x="184.0" y="147" class="m" fill="#4b5563" text-anchor="end">1.25</text>
+  <text x="146.0" y="164" class="t" fill="#1f2937" text-anchor="end">unordered_dense 4.11</text>
+  <text x="184.0" y="164" class="m" fill="#4b5563" text-anchor="end">1.29</text>
+  <text x="146.0" y="181" class="t" fill="#1f2937" text-anchor="end">indivi flat_umap</text>
+  <text x="184.0" y="181" class="m" fill="#4b5563" text-anchor="end">1.34</text>
+  <text x="146.0" y="198" class="t" fill="#1f2937" text-anchor="end">boost flat</text>
+  <text x="184.0" y="198" class="m" fill="#4b5563" text-anchor="end">1.38</text>
+  <text x="146.0" y="215" class="t" fill="#1f2937" text-anchor="end">indivi flat_wmap</text>
+  <text x="184.0" y="215" class="m" fill="#4b5563" text-anchor="end">1.48</text>
+  <text x="146.0" y="232" class="t" fill="#1f2937" text-anchor="end">absl flat</text>
+  <text x="184.0" y="232" class="m" fill="#4b5563" text-anchor="end">1.51</text>
+  <text x="146.0" y="249" class="t" fill="#1f2937" text-anchor="end">F14Value</text>
+  <text x="184.0" y="249" class="m" fill="#4b5563" text-anchor="end">1.65</text>
+  <text x="146.0" y="266" class="t" fill="#1f2937" text-anchor="end">absl node</text>
+  <text x="184.0" y="266" class="m" fill="#4b5563" text-anchor="end">2.80</text>
+  <text x="146.0" y="283" class="t" fill="#1f2937" text-anchor="end">boost node</text>
+  <text x="184.0" y="283" class="m" fill="#4b5563" text-anchor="end">3.04</text>
+  <text x="146.0" y="300" class="t" fill="#1f2937" text-anchor="end">F14Node</text>
+  <text x="184.0" y="300" class="m" fill="#4b5563" text-anchor="end">3.16</text>
+  <text x="146.0" y="317" class="t" fill="#1f2937" text-anchor="end">std::unordered_map</text>
+  <text x="184.0" y="317" class="m" fill="#4b5563" text-anchor="end">4.89</text>
   <rect x="192.0" y="341" width="11" height="11" class="f-flat" fill="#2563c9" opacity="0.85"/>
-  <text x="208.0" y="350" class="m">flat</text>
+  <text x="208.0" y="350" class="m" fill="#4b5563">flat</text>
   <rect x="266.0" y="341" width="11" height="11" class="f-dense" fill="#0e8f60" opacity="0.85"/>
-  <text x="282.0" y="350" class="m">dense</text>
+  <text x="282.0" y="350" class="m" fill="#4b5563">dense</text>
   <rect x="340.0" y="341" width="11" height="11" class="f-node" fill="#a53393" opacity="0.85"/>
-  <text x="356.0" y="350" class="m">node</text>
-  <text x="424.0" y="350" class="m">relative to unordered_dense 5.0: time for the first four panels, peak bytes per entry for the last</text>
+  <text x="356.0" y="350" class="m" fill="#4b5563">node</text>
+  <text x="424.0" y="350" class="m" fill="#4b5563">relative to unordered_dense 5.0: time for the first four panels, peak bytes per entry for the last</text>
 </svg>

--- a/doc/bench-readme-udm-str.svg
+++ b/doc/bench-readme-udm-str.svg
@@ -16,132 +16,132 @@
       .f-flat{fill:#5b9bf0}.f-dense{fill:#3cc492}.f-node{fill:#e070cd}
     }
   </style>
-  <rect class="surface" width="1030" height="212"/>
-  <text x="8" y="20" class="hd">relative to unordered_dense 5.0, std::string keys, what this map itself can be asked to be</text>
-  <text x="8" y="38" class="sub">geometric mean over one octave from 1,000,000 entries; lower is better, and 1.00 is level with unordered_dense 5.0. Rows are sorted by the geomean of all five panels; a bar torn off at the right ran past the axis.</text>
-  <text x="274" y="56" class="t" font-weight="600">build + destroy</text>
-  <line x1="273.6" y1="74" x2="273.6" y2="154" class="ax"/>
-  <text x="273.6" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="293.7" y1="74" x2="293.7" y2="154" class="ax"/>
-  <text x="293.7" y="72" class="m" text-anchor="middle">0.25</text>
-  <line x1="313.9" y1="74" x2="313.9" y2="154" class="ax"/>
-  <text x="313.9" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="334.0" y1="74" x2="334.0" y2="154" class="ax"/>
-  <text x="334.0" y="72" class="m" text-anchor="middle">0.75</text>
-  <line x1="354.1" y1="74" x2="354.1" y2="154" class="ax"/>
-  <text x="354.1" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="374.3" y1="74" x2="374.3" y2="154" class="ax"/>
-  <text x="374.3" y="72" class="m" text-anchor="middle">1.25</text>
-  <line x1="354.1" y1="74" x2="354.1" y2="154" class="ref"/>
-  <line x1="273.6" y1="74" x2="273.6" y2="154" class="base"/>
+  <rect class="surface" fill="#ffffff" width="1030" height="212"/>
+  <text x="8" y="20" class="hd" fill="#111827">relative to unordered_dense 5.0, std::string keys, what this map itself can be asked to be</text>
+  <text x="8" y="38" class="sub" fill="#4b5563">geometric mean over one octave from 1,000,000 entries; lower is better, and 1.00 is level with unordered_dense 5.0. Rows are sorted by the geomean of all five panels; a bar torn off at the right ran past the axis.</text>
+  <text x="274" y="56" class="t" fill="#1f2937" font-weight="600">build + destroy</text>
+  <line x1="273.6" y1="74" x2="273.6" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="273.6" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="293.7" y1="74" x2="293.7" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="293.7" y="72" class="m" fill="#4b5563" text-anchor="middle">0.25</text>
+  <line x1="313.9" y1="74" x2="313.9" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="313.9" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="334.0" y1="74" x2="334.0" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="334.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0.75</text>
+  <line x1="354.1" y1="74" x2="354.1" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="354.1" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="374.3" y1="74" x2="374.3" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="374.3" y="72" class="m" fill="#4b5563" text-anchor="middle">1.25</text>
+  <line x1="354.1" y1="74" x2="354.1" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="273.6" y1="74" x2="273.6" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M273.6,88.0 L322.1,88.0 Q324.6,88.0 324.6,90.5 L324.6,97.5 Q324.6,100.0 322.1,100.0 L273.6,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="330.6" y="96" class="m" text-anchor="start">0.63</text>
+  <text x="330.6" y="96" class="m" fill="#4b5563" text-anchor="start">0.63</text>
   <path d="M273.6,105.0 L328.4,105.0 Q330.9,105.0 330.9,107.5 L330.9,114.5 Q330.9,117.0 328.4,117.0 L273.6,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="336.9" y="113" class="m" text-anchor="start">0.71</text>
+  <text x="336.9" y="113" class="m" fill="#4b5563" text-anchor="start">0.71</text>
   <path d="M273.6,122.0 L351.6,122.0 Q354.1,122.0 354.1,124.5 L354.1,131.5 Q354.1,134.0 351.6,134.0 L273.6,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="360.1" y="130" class="m" text-anchor="start">1.00</text>
+  <text x="360.1" y="130" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M273.6,139.0 L350.8,139.0 Q353.3,139.0 353.3,141.5 L353.3,148.5 Q353.3,151.0 350.8,151.0 L273.6,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="359.3" y="147" class="m" text-anchor="start">0.99</text>
-  <text x="425" y="56" class="t" font-weight="600">find, 50% hits</text>
-  <line x1="424.9" y1="74" x2="424.9" y2="154" class="ax"/>
-  <text x="424.9" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="445.0" y1="74" x2="445.0" y2="154" class="ax"/>
-  <text x="445.0" y="72" class="m" text-anchor="middle">0.25</text>
-  <line x1="465.2" y1="74" x2="465.2" y2="154" class="ax"/>
-  <text x="465.2" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="485.3" y1="74" x2="485.3" y2="154" class="ax"/>
-  <text x="485.3" y="72" class="m" text-anchor="middle">0.75</text>
-  <line x1="505.4" y1="74" x2="505.4" y2="154" class="ax"/>
-  <text x="505.4" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="525.6" y1="74" x2="525.6" y2="154" class="ax"/>
-  <text x="525.6" y="72" class="m" text-anchor="middle">1.25</text>
-  <line x1="505.4" y1="74" x2="505.4" y2="154" class="ref"/>
-  <line x1="424.9" y1="74" x2="424.9" y2="154" class="base"/>
+  <text x="359.3" y="147" class="m" fill="#4b5563" text-anchor="start">0.99</text>
+  <text x="425" y="56" class="t" fill="#1f2937" font-weight="600">find, 50% hits</text>
+  <line x1="424.9" y1="74" x2="424.9" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="424.9" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="445.0" y1="74" x2="445.0" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="445.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0.25</text>
+  <line x1="465.2" y1="74" x2="465.2" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="465.2" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="485.3" y1="74" x2="485.3" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="485.3" y="72" class="m" fill="#4b5563" text-anchor="middle">0.75</text>
+  <line x1="505.4" y1="74" x2="505.4" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="505.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="525.6" y1="74" x2="525.6" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="525.6" y="72" class="m" fill="#4b5563" text-anchor="middle">1.25</text>
+  <line x1="505.4" y1="74" x2="505.4" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="424.9" y1="74" x2="424.9" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M424.9,88.0 L500.3,88.0 Q502.8,88.0 502.8,90.5 L502.8,97.5 Q502.8,100.0 500.3,100.0 L424.9,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="508.8" y="96" class="m" text-anchor="start">0.97</text>
+  <text x="508.8" y="96" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M424.9,105.0 L500.2,105.0 Q502.7,105.0 502.7,107.5 L502.7,114.5 Q502.7,117.0 500.2,117.0 L424.9,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="508.7" y="113" class="m" text-anchor="start">0.97</text>
+  <text x="508.7" y="113" class="m" fill="#4b5563" text-anchor="start">0.97</text>
   <path d="M424.9,122.0 L502.9,122.0 Q505.4,122.0 505.4,124.5 L505.4,131.5 Q505.4,134.0 502.9,134.0 L424.9,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="511.4" y="130" class="m" text-anchor="start">1.00</text>
+  <text x="511.4" y="130" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M424.9,139.0 L503.2,139.0 Q505.7,139.0 505.7,141.5 L505.7,148.5 Q505.7,151.0 503.2,151.0 L424.9,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="511.7" y="147" class="m" text-anchor="start">1.00</text>
-  <text x="576" y="56" class="t" font-weight="600">churn</text>
-  <line x1="576.2" y1="74" x2="576.2" y2="154" class="ax"/>
-  <text x="576.2" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="596.3" y1="74" x2="596.3" y2="154" class="ax"/>
-  <text x="596.3" y="72" class="m" text-anchor="middle">0.25</text>
-  <line x1="616.4" y1="74" x2="616.4" y2="154" class="ax"/>
-  <text x="616.4" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="636.6" y1="74" x2="636.6" y2="154" class="ax"/>
-  <text x="636.6" y="72" class="m" text-anchor="middle">0.75</text>
-  <line x1="656.7" y1="74" x2="656.7" y2="154" class="ax"/>
-  <text x="656.7" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="676.8" y1="74" x2="676.8" y2="154" class="ax"/>
-  <text x="676.8" y="72" class="m" text-anchor="middle">1.25</text>
-  <line x1="656.7" y1="74" x2="656.7" y2="154" class="ref"/>
-  <line x1="576.2" y1="74" x2="576.2" y2="154" class="base"/>
+  <text x="511.7" y="147" class="m" fill="#4b5563" text-anchor="start">1.00</text>
+  <text x="576" y="56" class="t" fill="#1f2937" font-weight="600">churn</text>
+  <line x1="576.2" y1="74" x2="576.2" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="576.2" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="596.3" y1="74" x2="596.3" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="596.3" y="72" class="m" fill="#4b5563" text-anchor="middle">0.25</text>
+  <line x1="616.4" y1="74" x2="616.4" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="616.4" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="636.6" y1="74" x2="636.6" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="636.6" y="72" class="m" fill="#4b5563" text-anchor="middle">0.75</text>
+  <line x1="656.7" y1="74" x2="656.7" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="656.7" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="676.8" y1="74" x2="676.8" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="676.8" y="72" class="m" fill="#4b5563" text-anchor="middle">1.25</text>
+  <line x1="656.7" y1="74" x2="656.7" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="576.2" y1="74" x2="576.2" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M576.2,88.0 L651.3,88.0 Q653.8,88.0 653.8,90.5 L653.8,97.5 Q653.8,100.0 651.3,100.0 L576.2,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="659.8" y="96" class="m" text-anchor="start">0.96</text>
+  <text x="659.8" y="96" class="m" fill="#4b5563" text-anchor="start">0.96</text>
   <path d="M576.2,105.0 L650.5,105.0 Q653.0,105.0 653.0,107.5 L653.0,114.5 Q653.0,117.0 650.5,117.0 L576.2,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="659.0" y="113" class="m" text-anchor="start">0.95</text>
+  <text x="659.0" y="113" class="m" fill="#4b5563" text-anchor="start">0.95</text>
   <path d="M576.2,122.0 L654.2,122.0 Q656.7,122.0 656.7,124.5 L656.7,131.5 Q656.7,134.0 654.2,134.0 L576.2,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="662.7" y="130" class="m" text-anchor="start">1.00</text>
+  <text x="662.7" y="130" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M576.2,139.0 L657.0,139.0 Q659.5,139.0 659.5,141.5 L659.5,148.5 Q659.5,151.0 657.0,151.0 L576.2,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="665.5" y="147" class="m" text-anchor="start">1.03</text>
-  <text x="727" y="56" class="t" font-weight="600">iterate</text>
-  <line x1="727.4" y1="74" x2="727.4" y2="154" class="ax"/>
-  <text x="727.4" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="752.6" y1="74" x2="752.6" y2="154" class="ax"/>
-  <text x="752.6" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="777.8" y1="74" x2="777.8" y2="154" class="ax"/>
-  <text x="777.8" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="803.0" y1="74" x2="803.0" y2="154" class="ax"/>
-  <text x="803.0" y="72" class="m" text-anchor="middle">3</text>
-  <line x1="828.1" y1="74" x2="828.1" y2="154" class="ax"/>
-  <text x="828.1" y="72" class="m" text-anchor="middle">4</text>
-  <line x1="752.6" y1="74" x2="752.6" y2="154" class="ref"/>
-  <line x1="727.4" y1="74" x2="727.4" y2="154" class="base"/>
+  <text x="665.5" y="147" class="m" fill="#4b5563" text-anchor="start">1.03</text>
+  <text x="727" y="56" class="t" fill="#1f2937" font-weight="600">iterate</text>
+  <line x1="727.4" y1="74" x2="727.4" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="727.4" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="752.6" y1="74" x2="752.6" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="752.6" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="777.8" y1="74" x2="777.8" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="777.8" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="803.0" y1="74" x2="803.0" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="803.0" y="72" class="m" fill="#4b5563" text-anchor="middle">3</text>
+  <line x1="828.1" y1="74" x2="828.1" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="828.1" y="72" class="m" fill="#4b5563" text-anchor="middle">4</text>
+  <line x1="752.6" y1="74" x2="752.6" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="727.4" y1="74" x2="727.4" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M727.4,88.0 L751.4,88.0 Q753.9,88.0 753.9,90.5 L753.9,97.5 Q753.9,100.0 751.4,100.0 L727.4,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="759.9" y="96" class="m" text-anchor="start">1.05</text>
+  <text x="759.9" y="96" class="m" fill="#4b5563" text-anchor="start">1.05</text>
   <path d="M727.4,105.0 L750.1,105.0 Q752.6,105.0 752.6,107.5 L752.6,114.5 Q752.6,117.0 750.1,117.0 L727.4,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="758.6" y="113" class="m" text-anchor="start">1.00</text>
+  <text x="758.6" y="113" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M727.4,122.0 L750.1,122.0 Q752.6,122.0 752.6,124.5 L752.6,131.5 Q752.6,134.0 750.1,134.0 L727.4,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="758.6" y="130" class="m" text-anchor="start">1.00</text>
+  <text x="758.6" y="130" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M727.4,139.0 L812.6,139.0 Q815.1,139.0 815.1,141.5 L815.1,148.5 Q815.1,151.0 812.6,151.0 L727.4,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="821.1" y="147" class="m" text-anchor="start">3.48</text>
-  <text x="879" y="56" class="t" font-weight="600">peak memory</text>
-  <line x1="878.7" y1="74" x2="878.7" y2="154" class="ax"/>
-  <text x="878.7" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="898.9" y1="74" x2="898.9" y2="154" class="ax"/>
-  <text x="898.9" y="72" class="m" text-anchor="middle">0.25</text>
-  <line x1="919.0" y1="74" x2="919.0" y2="154" class="ax"/>
-  <text x="919.0" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="939.1" y1="74" x2="939.1" y2="154" class="ax"/>
-  <text x="939.1" y="72" class="m" text-anchor="middle">0.75</text>
-  <line x1="959.3" y1="74" x2="959.3" y2="154" class="ax"/>
-  <text x="959.3" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="979.4" y1="74" x2="979.4" y2="154" class="ax"/>
-  <text x="979.4" y="72" class="m" text-anchor="middle">1.25</text>
-  <line x1="959.3" y1="74" x2="959.3" y2="154" class="ref"/>
-  <line x1="878.7" y1="74" x2="878.7" y2="154" class="base"/>
+  <text x="821.1" y="147" class="m" fill="#4b5563" text-anchor="start">3.48</text>
+  <text x="879" y="56" class="t" fill="#1f2937" font-weight="600">peak memory</text>
+  <line x1="878.7" y1="74" x2="878.7" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="878.7" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="898.9" y1="74" x2="898.9" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="898.9" y="72" class="m" fill="#4b5563" text-anchor="middle">0.25</text>
+  <line x1="919.0" y1="74" x2="919.0" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="919.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="939.1" y1="74" x2="939.1" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="939.1" y="72" class="m" fill="#4b5563" text-anchor="middle">0.75</text>
+  <line x1="959.3" y1="74" x2="959.3" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="959.3" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="979.4" y1="74" x2="979.4" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="979.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1.25</text>
+  <line x1="959.3" y1="74" x2="959.3" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="878.7" y1="74" x2="878.7" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M878.7,88.0 L949.8,88.0 Q952.3,88.0 952.3,90.5 L952.3,97.5 Q952.3,100.0 949.8,100.0 L878.7,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="958.3" y="96" class="m" text-anchor="start">0.91</text>
+  <text x="958.3" y="96" class="m" fill="#4b5563" text-anchor="start">0.91</text>
   <path d="M878.7,105.0 L954.9,105.0 Q957.4,105.0 957.4,107.5 L957.4,114.5 Q957.4,117.0 954.9,117.0 L878.7,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="963.4" y="113" class="m" text-anchor="start">0.98</text>
+  <text x="963.4" y="113" class="m" fill="#4b5563" text-anchor="start">0.98</text>
   <path d="M878.7,122.0 L956.8,122.0 Q959.3,122.0 959.3,124.5 L959.3,131.5 Q959.3,134.0 956.8,134.0 L878.7,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="965.3" y="130" class="m" text-anchor="start">1.00</text>
+  <text x="965.3" y="130" class="m" fill="#4b5563" text-anchor="start">1.00</text>
   <path d="M878.7,139.0 L948.8,139.0 Q951.3,139.0 951.3,141.5 L951.3,148.5 Q951.3,151.0 948.8,151.0 L878.7,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="957.3" y="147" class="m" text-anchor="start">0.90</text>
-  <text x="265.6" y="56" class="m" text-anchor="end">geomean</text>
-  <text x="227.60000000000002" y="96" class="t" text-anchor="end">unordered_dense segmented + huge</text>
-  <text x="265.6" y="96" class="m" text-anchor="end">0.89</text>
-  <text x="227.60000000000002" y="113" class="t" text-anchor="end">unordered_dense, huge pages</text>
-  <text x="265.6" y="113" class="m" text-anchor="end">0.91</text>
-  <text x="227.60000000000002" y="130" class="t" text-anchor="end" font-weight='600'>unordered_dense 5.0</text>
-  <text x="265.6" y="130" class="m" text-anchor="end">1.00</text>
-  <text x="227.60000000000002" y="147" class="t" text-anchor="end">unordered_dense segmented</text>
-  <text x="265.6" y="147" class="m" text-anchor="end">1.26</text>
+  <text x="957.3" y="147" class="m" fill="#4b5563" text-anchor="start">0.90</text>
+  <text x="265.6" y="56" class="m" fill="#4b5563" text-anchor="end">geomean</text>
+  <text x="227.60000000000002" y="96" class="t" fill="#1f2937" text-anchor="end">unordered_dense segmented + huge</text>
+  <text x="265.6" y="96" class="m" fill="#4b5563" text-anchor="end">0.89</text>
+  <text x="227.60000000000002" y="113" class="t" fill="#1f2937" text-anchor="end">unordered_dense, huge pages</text>
+  <text x="265.6" y="113" class="m" fill="#4b5563" text-anchor="end">0.91</text>
+  <text x="227.60000000000002" y="130" class="t" fill="#1f2937" text-anchor="end" font-weight='600'>unordered_dense 5.0</text>
+  <text x="265.6" y="130" class="m" fill="#4b5563" text-anchor="end">1.00</text>
+  <text x="227.60000000000002" y="147" class="t" fill="#1f2937" text-anchor="end">unordered_dense segmented</text>
+  <text x="265.6" y="147" class="m" fill="#4b5563" text-anchor="end">1.26</text>
   <rect x="273.6" y="171" width="11" height="11" class="f-dense" fill="#0e8f60" opacity="0.85"/>
-  <text x="289.6" y="180" class="m">dense</text>
-  <text x="357.6" y="180" class="m">relative to unordered_dense 5.0: time for the first four panels, peak bytes per entry for the last</text>
+  <text x="289.6" y="180" class="m" fill="#4b5563">dense</text>
+  <text x="357.6" y="180" class="m" fill="#4b5563">relative to unordered_dense 5.0: time for the first four panels, peak bytes per entry for the last</text>
 </svg>

--- a/doc/bench-readme-udm-u64.svg
+++ b/doc/bench-readme-udm-u64.svg
@@ -16,132 +16,132 @@
       .f-flat{fill:#5b9bf0}.f-dense{fill:#3cc492}.f-node{fill:#e070cd}
     }
   </style>
-  <rect class="surface" width="1030" height="212"/>
-  <text x="8" y="20" class="hd">relative to unordered_dense 5.0, uint64_t keys, what this map itself can be asked to be</text>
-  <text x="8" y="38" class="sub">geometric mean over one octave from 1,000,000 entries; lower is better, and 1.00 is level with unordered_dense 5.0. Rows are sorted by the geomean of all five panels; a bar torn off at the right ran past the axis.</text>
-  <text x="274" y="56" class="t" font-weight="600">build + destroy</text>
-  <line x1="273.6" y1="74" x2="273.6" y2="154" class="ax"/>
-  <text x="273.6" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="293.7" y1="74" x2="293.7" y2="154" class="ax"/>
-  <text x="293.7" y="72" class="m" text-anchor="middle">0.25</text>
-  <line x1="313.9" y1="74" x2="313.9" y2="154" class="ax"/>
-  <text x="313.9" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="334.0" y1="74" x2="334.0" y2="154" class="ax"/>
-  <text x="334.0" y="72" class="m" text-anchor="middle">0.75</text>
-  <line x1="354.1" y1="74" x2="354.1" y2="154" class="ax"/>
-  <text x="354.1" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="374.3" y1="74" x2="374.3" y2="154" class="ax"/>
-  <text x="374.3" y="72" class="m" text-anchor="middle">1.25</text>
-  <line x1="354.1" y1="74" x2="354.1" y2="154" class="ref"/>
-  <line x1="273.6" y1="74" x2="273.6" y2="154" class="base"/>
+  <rect class="surface" fill="#ffffff" width="1030" height="212"/>
+  <text x="8" y="20" class="hd" fill="#111827">relative to unordered_dense 5.0, uint64_t keys, what this map itself can be asked to be</text>
+  <text x="8" y="38" class="sub" fill="#4b5563">geometric mean over one octave from 1,000,000 entries; lower is better, and 1.00 is level with unordered_dense 5.0. Rows are sorted by the geomean of all five panels; a bar torn off at the right ran past the axis.</text>
+  <text x="274" y="56" class="t" fill="#1f2937" font-weight="600">build + destroy</text>
+  <line x1="273.6" y1="74" x2="273.6" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="273.6" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="293.7" y1="74" x2="293.7" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="293.7" y="72" class="m" fill="#4b5563" text-anchor="middle">0.25</text>
+  <line x1="313.9" y1="74" x2="313.9" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="313.9" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="334.0" y1="74" x2="334.0" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="334.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0.75</text>
+  <line x1="354.1" y1="74" x2="354.1" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="354.1" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="374.3" y1="74" x2="374.3" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="374.3" y="72" class="m" fill="#4b5563" text-anchor="middle">1.25</text>
+  <line x1="354.1" y1="74" x2="354.1" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="273.6" y1="74" x2="273.6" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M273.6,88.0 L319.8,88.0 Q322.3,88.0 322.3,90.5 L322.3,97.5 Q322.3,100.0 319.8,100.0 L273.6,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="328.3" y="96" class="m" text-anchor="start">0.60</text>
+  <text x="328.3" y="96" class="m" fill="#4b5563" text-anchor="start">0.60</text>
   <path d="M273.6,105.0 L317.2,105.0 Q319.7,105.0 319.7,107.5 L319.7,114.5 Q319.7,117.0 317.2,117.0 L273.6,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="325.7" y="113" class="m" text-anchor="start">0.57</text>
+  <text x="325.7" y="113" class="m" fill="#4b5563" text-anchor="start">0.57</text>
   <path d="M273.6,122.0 L322.4,122.0 Q324.9,122.0 324.9,124.5 L324.9,131.5 Q324.9,134.0 322.4,134.0 L273.6,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="330.9" y="130" class="m" text-anchor="start">0.64</text>
+  <text x="330.9" y="130" class="m" fill="#4b5563" text-anchor="start">0.64</text>
   <path d="M273.6,139.0 L351.6,139.0 Q354.1,139.0 354.1,141.5 L354.1,148.5 Q354.1,151.0 351.6,151.0 L273.6,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="360.1" y="147" class="m" text-anchor="start">1.00</text>
-  <text x="425" y="56" class="t" font-weight="600">find, 50% hits</text>
-  <line x1="424.9" y1="74" x2="424.9" y2="154" class="ax"/>
-  <text x="424.9" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="445.0" y1="74" x2="445.0" y2="154" class="ax"/>
-  <text x="445.0" y="72" class="m" text-anchor="middle">0.25</text>
-  <line x1="465.2" y1="74" x2="465.2" y2="154" class="ax"/>
-  <text x="465.2" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="485.3" y1="74" x2="485.3" y2="154" class="ax"/>
-  <text x="485.3" y="72" class="m" text-anchor="middle">0.75</text>
-  <line x1="505.4" y1="74" x2="505.4" y2="154" class="ax"/>
-  <text x="505.4" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="525.6" y1="74" x2="525.6" y2="154" class="ax"/>
-  <text x="525.6" y="72" class="m" text-anchor="middle">1.25</text>
-  <line x1="505.4" y1="74" x2="505.4" y2="154" class="ref"/>
-  <line x1="424.9" y1="74" x2="424.9" y2="154" class="base"/>
+  <text x="360.1" y="147" class="m" fill="#4b5563" text-anchor="start">1.00</text>
+  <text x="425" y="56" class="t" fill="#1f2937" font-weight="600">find, 50% hits</text>
+  <line x1="424.9" y1="74" x2="424.9" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="424.9" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="445.0" y1="74" x2="445.0" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="445.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0.25</text>
+  <line x1="465.2" y1="74" x2="465.2" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="465.2" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="485.3" y1="74" x2="485.3" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="485.3" y="72" class="m" fill="#4b5563" text-anchor="middle">0.75</text>
+  <line x1="505.4" y1="74" x2="505.4" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="505.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="525.6" y1="74" x2="525.6" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="525.6" y="72" class="m" fill="#4b5563" text-anchor="middle">1.25</text>
+  <line x1="505.4" y1="74" x2="505.4" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="424.9" y1="74" x2="424.9" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M424.9,88.0 L496.0,88.0 Q498.5,88.0 498.5,90.5 L498.5,97.5 Q498.5,100.0 496.0,100.0 L424.9,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="504.5" y="96" class="m" text-anchor="start">0.91</text>
+  <text x="504.5" y="96" class="m" fill="#4b5563" text-anchor="start">0.91</text>
   <path d="M424.9,105.0 L498.4,105.0 Q500.9,105.0 500.9,107.5 L500.9,114.5 Q500.9,117.0 498.4,117.0 L424.9,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="506.9" y="113" class="m" text-anchor="start">0.94</text>
+  <text x="506.9" y="113" class="m" fill="#4b5563" text-anchor="start">0.94</text>
   <path d="M424.9,122.0 L506.9,122.0 Q509.4,122.0 509.4,124.5 L509.4,131.5 Q509.4,134.0 506.9,134.0 L424.9,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="515.4" y="130" class="m" text-anchor="start">1.05</text>
+  <text x="515.4" y="130" class="m" fill="#4b5563" text-anchor="start">1.05</text>
   <path d="M424.9,139.0 L502.9,139.0 Q505.4,139.0 505.4,141.5 L505.4,148.5 Q505.4,151.0 502.9,151.0 L424.9,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="511.4" y="147" class="m" text-anchor="start">1.00</text>
-  <text x="576" y="56" class="t" font-weight="600">churn</text>
-  <line x1="576.2" y1="74" x2="576.2" y2="154" class="ax"/>
-  <text x="576.2" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="596.3" y1="74" x2="596.3" y2="154" class="ax"/>
-  <text x="596.3" y="72" class="m" text-anchor="middle">0.25</text>
-  <line x1="616.4" y1="74" x2="616.4" y2="154" class="ax"/>
-  <text x="616.4" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="636.6" y1="74" x2="636.6" y2="154" class="ax"/>
-  <text x="636.6" y="72" class="m" text-anchor="middle">0.75</text>
-  <line x1="656.7" y1="74" x2="656.7" y2="154" class="ax"/>
-  <text x="656.7" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="676.8" y1="74" x2="676.8" y2="154" class="ax"/>
-  <text x="676.8" y="72" class="m" text-anchor="middle">1.25</text>
-  <line x1="656.7" y1="74" x2="656.7" y2="154" class="ref"/>
-  <line x1="576.2" y1="74" x2="576.2" y2="154" class="base"/>
+  <text x="511.4" y="147" class="m" fill="#4b5563" text-anchor="start">1.00</text>
+  <text x="576" y="56" class="t" fill="#1f2937" font-weight="600">churn</text>
+  <line x1="576.2" y1="74" x2="576.2" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="576.2" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="596.3" y1="74" x2="596.3" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="596.3" y="72" class="m" fill="#4b5563" text-anchor="middle">0.25</text>
+  <line x1="616.4" y1="74" x2="616.4" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="616.4" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="636.6" y1="74" x2="636.6" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="636.6" y="72" class="m" fill="#4b5563" text-anchor="middle">0.75</text>
+  <line x1="656.7" y1="74" x2="656.7" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="656.7" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="676.8" y1="74" x2="676.8" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="676.8" y="72" class="m" fill="#4b5563" text-anchor="middle">1.25</text>
+  <line x1="656.7" y1="74" x2="656.7" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="576.2" y1="74" x2="576.2" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M576.2,88.0 L637.1,88.0 Q639.6,88.0 639.6,90.5 L639.6,97.5 Q639.6,100.0 637.1,100.0 L576.2,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="645.6" y="96" class="m" text-anchor="start">0.79</text>
+  <text x="645.6" y="96" class="m" fill="#4b5563" text-anchor="start">0.79</text>
   <path d="M576.2,105.0 L650.0,105.0 Q652.5,105.0 652.5,107.5 L652.5,114.5 Q652.5,117.0 650.0,117.0 L576.2,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="658.5" y="113" class="m" text-anchor="start">0.95</text>
+  <text x="658.5" y="113" class="m" fill="#4b5563" text-anchor="start">0.95</text>
   <path d="M576.2,122.0 L665.0,122.0 Q667.5,122.0 667.5,124.5 L667.5,131.5 Q667.5,134.0 665.0,134.0 L576.2,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="673.5" y="130" class="m" text-anchor="start">1.13</text>
+  <text x="673.5" y="130" class="m" fill="#4b5563" text-anchor="start">1.13</text>
   <path d="M576.2,139.0 L654.2,139.0 Q656.7,139.0 656.7,141.5 L656.7,148.5 Q656.7,151.0 654.2,151.0 L576.2,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="662.7" y="147" class="m" text-anchor="start">1.00</text>
-  <text x="727" y="56" class="t" font-weight="600">iterate</text>
-  <line x1="727.4" y1="74" x2="727.4" y2="154" class="ax"/>
-  <text x="727.4" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="752.6" y1="74" x2="752.6" y2="154" class="ax"/>
-  <text x="752.6" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="777.8" y1="74" x2="777.8" y2="154" class="ax"/>
-  <text x="777.8" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="803.0" y1="74" x2="803.0" y2="154" class="ax"/>
-  <text x="803.0" y="72" class="m" text-anchor="middle">1.5</text>
-  <line x1="828.1" y1="74" x2="828.1" y2="154" class="ax"/>
-  <text x="828.1" y="72" class="m" text-anchor="middle">2</text>
-  <line x1="777.8" y1="74" x2="777.8" y2="154" class="ref"/>
-  <line x1="727.4" y1="74" x2="727.4" y2="154" class="base"/>
+  <text x="662.7" y="147" class="m" fill="#4b5563" text-anchor="start">1.00</text>
+  <text x="727" y="56" class="t" fill="#1f2937" font-weight="600">iterate</text>
+  <line x1="727.4" y1="74" x2="727.4" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="727.4" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="752.6" y1="74" x2="752.6" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="752.6" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="777.8" y1="74" x2="777.8" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="777.8" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="803.0" y1="74" x2="803.0" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="803.0" y="72" class="m" fill="#4b5563" text-anchor="middle">1.5</text>
+  <line x1="828.1" y1="74" x2="828.1" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="828.1" y="72" class="m" fill="#4b5563" text-anchor="middle">2</text>
+  <line x1="777.8" y1="74" x2="777.8" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="727.4" y1="74" x2="727.4" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M727.4,88.0 L767.4,88.0 Q769.9,88.0 769.9,90.5 L769.9,97.5 Q769.9,100.0 767.4,100.0 L727.4,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="775.9" y="96" class="m" text-anchor="start">0.84</text>
+  <text x="775.9" y="96" class="m" fill="#4b5563" text-anchor="start">0.84</text>
   <path d="M727.4,105.0 L794.2,105.0 Q796.7,105.0 796.7,107.5 L796.7,114.5 Q796.7,117.0 794.2,117.0 L727.4,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="802.7" y="113" class="m" text-anchor="start">1.38</text>
+  <text x="802.7" y="113" class="m" fill="#4b5563" text-anchor="start">1.38</text>
   <path d="M727.4,122.0 L802.3,122.0 Q804.8,122.0 804.8,124.5 L804.8,131.5 Q804.8,134.0 802.3,134.0 L727.4,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="810.8" y="130" class="m" text-anchor="start">1.54</text>
+  <text x="810.8" y="130" class="m" fill="#4b5563" text-anchor="start">1.54</text>
   <path d="M727.4,139.0 L775.3,139.0 Q777.8,139.0 777.8,141.5 L777.8,148.5 Q777.8,151.0 775.3,151.0 L727.4,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="783.8" y="147" class="m" text-anchor="start">1.00</text>
-  <text x="879" y="56" class="t" font-weight="600">peak memory</text>
-  <line x1="878.7" y1="74" x2="878.7" y2="154" class="ax"/>
-  <text x="878.7" y="72" class="m" text-anchor="middle">0</text>
-  <line x1="898.9" y1="74" x2="898.9" y2="154" class="ax"/>
-  <text x="898.9" y="72" class="m" text-anchor="middle">0.25</text>
-  <line x1="919.0" y1="74" x2="919.0" y2="154" class="ax"/>
-  <text x="919.0" y="72" class="m" text-anchor="middle">0.5</text>
-  <line x1="939.1" y1="74" x2="939.1" y2="154" class="ax"/>
-  <text x="939.1" y="72" class="m" text-anchor="middle">0.75</text>
-  <line x1="959.3" y1="74" x2="959.3" y2="154" class="ax"/>
-  <text x="959.3" y="72" class="m" text-anchor="middle">1</text>
-  <line x1="979.4" y1="74" x2="979.4" y2="154" class="ax"/>
-  <text x="979.4" y="72" class="m" text-anchor="middle">1.25</text>
-  <line x1="959.3" y1="74" x2="959.3" y2="154" class="ref"/>
-  <line x1="878.7" y1="74" x2="878.7" y2="154" class="base"/>
+  <text x="783.8" y="147" class="m" fill="#4b5563" text-anchor="start">1.00</text>
+  <text x="879" y="56" class="t" fill="#1f2937" font-weight="600">peak memory</text>
+  <line x1="878.7" y1="74" x2="878.7" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="878.7" y="72" class="m" fill="#4b5563" text-anchor="middle">0</text>
+  <line x1="898.9" y1="74" x2="898.9" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="898.9" y="72" class="m" fill="#4b5563" text-anchor="middle">0.25</text>
+  <line x1="919.0" y1="74" x2="919.0" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="919.0" y="72" class="m" fill="#4b5563" text-anchor="middle">0.5</text>
+  <line x1="939.1" y1="74" x2="939.1" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="939.1" y="72" class="m" fill="#4b5563" text-anchor="middle">0.75</text>
+  <line x1="959.3" y1="74" x2="959.3" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="959.3" y="72" class="m" fill="#4b5563" text-anchor="middle">1</text>
+  <line x1="979.4" y1="74" x2="979.4" y2="154" class="ax" stroke="#e5e7eb"/>
+  <text x="979.4" y="72" class="m" fill="#4b5563" text-anchor="middle">1.25</text>
+  <line x1="959.3" y1="74" x2="959.3" y2="154" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>
+  <line x1="878.7" y1="74" x2="878.7" y2="154" class="base" stroke="#9ca3af"/>
   <path d="M878.7,88.0 L939.0,88.0 Q941.5,88.0 941.5,90.5 L941.5,97.5 Q941.5,100.0 939.0,100.0 L878.7,100.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="947.5" y="96" class="m" text-anchor="start">0.78</text>
+  <text x="947.5" y="96" class="m" fill="#4b5563" text-anchor="start">0.78</text>
   <path d="M878.7,105.0 L929.7,105.0 Q932.2,105.0 932.2,107.5 L932.2,114.5 Q932.2,117.0 929.7,117.0 L878.7,117.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="938.2" y="113" class="m" text-anchor="start">0.66</text>
+  <text x="938.2" y="113" class="m" fill="#4b5563" text-anchor="start">0.66</text>
   <path d="M878.7,122.0 L923.1,122.0 Q925.6,122.0 925.6,124.5 L925.6,131.5 Q925.6,134.0 923.1,134.0 L878.7,134.0 Z" class="f-dense" fill="#0e8f60" opacity="0.8"/>
-  <text x="931.6" y="130" class="m" text-anchor="start">0.58</text>
+  <text x="931.6" y="130" class="m" fill="#4b5563" text-anchor="start">0.58</text>
   <path d="M878.7,139.0 L956.8,139.0 Q959.3,139.0 959.3,141.5 L959.3,148.5 Q959.3,151.0 956.8,151.0 L878.7,151.0 Z" class="f-dense" fill="#0e8f60" opacity="0.95"/>
-  <text x="965.3" y="147" class="m" text-anchor="start">1.00</text>
-  <text x="265.6" y="56" class="m" text-anchor="end">geomean</text>
-  <text x="227.60000000000002" y="96" class="t" text-anchor="end">unordered_dense, huge pages</text>
-  <text x="265.6" y="96" class="m" text-anchor="end">0.78</text>
-  <text x="227.60000000000002" y="113" class="t" text-anchor="end">unordered_dense segmented + huge</text>
-  <text x="265.6" y="113" class="m" text-anchor="end">0.86</text>
-  <text x="227.60000000000002" y="130" class="t" text-anchor="end">unordered_dense segmented</text>
-  <text x="265.6" y="130" class="m" text-anchor="end">0.93</text>
-  <text x="227.60000000000002" y="147" class="t" text-anchor="end" font-weight='600'>unordered_dense 5.0</text>
-  <text x="265.6" y="147" class="m" text-anchor="end">1.00</text>
+  <text x="965.3" y="147" class="m" fill="#4b5563" text-anchor="start">1.00</text>
+  <text x="265.6" y="56" class="m" fill="#4b5563" text-anchor="end">geomean</text>
+  <text x="227.60000000000002" y="96" class="t" fill="#1f2937" text-anchor="end">unordered_dense, huge pages</text>
+  <text x="265.6" y="96" class="m" fill="#4b5563" text-anchor="end">0.78</text>
+  <text x="227.60000000000002" y="113" class="t" fill="#1f2937" text-anchor="end">unordered_dense segmented + huge</text>
+  <text x="265.6" y="113" class="m" fill="#4b5563" text-anchor="end">0.86</text>
+  <text x="227.60000000000002" y="130" class="t" fill="#1f2937" text-anchor="end">unordered_dense segmented</text>
+  <text x="265.6" y="130" class="m" fill="#4b5563" text-anchor="end">0.93</text>
+  <text x="227.60000000000002" y="147" class="t" fill="#1f2937" text-anchor="end" font-weight='600'>unordered_dense 5.0</text>
+  <text x="265.6" y="147" class="m" fill="#4b5563" text-anchor="end">1.00</text>
   <rect x="273.6" y="171" width="11" height="11" class="f-dense" fill="#0e8f60" opacity="0.85"/>
-  <text x="289.6" y="180" class="m">dense</text>
-  <text x="357.6" y="180" class="m">relative to unordered_dense 5.0: time for the first four panels, peak bytes per entry for the last</text>
+  <text x="289.6" y="180" class="m" fill="#4b5563">dense</text>
+  <text x="357.6" y="180" class="m" fill="#4b5563">relative to unordered_dense 5.0: time for the first four panels, peak bytes per entry for the last</text>
 </svg>

--- a/scripts/ab/mapsplot.py
+++ b/scripts/ab/mapsplot.py
@@ -71,6 +71,10 @@ ROWH = 17
 GAP = 16
 
 
+# Light values are ordinary attributes so that any renderer shows the chart; the stylesheet only
+# overrides them for dark mode. GitHub sanitizes an SVG it serves as an image and can drop the
+# <style>, and a surface rect whose only fill lives there renders as a black rectangle over
+# everything -- which is the same trap scripts/ab/plot.py documents at its own head().
 def head(w, h, surface=False):
     # A condensed family, so that eighteen map names fit beside five panels. An SVG in an <img>
     # can only use fonts the *reader* has, so the stack names one condensed face per platform --
@@ -105,7 +109,7 @@ def head(w, h, surface=False):
               '    }\n')
     s += '  </style>\n'
     if surface:
-        s += f'  <rect class="surface" width="{w}" height="{h}"/>\n'
+        s += f'  <rect class="surface" fill="#ffffff" width="{w}" height="{h}"/>\n'
     return s
 
 
@@ -173,8 +177,8 @@ def panels(out, title, sub, order, cols, vals, unit, ref_line=True, surface=Fals
     top = 86
     h = top + n * ROWH + 58
     s = head(width, h, surface)
-    s += f'  <text x="8" y="20" class="hd">{esc(title)}</text>\n'
-    s += f'  <text x="8" y="38" class="sub">{esc(sub)}</text>\n'
+    s += f'  <text x="8" y="20" class="hd" fill="#111827">{esc(title)}</text>\n'
+    s += f'  <text x="8" y="38" class="sub" fill="#4b5563">{esc(sub)}</text>\n'
     for ci, (ck, ch) in enumerate(cols):
         x0 = label + ci * (pw + GAP)
         vmax = max(vals.get((m, ck), 0.0) for m in order) * 1.02
@@ -196,19 +200,19 @@ def panels(out, title, sub, order, cols, vals, unit, ref_line=True, surface=Fals
         # ink dark enough for the inside of a mid-tone bar either. ~6.4px per glyph at 11.5px Inter.
         lblw = max(len(f"{vals.get((m, ck), 0.0):.2f}") for m in order) * 6.4 + 9
         scale = (pw - lblw) / max(tk[-1], 1e-9)
-        s += f'  <text x="{x0:.0f}" y="{top - 30:.0f}" class="t" font-weight="600">{esc(ch)}</text>\n'
+        s += f'  <text x="{x0:.0f}" y="{top - 30:.0f}" class="t" fill="#1f2937" font-weight="600">{esc(ch)}</text>\n'
         for t in tk:
             x = x0 + t * scale
             if x > x0 + pw + 1:
                 continue
-            s += f'  <line x1="{x:.1f}" y1="{top - 12}" x2="{x:.1f}" y2="{top + n * ROWH}" class="ax"/>\n'
-            s += (f'  <text x="{x:.1f}" y="{top - 14}" class="m" text-anchor="middle">'
+            s += f'  <line x1="{x:.1f}" y1="{top - 12}" x2="{x:.1f}" y2="{top + n * ROWH}" class="ax" stroke="#e5e7eb"/>\n'
+            s += (f'  <text x="{x:.1f}" y="{top - 14}" class="m" fill="#4b5563" text-anchor="middle">'
                   f'{t:g}</text>\n')
         if ref_line:
             x = x0 + 1.0 * scale
-            s += f'  <line x1="{x:.1f}" y1="{top - 12}" x2="{x:.1f}" y2="{top + n * ROWH}" class="ref"/>\n'
+            s += f'  <line x1="{x:.1f}" y1="{top - 12}" x2="{x:.1f}" y2="{top + n * ROWH}" class="ref" stroke="#4b5563" stroke-dasharray="4 3"/>\n'
         s += (f'  <line x1="{x0:.1f}" y1="{top - 12}" x2="{x0:.1f}" y2="{top + n * ROWH}" '
-              f'class="base"/>\n')
+              f'class="base" stroke="#9ca3af"/>\n')
         for i, m in enumerate(order):
             v = vals.get((m, ck))
             if v is None:
@@ -220,26 +224,26 @@ def panels(out, title, sub, order, cols, vals, unit, ref_line=True, surface=Fals
             shape = torn(x0, y, w, ROWH - 5) if over else bar(x0, y, w, ROWH - 5)
             s += (f'  <path d="{shape}" class="f-{fam}"'
                   f' fill="{FAMILY[fam][0]}" opacity="{0.95 if m == REF else 0.8}"/>\n')
-            s += (f'  <text x="{x0 + w + 6:.1f}" y="{y + ROWH - 9:.0f}" class="m" '
+            s += (f'  <text x="{x0 + w + 6:.1f}" y="{y + ROWH - 9:.0f}" class="m" fill="#4b5563" '
                   f'text-anchor="start">{v:.2f}</text>\n')
     name_x = label - (46 if rank else 8)
     if rank:
-        s += f'  <text x="{label - 8}" y="{top - 30:.0f}" class="m" text-anchor="end">geomean</text>\n'
+        s += f'  <text x="{label - 8}" y="{top - 30:.0f}" class="m" fill="#4b5563" text-anchor="end">geomean</text>\n'
     for i, m in enumerate(order):
         y = top + i * ROWH + ROWH - 7
-        s += (f'  <text x="{name_x}" y="{y:.0f}" class="t" text-anchor="end"'
+        s += (f'  <text x="{name_x}" y="{y:.0f}" class="t" fill="#1f2937" text-anchor="end"'
               f'{" font-weight=\'600\'" if m == REF else ""}>{esc(PRETTY.get(m, m))}</text>\n')
         if rank:
-            s += (f'  <text x="{label - 8}" y="{y:.0f}" class="m" text-anchor="end">'
+            s += (f'  <text x="{label - 8}" y="{y:.0f}" class="m" fill="#4b5563" text-anchor="end">'
                   f'{rank[m]:.2f}</text>\n')
     ly = top + n * ROWH + 26
     lx = label
     for fam in [f for f in ("flat", "dense", "node") if any(OF[m] == f for m in order)]:
         s += (f'  <rect x="{lx}" y="{ly - 9}" width="11" height="11" class="f-{fam}" '
               f'fill="{FAMILY[fam][0]}" opacity="0.85"/>\n')
-        s += f'  <text x="{lx + 16}" y="{ly}" class="m">{fam}</text>\n'
+        s += f'  <text x="{lx + 16}" y="{ly}" class="m" fill="#4b5563">{fam}</text>\n'
         lx += 74
-    s += f'  <text x="{lx + 10}" y="{ly}" class="m">{esc(unit)}</text>\n'
+    s += f'  <text x="{lx + 10}" y="{ly}" class="m" fill="#4b5563">{esc(unit)}</text>\n'
     s += "</svg>\n"
     open(out, "w").write(s)
     print(out)
@@ -379,9 +383,9 @@ def cmd_octave(argv):
     vmax = max(v for s in series.values() for _, v in s) * 1.06
     tk = ticks(vmax)
     s = head(W2, H2)
-    s += (f'  <text x="8" y="22" class="hd">{esc(work)} against table size, across one doubling and '
+    s += (f'  <text x="8" y="22" class="hd" fill="#111827">{esc(work)} against table size, across one doubling and '
           f'a little past it, {key} keys</text>\n')
-    s += (f'  <text x="8" y="42" class="sub">the same {len(xs)} sizes for every map, {lo:,} to '
+    s += (f'  <text x="8" y="42" class="sub" fill="#4b5563">the same {len(xs)} sizes for every map, {lo:,} to '
           f'{hi:,} entries; the large dots are the five sizes every ratio in this post is '
           f'averaged over</text>\n')
 
@@ -392,18 +396,18 @@ def cmd_octave(argv):
         return T + (1 - v / tk[-1]) * (H2 - T - B)
 
     for t in tk:
-        s += f'  <line x1="{L}" y1="{py(t):.1f}" x2="{W2 - R}" y2="{py(t):.1f}" class="ax"/>\n'
-        s += f'  <text x="{L - 8}" y="{py(t) + 4:.1f}" class="m" text-anchor="end">{t:g}</text>\n'
-    s += f'  <line x1="{L}" y1="{py(0):.1f}" x2="{W2 - R}" y2="{py(0):.1f}" class="base"/>\n'
-    s += f'  <text x="{L}" y="{T - 14}" class="m">nanoseconds per operation</text>\n'
+        s += f'  <line x1="{L}" y1="{py(t):.1f}" x2="{W2 - R}" y2="{py(t):.1f}" class="ax" stroke="#e5e7eb"/>\n'
+        s += f'  <text x="{L - 8}" y="{py(t) + 4:.1f}" class="m" fill="#4b5563" text-anchor="end">{t:g}</text>\n'
+    s += f'  <line x1="{L}" y1="{py(0):.1f}" x2="{W2 - R}" y2="{py(0):.1f}" class="base" stroke="#9ca3af"/>\n'
+    s += f'  <text x="{L}" y="{T - 14}" class="m" fill="#4b5563">nanoseconds per operation</text>\n'
     for i, n in enumerate(xs):
         if i % stride and i != len(xs) - 1:
             continue
-        s += (f'  <text x="{px(n):.1f}" y="{H2 - B + 18:.0f}" class="m" text-anchor="middle">'
+        s += (f'  <text x="{px(n):.1f}" y="{H2 - B + 18:.0f}" class="m" fill="#4b5563" text-anchor="middle">'
               f'{n:,}</text>\n')
         s += (f'  <line x1="{px(n):.1f}" y1="{py(0):.1f}" x2="{px(n):.1f}" y2="{py(0) + 4:.1f}" '
-              f'class="base"/>\n')
-    s += f'  <text x="{(L + W2 - R) / 2:.0f}" y="{H2 - 14}" class="m" text-anchor="middle">entries</text>\n'
+              f'class="base" stroke="#9ca3af"/>\n')
+    s += f'  <text x="{(L + W2 - R) / 2:.0f}" y="{H2 - 14}" class="m" fill="#4b5563" text-anchor="middle">entries</text>\n'
 
     ends = []
     for m in want:
@@ -427,7 +431,7 @@ def cmd_octave(argv):
         last = y
         s += (f'  <line x1="{x + 8:.1f}" y1="{y:.1f}" x2="{x + 22:.1f}" y2="{y:.1f}" '
               f'stroke="{col}" stroke-width="2.4" stroke-linecap="round"/>\n')
-        s += f'  <text x="{x + 28:.1f}" y="{y + 4:.1f}" class="m">{esc(label)}</text>\n'
+        s += f'  <text x="{x + 28:.1f}" y="{y + 4:.1f}" class="m" fill="#4b5563">{esc(label)}</text>\n'
     s += "</svg>\n"
     open(out, "w").write(s)
     print(out)
@@ -478,10 +482,10 @@ def cmd_hashlat(argv):
     # would be drawn straight through the axis and out over the legend.
     s += (f'  <clipPath id="plot"><rect x="{L}" y="{T}" width="{W2 - R - L}" '
           f'height="{H2 - T - B}"/></clipPath>\n')
-    s += '  <text x="8" y="22" class="hd">What a string hash costs a lookup, by key length</text>\n'
-    s += ('  <text x="8" y="42" class="sub">nanoseconds per hash, each one waiting on the one '
+    s += '  <text x="8" y="22" class="hd" fill="#111827">What a string hash costs a lookup, by key length</text>\n'
+    s += ('  <text x="8" y="42" class="sub" fill="#4b5563">nanoseconds per hash, each one waiting on the one '
           'before it, which is the order a map pays them in</text>\n')
-    s += ('  <text x="8" y="60" class="sub">median of three runs, every hash interleaved in one '
+    s += ('  <text x="8" y="60" class="sub" fill="#4b5563">median of three runs, every hash interleaved in one '
           'process; about 1.5 ns of every line is the chain\'s own store and load</text>\n')
 
     def px(n):
@@ -493,19 +497,19 @@ def cmd_hashlat(argv):
     axis_y = py(0)
     s += (f'  <rect x="{px(8):.1f}" y="{T:.0f}" width="{px(135) - px(8):.1f}" '
           f'height="{py(0) - T:.1f}" fill="#f1f5f9"/>\n')
-    s += (f'  <text x="{(px(8) + px(135)) / 2:.0f}" y="{T + 14:.0f}" class="m" '
+    s += (f'  <text x="{(px(8) + px(135)) / 2:.0f}" y="{T + 14:.0f}" class="m" fill="#4b5563" '
           f'text-anchor="middle">the lengths this post\'s string keys use</text>\n')
     for tv in tk:
-        s += f'  <line x1="{L}" y1="{py(tv):.1f}" x2="{W2 - R}" y2="{py(tv):.1f}" class="ax"/>\n'
-        s += f'  <text x="{L - 8}" y="{py(tv) + 4:.1f}" class="m" text-anchor="end">{tv:g}</text>\n'
-    s += f'  <line x1="{L}" y1="{axis_y:.1f}" x2="{W2 - R}" y2="{axis_y:.1f}" class="base"/>\n'
-    s += f'  <text x="{L}" y="{T - 14}" class="m">nanoseconds per hash, chained</text>\n'
+        s += f'  <line x1="{L}" y1="{py(tv):.1f}" x2="{W2 - R}" y2="{py(tv):.1f}" class="ax" stroke="#e5e7eb"/>\n'
+        s += f'  <text x="{L - 8}" y="{py(tv) + 4:.1f}" class="m" fill="#4b5563" text-anchor="end">{tv:g}</text>\n'
+    s += f'  <line x1="{L}" y1="{axis_y:.1f}" x2="{W2 - R}" y2="{axis_y:.1f}" class="base" stroke="#9ca3af"/>\n'
+    s += f'  <text x="{L}" y="{T - 14}" class="m" fill="#4b5563">nanoseconds per hash, chained</text>\n'
     for n in (4, 8, 16, 32, 64, 128, 256, 512, 1024):
-        s += (f'  <text x="{px(n):.1f}" y="{H2 - B + 18:.0f}" class="m" text-anchor="middle">'
+        s += (f'  <text x="{px(n):.1f}" y="{H2 - B + 18:.0f}" class="m" fill="#4b5563" text-anchor="middle">'
               f'{n}</text>\n')
         s += (f'  <line x1="{px(n):.1f}" y1="{axis_y:.1f}" x2="{px(n):.1f}" y2="{axis_y + 4:.1f}" '
-              f'class="base"/>\n')
-    s += (f'  <text x="{(L + W2 - R) / 2:.0f}" y="{H2 - 14}" class="m" text-anchor="middle">'
+              f'class="base" stroke="#9ca3af"/>\n')
+    s += (f'  <text x="{(L + W2 - R) / 2:.0f}" y="{H2 - 14}" class="m" fill="#4b5563" text-anchor="middle">'
           f'key length in bytes</text>\n')
 
     ends = []
@@ -528,7 +532,7 @@ def cmd_hashlat(argv):
         da = "" if dash == "none" else f' stroke-dasharray="4 3"'
         s += (f'  <line x1="{x + 8:.1f}" y1="{y:.1f}" x2="{x + 24:.1f}" y2="{y:.1f}" '
               f'stroke="{col}" stroke-width="2.4" stroke-linecap="round"{da}/>\n')
-        s += f'  <text x="{x + 30:.1f}" y="{y + 4:.1f}" class="m">{esc(label)}</text>\n'
+        s += f'  <text x="{x + 30:.1f}" y="{y + 4:.1f}" class="m" fill="#4b5563">{esc(label)}</text>\n'
     s += "</svg>\n"
     open(out, "w").write(s)
     print(out)


### PR DESCRIPTION
Follow-up to #281.

Every colour in `mapsplot.py`'s output lived in the `<style>` block. The surface rect was `<rect class="surface" width=.. height=..>` with no `fill`, so a renderer that drops the stylesheet — which a sanitiser serving SVG as an image may do — falls back to the SVG default fill, black, over the whole chart.

`scripts/ab/plot.py` already documents this and puts its light values in attributes. This makes `mapsplot.py` do the same: attributes carry the light theme, the stylesheet only overrides them in the `prefers-color-scheme: dark` query.

Verified by stripping `<style>` from the generated SVG and rendering it. Before: a black rectangle with bars and no text. After: the full chart, minus only the dark-mode switch.

The four `doc/bench-readme-*.svg` are regenerated with `scripts/ab/regen.sh --redraw`; no number changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)